### PR TITLE
Minor cleanup in esx_mock based tests.

### DIFF
--- a/vmdkops/cmd_test.go
+++ b/vmdkops/cmd_test.go
@@ -13,14 +13,15 @@ func TestCommands(t *testing.T) {
 	ops := vmdkops.VmdkOps{Cmd: vmdkops.MockVmdkCmd{}}
 	name := "myVolume"
 	opts := map[string]string{"size": "2gb", "format": "none"}
-	assert.Nil(t, ops.Create(name, opts))
+	if assert.Nil(t, ops.Create(name, opts)) {
 
-	opts = map[string]string{}
-	assert.Nil(t, ops.Attach(name, opts))
-	assert.Nil(t, ops.Detach(name, opts))
-	assert.Nil(t, ops.Remove(name, opts))
-	assert.Nil(t,
-		ops.Create("otherVolume",
-			map[string]string{"size": "1gb", "format": "ext4"}))
-	assert.Nil(t, ops.Remove("otherVolume", opts))
+	  opts = map[string]string{}
+	  assert.Nil(t, ops.Attach(name, opts))
+	  assert.Nil(t, ops.Detach(name, opts))
+	  assert.Nil(t, ops.Remove(name, opts))
+	}
+	if assert.Nil(t, ops.Create("otherVolume",
+				map[string]string{"size": "1gb", "format": "ext4"})) {
+	  assert.Nil(t, ops.Remove("otherVolume", opts))
+	}
 }


### PR DESCRIPTION
When running tests at home I got a few failures in mock tests.
It turned out to be the issue with my home config, but while investigated
I did a minor cleanup of the code:
- avoid running tests we know would fail because creation of block device failed
- make messages a bit more consistent and shorter
- add pid() to tmp file name to minimize the changes of stepping into old not-cleaned files ( happened to be when  VM crashed)

tested with 'make all' and CI
also, manually touched files to create conflicting names and made sure the messages are printed only for create failure
