### PR TITLE
Small fixes to address comment from the review of C VMCI fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	pluginSockDir = "/run/docker/plugins"
+	pluginSockDir  = "/run/docker/plugins"
 	vmdkPluginId   = "vmdk"
 	version        = "VMDK Volume Driver v0.3"
 )
@@ -51,6 +51,6 @@ func main() {
 	driver := newVmdkDriver(*mockEsx)
 	handler := volume.NewHandler(driver)
 
-	log.Print("Going into ServeUnix - Listening on Unix socket: %s", fullSocketAddress(vmdkPluginId))
+	log.Printf("Going into ServeUnix - Listening on %s", fullSocketAddress(vmdkPluginId))
 	fmt.Println(handler.ServeUnix("root", fullSocketAddress(vmdkPluginId)))
 }

--- a/vmdkops-esxsrv/server.c
+++ b/vmdkops-esxsrv/server.c
@@ -134,8 +134,8 @@ vmci_get_one_op(const int s,    // socket to listen on
 
    // get VMID. We really get CartelID for VM, but it will make do
    socklen_t len = sizeof(*vmid);
-   if (getsockopt(c, af, SO_VMCI_PEER_HOST_VM_ID, vmid, &len) == -1 || len
-            != sizeof(*vmid)) {
+   if (getsockopt(c, af, SO_VMCI_PEER_HOST_VM_ID, vmid, &len) == -1
+            || len != sizeof(*vmid)) {
       perror("sockopt SO_VMCI_PEER_HOST_VM_ID failed, continuing...");
       // will still try to recv message to know what was there - so no return
    }
@@ -182,7 +182,10 @@ vmci_get_one_op(const int s,    // socket to listen on
    }
    // protocol sanity check
    if (strlen(buf) + 1 != b) {
-      printf("Warning: len mismatch, expected %d, got %d\n", strlen(buf), b);
+      printf("Protocol error: len mismatch, expected %d, got %d\n",
+               strlen(buf), b);
+      close(c);
+      return -1;
    }
 
    return c;

--- a/vmdkops-esxsrv/vmci_srv.py
+++ b/vmdkops-esxsrv/vmci_srv.py
@@ -96,7 +96,7 @@ from pyVmomi import VmomiSupport, vim, vmodl
 DockVolsDir = "dockvols" # place in the same (with Docker VM) datastore
 MaxDescrSize = 10000     # we assume files smaller that that to be descriptor files
 MaxJsonSize = 1024 * 4   # max buf size for query json strings. Queries are limited in size
-MaxSkipCoint = 100       # max retries on VMCI Get Ops failures
+MaxSkipCount = 100       # max retries on VMCI Get Ops failures
 DefaultDiskSize = "100mb"
 BinLoc = "/usr/lib/vmware/vmdkops/bin/"
 
@@ -479,7 +479,7 @@ def main():
 
     af = c_int() ; vmciFd = c_int(); cartel = c_int32()
     sock = lib.vmci_init(byref(af), byref(vmciFd))
-    skipCount = MaxSkipCoint # retries for vmci_get_one_op failures
+    skipCount = MaxSkipCount # retries for vmci_get_one_op failures
     while True:
         c = lib.vmci_get_one_op(sock, af, byref(cartel), txt, c_int(bsize))
         print "lib.vmci_get_one_op returns {0} , buffer '{1}'".format(c, txt.value)
@@ -492,7 +492,7 @@ def main():
                 raise Exception("Too many errors from VMCI Get Ops - giving up.")
             continue
         else:
-            skipCount = MaxSkipCoint # reset the counter, just in case
+            skipCount = MaxSkipCount # reset the counter, just in case
 
         # Get VM name & ID from VSI (we only get cartelID from vmci, need to convert)
         vmmLeader = vsi.get("/userworld/cartel/%s/vmmLeader" % str(cartel.value))


### PR DESCRIPTION
The C VMCI fixes were merged to unblock the CI, and small comments were never
addressed. This change addresses the leftover review comments.

Also opportunistically in this change:
- fix to main.go init message (using correct method)
- updates to makefile to properly build test when test code changes
