### PR TITLE
Fix docker volume ls

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -82,9 +82,9 @@ func (d vmdkDriver) List(r volume.Request) volume.Response {
 	if err != nil {
 		return volume.Response{Err: err.Error()}
 	}
-	var response_volumes []*volume.Volume
-	for _, vol := range volumes {
-		response_volumes = append(response_volumes, &vol)
+	response_volumes := make([]*volume.Volume, 0, len(volumes))
+	for i, _ := range volumes {
+		response_volumes = append(response_volumes, &volumes[i])
 	}
 	return volume.Response{Volumes: response_volumes}
 }


### PR DESCRIPTION
When using a range loop in go you can't take a pointer to the value of the object returned.
It turns out that this is a temporary variable where the value is copied, so everytime you
 end up with the same pointer. Instead of using the value, you have to use the index and
then index the original array. This implicit pointer nonsense made for some fun debugging.
