### PR TITLE
Changing VMCI C files now causes rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ PLUGIN := github.com/vmware/$(PNAME)
 GO := GO15VENDOREXPERIMENT=1 go 
 
 # make sure we rebuild of vmkdops or Dockerfile change (since we develop them together)
-EXTRA_SRC = vmdkops/*.go 
+VMDKOPS_MODULE := vmdkops
+EXTRA_SRC      = $(VMDKOPS_MODULE)/*.go $(VMDKOPS_MODULE)/vmci/*.[ch]
 
 # All sources. We rebuild if anything changes here
 SRC = plugin.go main.go 


### PR DESCRIPTION
a trivial fix to Makefile - now picking up *c and *h in vmdkops/vmci as dependencies for build.
tested by touching the c file and running ./build.sh - it was silent  before, and it rebuilds after. 
