### PR TITLE
Disable Keepalives in go-plugin-helper http server

### DIFF
--- a/vendor/github.com/docker/go-plugins-helpers/sdk/handler.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/handler.go
@@ -64,6 +64,7 @@ func (h Handler) listenAndServe(proto, addr, group string) error {
 		Addr:    addr,
 		Handler: h.mux,
 	}
+	server.SetKeepAlivesEnabled(false)
 
 	switch proto {
 	case "tcp":


### PR DESCRIPTION
When a docker command is run, the daemon makes multiple connections to
the server that only send a single request. The server is keeping these
sockets open. By disabling KeepAlive, the file descriptors no longer
leak.

To Reproduce leak (without this fix):
1. Start plugin
2. run `docker volume ls`
3. Check number of open FDs to the server:
   `sudo lsof | grep /run/docker/plugins/vmdk.sock | wc -l`
4. Repeat steps 2+3 and watch the Leak occur

Performing the steps above with this patch will keep that count stable.
