### PR TITLE
Added basic logging to Pythoncode (vmci_srv.py)

### DIFF
--- a/drone-scripts/testremote-wrapper.sh
+++ b/drone-scripts/testremote-wrapper.sh
@@ -31,7 +31,8 @@ dump_log() {
   echo "*************************************************************************"
   echo "dumping log: ESX " $ESX
   echo "*************************************************************************"
-  $SSH $ESX cat "/var/log/vmware/docker-vmdk-plugin.log"
+  $SSH $ESX cat /var/log/vmware/docker-vmdk-plugin.log
+  $SSH $ESX cat /tmp/plugin.log
   echo "*************************************************************************"
   echo "dumping log: VM " $VM1
   echo "*************************************************************************"

--- a/scripts/startesx.sh
+++ b/scripts/startesx.sh
@@ -3,6 +3,9 @@
 # The real log is in "/var/log/vmware/docker-vmdk-plugin.log" (see vmci_srv.py )
 # redirtecting stdio/err to /tmp/plugin.log in case we missed something in logs
 # this will be gone when VIB work is complete
+# Note that we are resetting actual log here - it is useful in Drone runs. 
 log=/tmp/plugin.log
-echo === `date` Actual logs are in /var/log/vmware/docker-vmdk-plugin.log  === > $log
+pylog=/var/log/vmware/docker-vmdk-plugin.log 
+echo === `date` Actual logs are in $pylog  === > $log
+cat /dev/null > $pylog
 nohup python /usr/lib/vmware/vmdkops/bin/vmci_srv.py >> $log 2>&1 &

--- a/vmdkops-esxsrv/vmci_srv.py
+++ b/vmdkops-esxsrv/vmci_srv.py
@@ -104,9 +104,9 @@ LogFile = "/var/log/vmware/docker-vmdk-plugin.log"
 def LogSetup(logfile):
     logging.basicConfig(filename=logfile,
                         level=logging.DEBUG,
-                        format='%(asctime)-12s %(message)s',
-                        datefmt='%X %x')
-    logging.info("===" + time.strftime('%X %x %Z') + "Starting vmdkops service ===")
+                        format='%(asctime)-12s %(process)d [%(levelname)s] %(message)s',
+                        datefmt='%x %X')
+    logging.info("===" + time.strftime('%x %X %Z') + "Starting vmdkops service ===")
 
 
 # Run executable on ESX as needed for vmkfstools invocation (until normal disk create is written)


### PR DESCRIPTION
This replaces misc prints with simpe logging to /var/log/vmware/docker-vmdk-plugin.log.
Old location (/tmp/plugin.log) kept in tact just in case there is some sysout
(It will be dropped when we run server part from VIB/jumpstart. )

Addresses https://github.com/vmware/docker-vmdk-plugin/issues/100
