### PR TITLE
Add steps to run drone on dev setup.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ git commit -m "Added new dependency go-plugins-helpers"
 
 The work flow for coding looks like this
 
-- Each checkin into a branch on the official repo will run the full set of 
+- Each checkin into a branch on the official repo will run the full set of
   tests.
 
 - On Pull Requests the full set of tests will be run.
@@ -54,11 +54,126 @@ There is a webhook setup between github repo and the CI server. The CI server us
 
 The credentials for Docker Hub deployment is secured using http://readme.drone.io/usage/secrets/
 
-TODO:
+### Running CI/CD on a dev setup
+Each developer can run tests part of the CI/CD system locally in their sandbox.
 
-1. Push Docker images on failures, needs custom scripting.
-2. Deploy VMs on nested ESX.
-3. Write tests for end to end testing.
-  1. Needs a guarantee that only one build running tests at a time.
-4. Write a stub server to allow for unit testing the docker plugin code.
-5. On failure for now the publishing will be manual. Going forward 0.6 release of drone will support publish on failure. One option might be to run a forked drone release in co-ordination with the CNA folks.
+* Setup:
+The current CI/CD workflow assumes that the testbed consists of:
+   - One ESX
+   - 2 Linux VMs running on the same datastore in the ESX.
+
+* Install [Drone CLI](https://github.com/drone/drone-cli)
+```
+curl http://downloads.drone.io/drone-cli/drone_linux_amd64.tar.gz | tar zx
+sudo install -t /usr/local/bin drone
+```
+
+* If not already done, checkout source code in $GOPATH
+```
+mkdir -p $GOPATH/src/github.com/vmware
+cd $GOPATH/src/github.com/vmware
+git clone https://github.com/vmware/docker-vmdk-plugin.git
+```
+
+* Edit the .drone.yml file to reflect the devsetup. If the machine running drone is also one of the target machines, edit the Makefile to not restart docker.
+
+Sample .drone.yml :
+```
+diff --git a/.drone.yml b/.drone.yml
+index 5550172..9a4b872 100644
+--- a/.drone.yml
++++ b/.drone.yml
+@@ -5,13 +5,13 @@ build:
+       # Needed for creating docker images
+       - /var/run/docker.sock:/var/run/docker.sock
+     environment:
+-      - GOVC_USERNAME=$$CI_VMWARE_ESX_USER
+-      - GOVC_PASSWORD=$$CI_VMWARE_ESX_PASS
++      - GOVC_USERNAME=root
++      - GOVC_PASSWORD=
+       - GOVC_INSECURE=1
+-      - GOVC_URL=$$CI_ESX_IP
++      - GOVC_URL=10.20.105.54
+     commands:
+-      - export VM1=`govc vm.ip ubuntu`
+-      - export VM2=`govc vm.ip ubuntu-2`
++      - export VM1=10.20.105.121
++      - export VM2=10.20.104.210
+       - make
+       - make test
+       - ./hack/setup.sh $GOVC_URL $VM1 $VM2 $$BUILD_NUMBER < /dev/null
+```
+
+Do not restart docker if machine running drone is also a VM in the devsetup.
+
+Sample Makefile:
+```
+diff --git a/Makefile b/Makefile
+index a376536..093420d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -126,7 +126,7 @@ clean-vm:
+        -$(SSH) $(VM) rm /tmp/$(STARTVM) /tmp/$(STOPVM)
+        -$(SSH) $(VM) rm -rvf /mnt/vmdk/$(TEST_VOL_NAME)
+        -$(SSH) $(VM) docker volume rm $(TEST_VOL_NAME)  # delete any local datavolumes
+-       -$(SSH) $(VM) service docker restart
++       #-$(SSH) $(VM) service docker restart
+ 
+ .PHONY: clean-esx
+ clean-esx:
+```
+
+* Setup ssh keys on linux nodes & ESX
+
+Linux:
+```
+export NODE=root@10.20.105.54
+cat ~/.ssh/id_rsa.pub | ssh $NODE  "mkdir -p ~/.ssh && cat >>  ~/.ssh/authorized_keys"
+```
+
+ESX:
+```
+cat ~/.ssh/id_rsa.pub | ssh $NODE " cat >> /etc/ssh/keys-root/authorized_keys"
+```
+Test SSH keys, login form the drone node should not require typing in a password.
+
+* Run drone exec
+
+```
+cd cd $GOPATH/src/github.com/vmware/docker-vmdk-plugin/
+drone exec --trusted -i ~/.ssh/id_rsa
+```
+
+### Running the tests manually.
+
+Scripts invoked by CI/CD can also be run manually.
+
+Setup:
+```
+export ESX=root@10.20.105.54
+make deploy-esx
+export VM=root@10.20.105.121
+make deploy-vm
+export VM=root@10.20.105.201
+make deploy-vm
+```
+
+or
+
+```
+make deploy-esx ESX=root@10.20.105.54
+make deploy-vm VM=root@10.20.105.121
+make deploy-vm VM=root@10.20.104.210
+```
+
+Test:
+```
+make testremote VM=root@10.20.105.121 VM2=root@10.20.104.210
+```
+
+Cleanup:
+```
+make clean-vm VM=root@10.20.105.121
+make clean-vm VM=root@10.20.104.210
+make clean-esx ESX=root@10.20.105.54
+```


### PR DESCRIPTION
This includes
1. Steps to run drone on a developer test bed locally.
2. Manually invoking make to run the tests.
