### PR TITLE
Add signal handling. Do not generate pyc files

### DIFF
--- a/scripts/startesx.sh
+++ b/scripts/startesx.sh
@@ -8,4 +8,4 @@ log=/tmp/plugin.log
 pylog=/var/log/vmware/docker-vmdk-plugin.log 
 echo === `date` Actual logs are in $pylog  === > $log
 cat /dev/null > $pylog
-nohup python /usr/lib/vmware/vmdkops/bin/vmci_srv.py >> $log 2>&1 &
+nohup python -B /usr/lib/vmware/vmdkops/bin/vmci_srv.py >> $log 2>&1 &


### PR DESCRIPTION
1. Introduces signal handling but does not block on pending operation. 
2. Stop generating pyc files.

Addresses 
https://github.com/vmware/docker-vmdk-plugin/issues/137
https://github.com/vmware/docker-vmdk-plugin/issues/29
