### PR TITLE
Add support for `docker volume ls`

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -78,9 +78,15 @@ func (d vmdkDriver) Get(r volume.Request) volume.Response {
 }
 
 func (d vmdkDriver) List(r volume.Request) volume.Response {
-	log.Printf("'List' called on %s - TBD return volumes list \n", r.Name)
-	return volume.Response{Err: ""}
-
+	volumes, err := vmdkops.VmdkList()
+	if err != nil {
+		return volume.Response{Err: err.Error()}
+	}
+	var response_volumes []*volume.Volume
+	for _, vol := range volumes {
+		response_volumes = append(response_volumes, &vol)
+	}
+	return volume.Response{Volumes: response_volumes}
 }
 
 // request attach and them mounts the volume

--- a/vmdkops-esxsrv/vmci_srv.py
+++ b/vmdkops-esxsrv/vmci_srv.py
@@ -180,7 +180,7 @@ def removeVMDK(vmdkPath):
 def listVMDK(path):
 	vmdks = [x for x in os.listdir(path) if  ".vmdk" in x and
 			os.stat(os.path.join(path, x)).st_size < MaxDescrSize]
-	return [x.replace(".vmdk", "") for x in vmdks]
+        return [{u'Name': x.replace(".vmdk", ""), u'Mountpoint': path} for x in vmdks]
 
 # Find VM , reconnect if needed. throws on error
 def findVmByName(vmName):
@@ -474,11 +474,8 @@ def main():
 		# note: Connection can time out on idle. TODO: to refresh in that case
 		details = req["details"]
 		opts = details["Opts"] if "Opts" in details else None
-		ret = executeRequest(vmName, vmId, cfgPath,
-								req["cmd"], details["Name"], opts)
-		print "execute_request: handler returns " , ret
-
-		err = l.vmci_reply(c, c_char_p(str(ret)))
+		ret = executeRequest(vmName, vmId, cfgPath, req["cmd"], details["Name"], opts)
+		err = l.vmci_reply(c, c_char_p(json.dumps(ret)))
 		print "execute_request: VMCI replied with errcode ", err
 
 	l.close(sock, vmciFd)

--- a/vmdkops/vmci/vmci_client.c
+++ b/vmdkops/vmci/vmci_client.c
@@ -1,5 +1,5 @@
 //
-// VMCI sockets communication - client side. 
+// VMCI sockets communication - client side.
 //
 // Called mainly from Go code.
 //
