### PR TITLE
Minor changes to error text and deploy-vm

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -124,9 +124,8 @@ func (d vmdkDriver) Remove(r volume.Request) volume.Response {
 
 	// Docker is supposed to block 'remove' command if the volume is used. Verify.
 	if refcounts[r.Name] != 0 {
-		msg := fmt.Sprintf("Refcount error, volume=%s, refcount=%d  "+
-			"(possibly unmount request for a non-mounted volume)",
-			r.Name, refcounts[r.Name])
+		msg := fmt.Sprintf("Remove faiure - volume is still mounted. " +
+		    " volume=%s, refcount=%d", r.Name, refcounts[r.Name])
 		log.Error(msg)
 		return volume.Response{Err: msg}
 	}

--- a/scripts/cleanvm.sh
+++ b/scripts/cleanvm.sh
@@ -9,4 +9,8 @@ if [ "$pid" != "" ]
 then
    kill $pid
 fi
-$DEBUG rm -rvf /mnt/vmdk/*
+for d in /mnt/vmdk/*
+do
+   $DEBUG umount $d 2>/dev/null
+   $DEBUG rm -rvf $d
+done


### PR DESCRIPTION
- changed error message in remove to reflect reality
- made deploy-vm unmount volume before removing mount point

Manual test for the message (started container with a volume, killed docker with -9 and then tried to remove the volume - docker is fine with it but refcounter blocks it)
Same test validated that unmount works 
