### PR TITLE
Fixed a couple of bug in KV code - misuse of unicode concat, and missing check for status

### DIFF
--- a/vmdkops-esxsrv/vmci_srv.py
+++ b/vmdkops-esxsrv/vmci_srv.py
@@ -381,17 +381,16 @@ def disk_attach(vmdkPath, vm):
   # attach below if it is
 
   status = kv.get(vmdkPath, 'status')
-  logging.info("Attaching " + vmdkPath + " with status " + status)
-  if status != 'detached':
+  logging.info("Attaching {0} with status {1}".format(vmdkPath,  status))
+  if status and status != 'detached':
      vmUuid = kv.get(vmdkPath, 'attachedVMUuid')
      if vmUuid:
         if vmUuid == vm.config.uuid:
-           logging.warning(vmdkPath + " is already attached, skipping duplicate attach request.")
-           return err(vmdkPath + " is already attached, skipping duplicate attach request.")
+           msg = "{0} is already attached, skipping duplicate request.".format(vmdkPath)
         else:
-           logging.warning(vmdkPath + " is attached to VM with ID " + str(vm.config.uuid) +
-                           " skipping attach request.")
-           return err("%s is in use." % vmdkPath)
+           msg = "{0} is attached to VM ID={1}, skipping attach request".format(vmdkPath, vmUuid)
+        logging.warning(msg)
+        return err(msg)
 
   # Now find a slot on the controller  , if needed
   if not diskSlot:


### PR DESCRIPTION
Python was throwing when hitting the "string" + var code where var is unicode. This was a message in error handling in KB code. Fixed it by converting to format().
Also was missing a check for status , so KV code misinterpreted status=None as "already attached"

tested manually on Andrew's testbed - it had pre-existing volume with no sidecar (which is why the error condition in KV was triggered) 
- before: python died
- after: test passed