@@ -40,7 +40,7 @@ typedef struct {
 #define ANSW_BUFSIZE 1024  // fixed size for json reply or specific errmsg
 #define MAXBUF ANSW_BUFSIZE + 1 // Safety limit
 
-typedef struct {
+typedef struct be_answer {
    int status; // TBD: OK, parse error, access denied, etc...
    char buf[ANSW_BUFSIZE];
 } be_answer;
@@ -282,9 +282,9 @@ host_request(be_funcs *be, be_request* req, be_answer* ans, int cid, int port)
 // Entry point for vsocket requests
 //
 be_sock_status
-Vmci_GetReply(int port, const char* json_request, const char* be_name)
+Vmci_GetReply(int port, const char* json_request, const char* be_name, be_answer* ans)
 {
-   	be_answer ans;
+//   	be_answer ans;
    	be_request req;
 
 	be_funcs *be = get_backend(be_name);
@@ -295,6 +295,5 @@ Vmci_GetReply(int port, const char* json_request, const char* be_name)
    req.mlen = strnlen(json_request, MAXBUF);
    req.msg = json_request;
 
-   return host_request(be, &req, &ans, ESX_VMCI_CID, port);
+   return host_request(be, &req, ans, ESX_VMCI_CID, port);
 }
-

--- a/vmdkops/vmdkops.go
+++ b/vmdkops/vmdkops.go
@@ -4,6 +4,7 @@ package vmdkops
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/docker/go-plugins-helpers/volume"
 	"log"
 	"syscall"
 	"unsafe"
@@ -60,14 +61,23 @@ type requestToVmci struct {
 	Details VolumeInfo `json:"details"`
 }
 
-// Send a command 'cmd' to VMCI, via C API
-func vmdkCmd(cmd string, name string, opts map[string]string) string {
+type VolumeError struct {
+	msg string
+}
 
+func (e *VolumeError) Error() string {
+	return e.msg
+}
+
+// Send a command 'cmd' to VMCI, via C API
+// Return the resulting JSON or an error. Each Public API function will decode
+// the JSON corresponding to it's return type, and return an error if decoding fails.
+func vmdkCmd(cmd string, name string, opts map[string]string) ([]byte, error) {
 	json_str, err := json.Marshal(&requestToVmci{
 		Ops:     cmd,
 		Details: VolumeInfo{Name: name, Options: opts}})
 	if err != nil {
-		return fmt.Sprintf("Failed to marshal json: %s", err)
+		return nil, fmt.Errorf("Failed to marshal json: %v", err)
 	}
 
 	cmd_s := C.CString(string(json_str))
@@ -76,48 +86,96 @@ func vmdkCmd(cmd string, name string, opts map[string]string) string {
 	be_s := C.CString(commBackendName)
 	defer C.free(unsafe.Pointer(be_s))
 
+	// Get the response data in json
+	ans := (*C.be_answer)(C.malloc(C.sizeof_struct_be_answer))
+	defer C.free(unsafe.Pointer(ans))
+
 	// connect, send command, get reply, disconnect - all in one shot
-	ret := C.Vmci_GetReply(C.int(vmciEsxPort), cmd_s, be_s)
+	ret := C.Vmci_GetReply(C.int(vmciEsxPort), cmd_s, be_s, ans)
 
 	if ret != 0 {
 		log.Print("Warning - no connection to ESX over vsocket, trace only")
-		return fmt.Sprintf("vmdkCmd err: %d (%s)", ret, syscall.Errno(ret).Error())
+		return nil, fmt.Errorf("vmdkCmd err: %d (%s)", ret, syscall.Errno(ret).Error())
 	}
-
-	return ""
+	return []byte(C.GoString((*C.char)(unsafe.Pointer(&ans.buf)))), nil
 }
 
 // public API
 func (v VolumeInfo) Create() string {
-	return vmdkCmd("create", v.Name, v.Options)
+	_, err := vmdkCmd("create", v.Name, v.Options)
+	if err != nil {
+		return err.Error()
+	}
+	return ""
 }
 func (v VolumeInfo) Remove() string {
-	return vmdkCmd("create", v.Name, v.Options)
+	_, err := vmdkCmd("create", v.Name, v.Options)
+	if err != nil {
+		return err.Error()
+	}
+	return ""
 }
 func (v VolumeInfo) Attach() string {
-	return vmdkCmd("create", v.Name, v.Options)
+	_, err := vmdkCmd("create", v.Name, v.Options)
+	if err != nil {
+		return err.Error()
+	}
+	return ""
 }
 func (v VolumeInfo) Detach() string {
-	return vmdkCmd("create", v.Name, v.Options)
+	_, err := vmdkCmd("create", v.Name, v.Options)
+	if err != nil {
+		return err.Error()
+	}
+	return ""
 }
 func (v VolumeInfo) List() string {
-	return vmdkCmd("list", v.Name, v.Options)
+	_, err := vmdkCmd("list", v.Name, v.Options)
+	if err != nil {
+		return err.Error()
+	}
+	return ""
 }
 
 func VmdkCreate(name string, opts map[string]string) string {
-	return vmdkCmd("create", name, opts)
+	_, err := vmdkCmd("create", name, opts)
+	if err != nil {
+		return err.Error()
+	}
+	return ""
 }
 func VmdkRemove(name string, opts map[string]string) string {
-	return vmdkCmd("remove", name, opts)
+	_, err := vmdkCmd("remove", name, opts)
+	if err != nil {
+		return err.Error()
+	}
+	return ""
 }
 func VmdkAttach(name string, opts map[string]string) string {
-	return vmdkCmd("attach", name, opts)
+	_, err := vmdkCmd("attach", name, opts)
+	if err != nil {
+		return err.Error()
+	}
+	return ""
 }
 func VmdkDetach(name string, opts map[string]string) string {
-	return vmdkCmd("detach", name, opts)
+	_, err := vmdkCmd("detach", name, opts)
+	if err != nil {
+		return err.Error()
+	}
+	return ""
 }
-func VmdkList(name string, opts map[string]string) string {
-	return vmdkCmd("list", name, opts)
+func VmdkList() ([]volume.Volume, error) {
+	str, err := vmdkCmd("list", "", make(map[string]string))
+	if err != nil {
+		return nil, err
+	}
+	result := make([]volume.Volume, 0)
+	err = json.Unmarshal(str, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 func TestSetDummyBackend() {


### PR DESCRIPTION
When the driver attempts a `List` in `plugin.go`,
it calls `vmdkops.VmdkList()`, which now returns a pair of type `([]volume.Volume, error)`.
If there was no error then the slice returned is used to build up a client response.
In order to retrieve this list of Volumes, Json plumbing was required at the go/C boundary
in `vmdkops.go` and `vmci_client.c`. This plumbing was also required of The python server
running on ESX in `vmci_srv.py`.

In order to prevent having to change the entire API at once, backwards compatibility was
maintained with all other functions beside List. These should all be updated in another PR.
