### PR TITLE
Prevent FindChild() timeout in vmdk_ops.py

### DIFF
--- a/vmdkops-esxsrv/vmdk_ops.py
+++ b/vmdkops-esxsrv/vmdk_ops.py
@@ -155,7 +155,7 @@ def findVmByName(vmName):
 	vm = None
 	try:
 		vm = FindChild(GetVmFolder(), vmName)
-	except AttributeError as ex:
+	except vim.fault.NotAuthenticated as ex:
 		connectLocal() 					#  retry
 		vm = FindChild(GetVmFolder(), vmName)
 


### PR DESCRIPTION
Handle the correct (vim.fault.NotAuthenticated) exception and reconnect.

Fixes #36
