### PR TITLE
Added tests framework to run GO test code against Docker with plugin installed

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,8 +14,8 @@ build:
       - export VM1=`govc vm.ip ubuntu`
       - export VM2=`govc vm.ip ubuntu-2`
       - make
-      - make test
       - ./hack/setup.sh $GOVC_URL $VM1 $VM2 $$BUILD_NUMBER < /dev/null
+      - make test
       - ./hack/end2end.sh $GOVC_URL $VM1 $VM2 $$BUILD_NUMBER < /dev/null
 
 publish:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src/dvolplug/dvolplug
 .copy_*
 */*.vib
 */payloads/
+*.test

--- a/build.sh
+++ b/build.sh
@@ -56,9 +56,14 @@ fi
 plugin=docker-vmdk-plugin  
 plugin_container_version=0.4
 plug_container=kerneltime/vibauthor-and-go:$plugin_container_version
+dockerfile=Dockerfile.vibauthor-and-go
+
 GOPATH=/go
 
 # mount point within the container.
-dir=$GOPATH/src/github.com/vmware/docker-vmdk-plugin
+dir=$GOPATH/src/github.com/vmware/$plugin
 
+set -x
 docker run --privileged --rm -v $PWD:$dir -w $dir $plug_container make $1
+set +x
+

--- a/hack/startesx.sh
+++ b/hack/startesx.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-nohup python /usr/lib/vmware/vmdkops/bin/vmci_srv.py > /tmp/plugin.log 2>&1 &
+log=/tmp/plugin.log
+echo ==== `date` ===== >> $log
+nohup python /usr/lib/vmware/vmdkops/bin/vmci_srv.py >> $log 2>&1 &

--- a/hack/startvm.sh
+++ b/hack/startvm.sh
@@ -1,2 +1,4 @@
 #!/bin/sh
-/usr/local/bin/docker-vmdk-plugin < /dev/null > /tmp/plugin.log 2>&1 &
+log=/tmp/plugin.log
+echo ==== `date` ===== >> $log
+/usr/local/bin/docker-vmdk-plugin < /dev/null >> $log 2>&1 &

--- a/hack/stopvm.sh
+++ b/hack/stopvm.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 kill `pidof docker-vmdk-plugin`
 rm -rvf /mnt/vmdk/*
-

--- a/sanity_test.go
+++ b/sanity_test.go
@@ -1,0 +1,44 @@
+// basic sanity test
+
+package main
+
+import (
+	"fmt"
+	"github.com/docker/engine-api/client"
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
+	"testing"
+)
+
+const (
+	endpoint   = "unix:///var/run/docker.sock"
+	apiVersion = "v1.22"
+)
+
+// Connects to docker via unix socket and runs basic tests.
+
+func TestSanity(t *testing.T) {
+	defaultHeaders := map[string]string{"User-Agent": "engine-api-cli-1.0"}
+
+	fmt.Println("Connecting to ", endpoint)
+	cli, err := client.NewClient(endpoint, apiVersion, nil, defaultHeaders)
+	if err != nil {
+		t.Fatal("Failed to connect to the client at ", endpoint, " , err: ", err)
+	}
+
+	options := types.ContainerListOptions{All: true}
+	containers, err := cli.ContainerList(options)
+	if err != nil {
+		t.Fatal("Failed to enumerate options, err: ", err)
+	}
+	fmt.Println("Containers count: ", len(containers))
+
+	reply, err := cli.VolumeList(filters.Args{})
+	if err != nil {
+		t.Fatal("Failed to enumerate  volumes")
+	}
+	fmt.Println("Volumes count:", len(reply.Volumes))
+	//	for _, v := range reply.Volumes {
+	//		fmt.Println(v.Name, v.Driver, v.Mountpoint)
+	//	}
+}


### PR DESCRIPTION
  Added tests framework to run GO plugin test code against Docker

Notes:
- we currently support only one Docker engine to run the test against, so multi-engine tests support will be done later.
- Test may fail with "wrong json message" or something like that - the fix is ready and will be checked in when this is in 

We now 'build' *.test files in ./bin folder, and 'deploy' them to guest:/tmp.
    We Use 'testremote' executes them. There is not much there yet - we print container and volume count and exit.
    This change is intendended to bring end to end support for GO testing - individual tests will be added later.

To add tests - add you TestWhatever(t *testing.T) to sanity_test.c.
    Use proper functions from golang 'testing' module to report results.

```
Changes
=======

Changes to build container:
- Added to build container: gvt (for manipulating vendoring) and other misc, fixes to Dockerfile

Changes to Makefiles:
- 'build' target now builds tests (bin/*test)
- 'deploy' target deploys them to guest:/tmp
- 'remotetest' target runs them

New files:
- Added sanity_test.go which currently only prints containers and volumes count - but runs against docker API

Assumption:
- We assume SSH keys between build machine and GUEST/HOST (see Makefile) are properly configured.
```
