### PR TITLE
Use structured logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,12 @@ VMDKOPS_MODULE := vmdkops
 VMDKOPS_MODULE_SRC = $(VMDKOPS_MODULE)/*.go $(VMDKOPS_MODULE)/vmci/*.[ch]
 
 # All sources. We rebuild if anything changes here
-SRC = plugin.go main.go
+SRC = plugin.go main.go log_formatter.go
 
 #  TargetprintNQuit
 
 # The default build is using a prebuilt docker image that has all dependencies.
-.PHONY: dockerbuild 
+.PHONY: dockerbuild
 dockerbuild:
 	@./scripts/check.sh dockerbuild
 	./scripts/build.sh
@@ -40,7 +40,7 @@ dockerbuild:
 # The non docker build.
 .PHONY: build
 build: prereqs $(PLUGIN_BIN) $(BIN)/$(VMDKOPS_MODULE).test $(BIN)/$(PLUGNAME).test
-	@cd  $(ESX_SRC)  ; $(MAKE)  $@ 
+	@cd  $(ESX_SRC)  ; $(MAKE)  $@
 
 .PHONY: prereqs
 prereqs:
@@ -67,7 +67,7 @@ clean:
 # ----------
 # temporary goal to simplify my deployments and sanity check test (create/delete)
 #
-# expectations: 
+# expectations:
 #   Need target machines (ESX/Guest) to have proper ~/.ssh/authorized_keys
 #
 # Usage:
@@ -121,9 +121,9 @@ deploy-vm:
 deploy: deploy-esx deploy-vm
 	@echo Done
 
-	
+
 #
-# 'make test' or 'make testremote' 
+# 'make test' or 'make testremote'
 # CAUTION: FOR NOW, RUN testremote DIRECTLY VIA 'make'. DO NOT run via './build.sh'
 #  reason: ssh keys for accessing remote hosts are not in container used by ./build.sh
 # ----------
@@ -131,9 +131,9 @@ deploy: deploy-esx deploy-vm
 
 # this is a set of unit tests run on build machine
 .PHONY: test
-test: 
+test:
 	$(GO) test $(PLUGIN)/vmdkops
-	
+
 # does sanity check of create/remove docker volume on the guest
 TEST_VOL_NAME?=MyVolume
 

--- a/README.md
+++ b/README.md
@@ -35,26 +35,26 @@ To read more about code developement and testing read [CONTRIBUTING.md](https://
 
 Native ESXi VMDK support for Docker Data Volumes.
 
-When Docker runs in a VM under ESXi hypervisor, we allow Docker user to 
-create and use VMDK-based data volumes. Example: 
+When Docker runs in a VM under ESXi hypervisor, we allow Docker user to
+create and use VMDK-based data volumes. Example:
 
 ```Shell
 docker volume create --driver=vmdk --name=MyStorage -o size=10gb
 docker run --rm -it -v MyStorage:/mnt/data busybox sh
 ```
 
-This will create a MyStorage.vmdk on the same datastore where Docker VM is 
-located. This vmdk will be attached to the Docker VM on "docker run" and 
-the containers can use this storage for data. 
+This will create a MyStorage.vmdk on the same datastore where Docker VM is
+located. This vmdk will be attached to the Docker VM on "docker run" and
+the containers can use this storage for data.
 
-This repo contains guest code and ESXi code. 
+This repo contains guest code and ESXi code.
 
 The docker-vmdk-plugin service runs in docker VM and talks to Docker Volume
-Plugin API via Unix Sockets. It then relays requests via VMWare vSockets 
-host-guest communication to a edicated service on ESXi. 
+Plugin API via Unix Sockets. It then relays requests via VMWare vSockets
+host-guest communication to a edicated service on ESXi.
 
 The docker plugin code makes use of  vmdkops module  (found  in ./vmdkops)
-and ESX python service (found in ./vmdkops-esxsrc). 
+and ESX python service (found in ./vmdkops-esxsrc).
 
 The end results is that "docker volume create --drive vmdk" is capable
 of creating VMDK disks on enclosing ESX host, and using the new volume auto
@@ -66,18 +66,18 @@ Build prerequisites:
  - Linux with Docker (1.8+ is supported)
  - git
  - make
- 
+
 Build results are in ./bin.
- 
+
 ### Using docker (Recommended)
 
-Use it when you do not have GO, vibauthor and 32 bit C libraries on your machine, 
-or do not plan to impact your GO projects. 
+Use it when you do not have GO, vibauthor and 32 bit C libraries on your machine,
+or do not plan to impact your GO projects.
 
 ```Shell
 git clone https://github.com/vmware/docker-vmdk-plugin.git
 cd docker-vmdk-plugin
-make # Build and run unit tests. 
+make # Build and run unit tests.
 make clean
 ```
 
@@ -86,16 +86,18 @@ There are also the following targets:
 make clean       # removes binaries build by 'make'
 make test        # runs whatever unit tests we have
 make deploy      # deploys to your test box (see below)
-make clean-esx   # uninstalls from esx 
+make clean-esx   # uninstalls from esx
 make clean-vm    # uninstalls from vm
 make testremote  # runs sanity check docker commands for volumes
 ```
+Note that `make testremote` reads log output from the plugin at `/var/log/docker-vmdk-plugin.log`.
+
 For more details refer to [CONTRIBUTING.md](https://github.com/vmware/docker-vmdk-plugin/blob/master/CONTRIBUTING.md)
 
 ### Building on Photon TP2 Minimal
 
-Photon TP2 Minimal does not have git or make installed, and does not 
-not start docker by default, so you need to do this before running make: 
+Photon TP2 Minimal does not have git or make installed, and does not
+not start docker by default, so you need to do this before running make:
 
 ```Shell
  # Photon TP2 Minimal only:
@@ -103,7 +105,7 @@ tyum install -y git
 tyum install -y make
 systemctl start docker
 ```
-and then the git/cd/make sequence. 
+and then the git/cd/make sequence.
 
 ### Building without Docker
 
@@ -112,7 +114,7 @@ This build requires
 - vibauthor
 - 32 bit libc headers (as it is needed for ESX-side vSocket shim compilation.)
 
-With these prerequisites, you can do the following to build: 
+With these prerequisites, you can do the following to build:
 
 ```
 mkdir -p $(GOPATH)/src/github.com/vmware

--- a/drone-scripts/testremote-wrapper.sh
+++ b/drone-scripts/testremote-wrapper.sh
@@ -14,6 +14,7 @@ VM1=root@$2
 VM2=root@$3
 BUILD_NUMBER=$4
 SSH="ssh -o StrictHostKeyChecking=no"
+LOGFILE="/var/log/docker-vmdk-plugin.log"
 
 if [ $# -lt 3 ]
 then
@@ -35,11 +36,11 @@ dump_log() {
   echo "*************************************************************************"
   echo "dumping log: VM " $VM1
   echo "*************************************************************************"
-  $SSH $VM1 cat /tmp/plugin.log
+  $SSH $VM1 cat $LOGFILE
   echo "*************************************************************************"
   echo "dumping log: VM " $VM2
   echo "*************************************************************************"
-  $SSH $VM2 cat /tmp/plugin.log
+  $SSH $VM2 cat $LOGFILE
 }
 
 if make testremote VM=$VM1 VM2=$VM2 TEST_VOL_NAME=vol-build$BUILD_NUMBER

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -6,7 +6,7 @@ package fs
 
 import (
 	"fmt"
-	"log"
+	log "github.com/Sirupsen/logrus"
 	"os"
 	"os/exec"
 	"strings"
@@ -32,11 +32,13 @@ func Mkdir(path string) error {
 func Mount(mountpoint string, name string, fs string) error {
 	out, err := exec.Command("blkid", []string{"-L", name}...).Output()
 	if err != nil {
-		log.Printf("Failed to discover device using blkid")
-		return fmt.Errorf("blkid err: %T", err)
+		return fmt.Errorf("Failed to discover device  using blkid")
 	} else {
 		device := strings.TrimRight(string(out), " \n")
-		log.Printf("Mounting %s for label %s", device, mountpoint)
+		log.WithFields(log.Fields{
+			"device":     device,
+			"mountpoint": mountpoint,
+		}).Debug("Calling syscall.Mount()")
 		//_, err = exec.Command("mount", []string{device, mountpoint}...).Output()
 		err = syscall.Mount(device, mountpoint, fs, 0, "")
 		if err != nil {

--- a/log_formatter.go
+++ b/log_formatter.go
@@ -1,0 +1,69 @@
+// * This file contains an implementation of a
+// * [Logrus Formatter](https://github.com/Sirupsen/logrus#formatters) according to VMware CNA
+// * storage team specifications. The `appendKeyValue` and `needsQuoting` functions are copied
+// * from the implementation of the TextFormatter in Logrus.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"strings"
+)
+
+type VmwareFormatter struct{}
+
+func (f *VmwareFormatter) Format(entry *log.Entry) ([]byte, error) {
+	b := &bytes.Buffer{}
+	fmt.Fprint(b, entry.Time.String())
+	b.WriteByte(' ')
+	b.WriteByte('[')
+	fmt.Fprint(b, strings.ToUpper(entry.Level.String()))
+	b.WriteByte(']')
+	b.WriteByte(' ')
+	b.WriteString(entry.Message)
+	for key, value := range entry.Data {
+		f.appendKeyValue(b, key, value)
+	}
+	b.WriteByte('\n')
+	return b.Bytes(), nil
+}
+
+func needsQuoting(text string) bool {
+	for _, ch := range text {
+		if !((ch >= 'a' && ch <= 'z') ||
+			(ch >= 'A' && ch <= 'Z') ||
+			(ch >= '0' && ch <= '9') ||
+			ch == '-' || ch == '.') {
+			return false
+		}
+	}
+	return true
+}
+
+func (f *VmwareFormatter) appendKeyValue(b *bytes.Buffer, key string, value interface{}) {
+
+	b.WriteString(key)
+	b.WriteByte('=')
+
+	switch value := value.(type) {
+	case string:
+		if needsQuoting(value) {
+			b.WriteString(value)
+		} else {
+			fmt.Fprintf(b, "%q", value)
+		}
+	case error:
+		errmsg := value.Error()
+		if needsQuoting(errmsg) {
+			b.WriteString(errmsg)
+		} else {
+			fmt.Fprintf(b, "%q", value)
+		}
+	default:
+		fmt.Fprint(b, value)
+	}
+
+	b.WriteByte(' ')
+}

--- a/vmdkops/mock_vmdkcmd.go
+++ b/vmdkops/mock_vmdkcmd.go
@@ -7,9 +7,9 @@ package vmdkops
 import (
 	"encoding/json"
 	"fmt"
+	log "github.com/Sirupsen/logrus"
 	"github.com/vmware/docker-vmdk-plugin/fs"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"strconv"
@@ -30,7 +30,7 @@ func (_ MockVmdkCmd) Run(cmd string, name string, opts map[string]string) ([]byt
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("Running Mock Cmd %s", cmd)
+	log.WithFields(log.Fields{"cmd": cmd}).Debug("Running Mock Cmd")
 	switch cmd {
 	case "create":
 		err := create_block_device(name)

--- a/vmdkops/vmdkcmd.go
+++ b/vmdkops/vmdkcmd.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/Sirupsen/logrus"
 	"syscall"
 	"unsafe"
 )
@@ -72,12 +72,13 @@ func (_ VmdkCmd) Run(cmd string, name string, opts map[string]string) ([]byte, e
 	ret := C.Vmci_GetReply(C.int(vmciEsxPort), cmd_s, be_s, ans)
 
 	if ret != 0 {
-		log.Print("Warning - no connection to ESX over vsocket, trace only")
+		log.Warn("No connection to ESX over vsocket, trace only")
 		return nil, fmt.Errorf("vmdkCmd err: %d (%s)", ret, syscall.Errno(ret).Error())
 	}
 	response := []byte(C.GoString(ans.buf))
 	C.free(unsafe.Pointer(ans.buf))
-	err = unmarshalError(response); if err != nil {
+	err = unmarshalError(response)
+	if err != nil {
 		return nil, err
 	}
 	// There was no error, so return the slice containing the json response


### PR DESCRIPTION
Convert all log.Printf calls to use `logrus`.
Add a `--log_level` flag to the plugin binary to enable changing of the logrus log level.

Note that this PR doesn't actually log to a file or service as I don't know where it should log. 

Implements #41 and #121
