### PR TITLE
In-memory mount refcounter implementation

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 	// connect to this socket
 	port := flag.Int("port", 15000, "Default port for vmci")
 	mockEsx := flag.Bool("mock_esx", false, "Mock the ESX server")
-	logLevel := flag.String("log_level", "info", "Logging Level")
+	logLevel := flag.String("log_level", "debug", "Logging Level")
 	configFile := flag.String("config", defaultConfigPath, "Configuration file path")
 	flag.Parse()
 

--- a/vmdkops/vmdkops.go
+++ b/vmdkops/vmdkops.go
@@ -5,13 +5,11 @@ package vmdkops
 import (
 	"encoding/json"
 	"fmt"
+	log "github.com/Sirupsen/logrus"
 )
 
 //
 // * VMDK CADD (Create/Attach/Detach/Delete) operations client code.
-// *
-// *
-// * TODO: drop fprintf  and return better errors
 // *
 // * TODO: allow concurrency from multiple containers. Specifically, split into
 // * Vmci_SubmitRequst() [not blocking] and Vmci_GetReply() [blocking] so the
@@ -37,30 +35,35 @@ type VolumeData struct {
 
 // Create a volume
 func (v VmdkOps) Create(name string, opts map[string]string) error {
+	log.Debugf("vmdkOp.Create name=%s", name)
 	_, err := v.Cmd.Run("create", name, opts)
 	return err
 }
 
 // Remove a volume
 func (v VmdkOps) Remove(name string, opts map[string]string) error {
+	log.Debugf("vmdkOps.Remove name=%s", name)
 	_, err := v.Cmd.Run("remove", name, opts)
 	return err
 }
 
 // Attach a volume
 func (v VmdkOps) Attach(name string, opts map[string]string) error {
+	log.Debugf("vmdkOps.Attach name=%s", name)
 	_, err := v.Cmd.Run("attach", name, opts)
 	return err
 }
 
 // Detach a volume
 func (v VmdkOps) Detach(name string, opts map[string]string) error {
+	log.Debugf("vmdkOps.Detach name=%s", name)
 	_, err := v.Cmd.Run("detach", name, opts)
 	return err
 }
 
 // List all volumes
 func (v VmdkOps) List() ([]VolumeData, error) {
+	log.Debugf("vmdkOps.List")
 	str, err := v.Cmd.Run("list", "", make(map[string]string))
 	if err != nil {
 		return nil, err
@@ -76,6 +79,7 @@ func (v VmdkOps) List() ([]VolumeData, error) {
 
 // Get for volume
 func (v VmdkOps) Get(name string) (VolumeData, error) {
+	log.Debugf("vmdkOps.Get name=%s", name)
 	volumes, err := v.List()
 	if err != nil {
 		return VolumeData{}, err


### PR DESCRIPTION
Keeps track of mounted volumes and their refcount, and issues
 mount/unmount requests only if needed (when refcount flips between 1 and 0)

This prevents multiple mount / unmount requests sent from plugin and allows multiple running containers to truly share a volume. A redundant mount/unmount  sent to ESX are errors and keep being treated as such (that's why I closed #200) 

**Tested**: manually by running multiple containers with volume in different shells and checking refcount log; as well as saving file in one running container and checking on another.

**To be done in follow-up PRs**
- Automated tests - parallel containers invocation which use the volume. it will need some changes in sanity_test.go, I'd like to do it as a separated PR
- Crash recovery - when Plugin is restarted, it knows about this fact and I hope it can interrogate Docker for volume usage in running containers (investigation pending). Plan B: local persistence. Either way I'll send a write up when investigation is done
- Crash recovery - when Docker is restarted. Investigation pending
