### PR TITLE
Clean up state left by unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ clean-vm:
 	-$(SSH) $(VM) rm /tmp/$(STARTVM) /tmp/$(STOPVM)
 	-$(SSH) $(VM) rm -rvf /mnt/vmdk/$(TEST_VOL_NAME)
 	-$(SSH) $(VM) docker volume rm $(TEST_VOL_NAME)  # delete any local datavolumes
+	-$(SSH) $(VM) rm -rvf /tmp/docker-volumes/
 	-$(SSH) $(VM) service docker restart
 
 .PHONY: clean-esx

--- a/vmdkops/cmd_test.go
+++ b/vmdkops/cmd_test.go
@@ -22,4 +22,5 @@ func TestCommands(t *testing.T) {
 	assert.Nil(t,
 		ops.Create("otherVolume",
 			map[string]string{"size": "1gb", "format": "ext4"}))
+	assert.Nil(t, ops.Remove("otherVolume", opts))
 }


### PR DESCRIPTION
This should cover the case where the unit test was run locally or via drone.
