### PR TITLE
Small fixes to message format and resilience to attachedVMUuid absense

### DIFF
--- a/vmdkops-esxsrv/vmdk_ops.py
+++ b/vmdkops-esxsrv/vmdk_ops.py
@@ -425,8 +425,10 @@ def disk_detach(vmdkPath, vm):
      volMeta = kv.getAll(vmdkPath)
      if volMeta:
         volMeta['status'] = 'detached'
-        del volMeta['attachedVMUuid']
-        kv.setAll(vmdkPath, volMeta)
+        try:
+            del volMeta['attachedVMUuid']
+        finally:
+            kv.setAll(vmdkPath, volMeta)
   except vim.fault.GenericVmConfigFault as ex:
      for f in ex.faultMessage:
         logging.warning(f.message)

--- a/vmdkops/vmci/vmci_client.c
+++ b/vmdkops/vmci/vmci_client.c
@@ -216,21 +216,21 @@ vsock_get_reply(be_sock_id *s, be_request *r, be_answer* a)
    b = MAGIC;
    ret = send(s->sock_id, &b, sizeof b, 0);
    if (ret == -1 || ret != sizeof b) {
-      printf("Failed to send magic: ret %d (%s) expected ret %d\n",
+      printf("Failed to send magic: ret %d (%s) expected ret %lu\n",
                ret, strerror(errno), sizeof b);
       return -1;
    }
 
    ret = send(s->sock_id, &r->mlen, sizeof r->mlen, 0);
    if (ret == -1 || ret != sizeof r->mlen) {
-      printf("Failed to send len: ret %d (%s) expected ret %d\n",
+      printf("Failed to send len: ret %d (%s) expected ret %lu\n",
                ret, strerror(errno), sizeof r->mlen);
       return -1;
    }
 
    ret = send(s->sock_id, r->msg, r->mlen, 0);
    if (ret == -1 || ret != r->mlen) {
-      printf("Failed to send content: ret %d (%s) expected ret\n",
+      printf("Failed to send content: ret %d (%s) expected ret %d\n",
                ret, strerror(errno), r->mlen);
       return -1;
    }

--- a/vmdkops/vmdkcmd.go
+++ b/vmdkops/vmdkcmd.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
-	"syscall"
 	"unsafe"
 )
 
@@ -71,8 +70,11 @@ func (vmdkCmd VmdkCmd) Run(cmd string, name string, opts map[string]string) ([]b
 	ret := C.Vmci_GetReply(C.int(vmciEsxPort), cmdS, beS, ans)
 
 	if ret != 0 {
-		log.Warn("No connection to ESX over vsocket, trace only")
-		return nil, fmt.Errorf("vmdkCmd err: %d (%s)", ret, syscall.Errno(ret).Error())
+		msg := "Failed to connect to ESX over vsocket"
+		// TODO: vci_client.c:vsock_get_reply needs to return meaninful errcode
+		// and we need to issue details on connection failure
+		log.Warn(msg)
+		return nil, errors.New(msg)
 	}
 	response := []byte(C.GoString(ans.buf))
 	C.free(unsafe.Pointer(ans.buf))


### PR DESCRIPTION
I was working on refcounts discovery and theses issues were super annoying so I fixed them in a this PR.
- Corrected warnings in printf formats in vmci_client.c
- Protected against attachedVMUuid absense in metadata 
- Finally fixed Docker-side message `err=-1` seen when Plugin can't connect to ESX

Tested manually: 
- in different test scenarios I saw python throwing on the attachedVMUUid missing, the issue went away after the fix (log below)
- go test ." was generating C compile warning on printf formst long int vs. int mismatch (go test compiled with -Wall) ; they also went away
- Instead of "-1" error from vmdkOps when it failed to connect to ESX, it now prints (and shows on the screen) this
  `2016-04-04 20:09:42.133179851 -0700 PDT [WARNING] Failed to connect to ESX over vsocket`

appendix: python throwing before the fix:

```
03/23/16 06:40:23 1355074 [INFO] Attaching /vmfs/volumes/56be7b43-11018e33-fe41-000c293742b9/dockvols/v1.vmdk with status detached
03/23/16 06:40:23 1355074 [DEBUG]  controllerKey=1001 slot=1
03/23/16 06:40:29 1355074 [DEBUG] executeRequest ret = {u'Error': 'Failed to add disk scsi1:1.'}
03/23/16 06:40:29 1355074 [DEBUG] lib.vmci_reply: VMCI replied with errcode 0 
03/23/16 06:40:29 1355074 [DEBUG] lib.vmci_get_one_op returns 7, buffer '{"cmd":"detach","details":{"Name":"v1"}}'
03/23/16 06:40:29 1355074 [INFO] *** detachVMDK: /vmfs/volumes/56be7b43-11018e33-fe41-000c293742b9/dockvols/v1.vmdk from Ubuntu14-server VM uuid=564d763c-bb5c-e1b7-3319-52640d0e294f
03/23/16 06:40:29 1355074 [DEBUG] findDeviceByPath: MATCH: /vmfs/volumes/56be7b43-11018e33-fe41-000c293742b9/dockvols/v1.vmdk
03/23/16 06:40:31 1355074 [ERROR] 'attachedVMUuid'
Traceback (most recent call last):
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 505, in main
    handleVmciRequests()
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 486, in handleVmciRequests
    ret = executeRequest(vmName, vmId, cfgPath, req["cmd"], details["Name"], opts)
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 213, in executeRequest
    return detachVMDK(vmdkPath, vmName)
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 179, in detachVMDK
    disk_detach(vmdkPath, vm)
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 427, in disk_detach
    del volMeta['attachedVMUuid']
KeyError: 'attachedVMUuid'
```
