### PR TITLE
Ignore unmount failures and continue with detach

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -41,7 +41,7 @@ package main
 
 import (
 	//	"encoding/json"
-	"fmt"
+	//      "fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/go-plugins-helpers/volume"
 	"github.com/vmware/docker-vmdk-plugin/fs"
@@ -133,7 +133,7 @@ func (d vmdkDriver) unmountVolume(r volume.Request) error {
 	err := fs.Unmount(mountpoint)
 	if err != nil {
 		log.WithFields(log.Fields{"mountpoint": mountpoint, "error": err}).Error("Failed to unmount ")
-		return fmt.Errorf("Unmount failed: %T", err)
+                // Do not return error. Continue with detach.
 	}
 	return d.ops.Detach(r.Name, r.Options)
 }


### PR DESCRIPTION
Bugs like #188 keep VMDK attached to VM. 

For failed container starts, docker tries to unmount and remove volume but we bail out from unmount without detaching VMDK. 

Testing Done:
Repro #188 and make sure VMDK is no longer attached to VM. 
Here are plugin logs;
2016-03-21 19:42:54.86792628 -0700 PDT [INFO] Mounting Volume name=0123456789abcdefghijklmnopqrstuvwxyz mountpoint="/mnt/vmdk/0123456789abcdefghijklmnopqrstuvwxyz"
2016-03-21 19:42:56.229102895 -0700 PDT [ERROR] Failed to mount name=0123456789abcdefghijklmnopqrstuvwxyz error="/vmfs/volumes/4bad174b-b67f5cfc-2fc6-0026b966a303/dockvols/0123456789abcdefghijklmnopqrstuvwxyz.vmdk is already attached, skipping duplicate attach request."
2016-03-21 19:42:58.574289538 -0700 PDT [ERROR] Failed to unmount mountpoint="/mnt/vmdk/0123456789abcdefghijklmnopqrstuvwxyz" error="invalid argument"
2016-03-21 19:43:15.540282126 -0700 PDT [INFO] Unmounting Volume name=0123456789abcdefghijklmnopqrstuvwxyz
2016-03-21 19:43:15.540360158 -0700 PDT [INFO] Unmount Succeeded name=0123456789abcdefghijklmnopqrstuvwxyz
