### PR TITLE
Add config file support and log rotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,18 +74,21 @@ lint:
 	@echo "Running $@"
 	${GOPATH}/bin/golint
 	${GOPATH}/bin/golint vmdkops
+	${GOPATH}/bin/golint config
+	${GOPATH}/bin/golint fs
 
 .PHONY: vet
 vet:
 	@echo "Running $@"
 	@go vet *.go
 	@go vet vmdkops/*.go
+	@go vet config/*.go
+	@go vet fs/*.go
 
 .PHONY: fmt
 fmt:
 	@echo "Running $@"
-	gofmt -s -l *.go
-	gofmt -s -l vmdkops/*.go
+	gofmt -s -l *.go vmdkops/*.go config/*.go fs/*.go
 
 #
 # 'make deploy'
@@ -172,6 +175,7 @@ test:
 .PHONY: testasroot
 testasroot:
 	$(GO) test $(PLUGIN)/vmdkops
+	$(GO) test $(PLUGIN)/config
 
 # does sanity check of create/remove docker volume on the guest
 TEST_VOL_NAME ?= TestVolume

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,49 @@
+package config
+
+// Read the plugin configuration file. The file is stored in JSON.
+// See default-config.json at the root of the project.
+
+import (
+	"encoding/json"
+	"io/ioutil"
+)
+
+const (
+	defaultLogPath       = "/var/log/docker-vmdk-plugin.log"
+	defaultMaxLogSizeMb  = 100
+	defaultMaxLogAgeDays = 28
+)
+
+// Config stores the configuration for the plugin
+type Config struct {
+	LogPath       string `json:",omitempty"`
+	MaxLogSizeMb  int    `json:",omitempty"`
+	MaxLogAgeDays int    `json:",omitempty"`
+}
+
+// Load the configuration from a file and return a Config.
+func Load(path string) (Config, error) {
+	jsonBlob, err := ioutil.ReadFile(path)
+	if err != nil {
+		return Config{}, err
+	}
+	var config Config
+	if err := json.Unmarshal(jsonBlob, &config); err != nil {
+		return Config{}, err
+	}
+	SetDefaults(&config)
+	return config, nil
+}
+
+// SetDefaults for any config setting that is at its `bottom`
+func SetDefaults(config *Config) {
+	if config.LogPath == "" {
+		config.LogPath = defaultLogPath
+	}
+	if config.MaxLogSizeMb == 0 {
+		config.MaxLogSizeMb = defaultMaxLogSizeMb
+	}
+	if config.MaxLogAgeDays == 0 {
+		config.MaxLogAgeDays = defaultMaxLogAgeDays
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,17 @@
+package config_test
+
+// Test Loading JSON config files
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/docker-vmdk-plugin/config"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	conf, err := config.Load("../default-config.json")
+	assert.Nil(t, err)
+	assert.Equal(t, conf.MaxLogSizeMb, 100)
+	assert.Equal(t, conf.MaxLogAgeDays, 28)
+	assert.Equal(t, conf.LogPath, "/var/log/docker-vmdk-plugin.log")
+}

--- a/default-config.json
+++ b/default-config.json
@@ -1,0 +1,3 @@
+{"MaxLogAgeDays": 28,
+ "MaxLogSizeMb": 100,
+ "LogPath": "/var/log/docker-vmdk-plugin.log"}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 )
 
+// Mkdir creates a directory at the specifiied path
 func Mkdir(path string) error {
 	stat, err := os.Lstat(path)
 	if os.IsNotExist(err) {
@@ -29,26 +30,27 @@ func Mkdir(path string) error {
 	return nil
 }
 
+// Mount discovers which devices are for which volume using blkid.
+// It then mounts the filesystem (`fs`) on the device at the given mountpoint.
 func Mount(mountpoint string, name string, fs string) error {
 	out, err := exec.Command("blkid", []string{"-L", name}...).Output()
 	if err != nil {
 		return fmt.Errorf("Failed to discover device  using blkid")
-	} else {
-		device := strings.TrimRight(string(out), " \n")
-		log.WithFields(log.Fields{
-			"device":     device,
-			"mountpoint": mountpoint,
-		}).Debug("Calling syscall.Mount()")
-		//_, err = exec.Command("mount", []string{device, mountpoint}...).Output()
-		err = syscall.Mount(device, mountpoint, fs, 0, "")
-		if err != nil {
-			return fmt.Errorf("Failed to mount device %s at %s: %s", device, mountpoint, err)
-		}
+	}
+	device := strings.TrimRight(string(out), " \n")
+	log.WithFields(log.Fields{
+		"device":     device,
+		"mountpoint": mountpoint,
+	}).Debug("Calling syscall.Mount()")
+	//_, err = exec.Command("mount", []string{device, mountpoint}...).Output()
+	err = syscall.Mount(device, mountpoint, fs, 0, "")
+	if err != nil {
+		return fmt.Errorf("Failed to mount device %s at %s: %s", device, mountpoint, err)
 	}
 	return nil
 }
 
-// TODO : use goroutine ?
+// Unmount a device from the given mountpoint.
 func Unmount(mountpoint string) error {
 	return syscall.Unmount(mountpoint, 0)
 }


### PR DESCRIPTION
- Update the Makefile to run lint, vet, and fmt against `config` and
  `fs` directories. Add config directory to the `testasroot` target.
- Add a config package to load a JSON config file with a default
  location of `/etc/docker-vmdk-plugin.conf`. This can be changed with a
  command line parameter `--config`
- Add an example default config file used by the config test in
  `default-config.json`
- Fix golint warnings in `fs` and `vmdkops`
- Configure logging via lumberjack using the config

Note that with this PR the plugin will no longer run without a config file. 
