### PR TITLE
Added VIB install to 'make deploy'  and small cleanup in build

### DIFF
--- a/src/dvolplug/Makefile
+++ b/src/dvolplug/Makefile
@@ -28,8 +28,7 @@ $(BIN)/$(PLUGIN): $(SRC)
 	@-mkdir -p $(BIN)
 
 clean: 
-	go clean $(PLUGIN)
-	rm -f $(BIN)/$(PLUGIN) .build_*
+	rm -f $(BIN)/* .build_*
 
 #TBD: this is a good place to add unit tests...	
 test: build

--- a/vmdkops-esxsrv/Makefile
+++ b/vmdkops-esxsrv/Makefile
@@ -50,7 +50,7 @@ $(VMCI_SRV_LIB): $(C_SRC)
 	
 	
 clean:
-	rm -fr $(VIB) $(VMCI_SRV_LIB) $(PAYLOAD_BIN)
+	rm -fr $(VIB) $(VMCI_SRV_LIB) $(PAYLOAD)
 
 test: build
 	@echo "*** Info: No unit test here  yet ($(PWD))"	


### PR DESCRIPTION
This impacts only 'make deploy' and 'make clean'
- 'make deploy' now calls ./build.sh to build, then copies VIB file to ESX and properly installs it.  
- 'make clean' does not require GO anymore and this is easier to run
- small cleanup of unused and unneeded vars in makefiles
