### PR TITLE
Initial version of ESX admin script

### DIFF
--- a/vmdkops-esxsrv/Makefile
+++ b/vmdkops-esxsrv/Makefile
@@ -1,9 +1,9 @@
-# 
+#
 # Makefile for ESX "vmdkops" service - host part of "vmware/vmdkops" Go package
 #
 # Prepares payload folder for vibauthor and builds/places neede stuff there
 # We expect the actual vibauthor to be run via dedicated container upstair
-# 
+#
 
 # deliverables (placed by build)
 BIN := ../bin
@@ -12,9 +12,9 @@ OFFLINE_DEPOT := vmware-esx-vmdkops-1.0.0.zip
 VIB_BIN  = $(BIN)/$(VIB)
 
 # code
-PY_SRC := vmdk_ops.py volumeKVStore.py kvESX.py
+PY_SRC := vmdk_ops.py volumeKVStore.py kvESX.py vmdkops_admin.py
 C_SRC  := vmci/vmci_server.c
-INIT_SCRIPT := vmdk-opsd 
+INIT_SCRIPT := vmdk-opsd
 
 # extra stuff to copy to vib
 TOOLS := tools/lin32/mkfs.ext4
@@ -35,8 +35,8 @@ VMDKOPS_BIN = $(VMDKOPS_PAYLOAD)$(ESX_BIN)
 VMDKOPS_INITD = $(VMDKOPS_PAYLOAD)$(INITD_PATH)
 
 # We need to build C code as 32 bits.
-# Reason: vSockets return cartelId to ID connecting VM. We use VSI to convert 
-#       it to VM name/ID. ESX is shipped with 32bit VSI python module only, so 
+# Reason: vSockets return cartelId to ID connecting VM. We use VSI to convert
+#       it to VM name/ID. ESX is shipped with 32bit VSI python module only, so
 #       we use 32bit python and 32 bit shared libs for VMCI/vSockets
 CFLAGS  := -fPIC -m32 -shared
 cc := gcc
@@ -44,7 +44,7 @@ VIBAUTHOR := vibauthor
 BDIR := ../bin
 WDIR := .
 
-# this is used from a Makefile upstairs, and could be used manually 
+# this is used from a Makefile upstairs, and could be used manually
 .PHONY: build
 build: $(VIB_BIN)
 
@@ -66,14 +66,14 @@ $(VIB_BIN): descriptor.xml $(PY_FILES) $(TOOLS)
 
 $(VMCI_SRV_LIB): $(C_SRC)
 	$(CC) $(CFLAGS) -o $@ $(C_SRC)
-	
+
 .PHONY:	clean
 clean:
 	rm -rf $(VIB) $(VMCI_SRV_LIB) $(PAYLOAD)
 
 .PHONY: test
 test: build
-	@echo "? Info: No unit test here yet."	
+	@echo "? Info: No unit test here yet."
 
 
 

--- a/vmdkops-esxsrv/vmdkops_admin.py
+++ b/vmdkops-esxsrv/vmdkops_admin.py
@@ -1,0 +1,75 @@
+#! /usr/bin/env python
+
+# This is the admin cli for esx vmdk volume management
+
+import argparse
+
+def main():
+  namespace = parse_args()
+  print namespace
+
+def create_parser():
+  parser = argparse.ArgumentParser(description='Manage VMDK Volumes')
+  subparsers = parser.add_subparsers();
+  add_ls_parser(subparsers)
+  add_df_parser(subparsers)
+  add_policy_parsers(subparsers)
+  return parser
+
+def parse_args():
+  parser = create_parser()
+  args = parser.parse_args()
+  args.func(args)
+
+def add_ls_parser(subparsers):
+  parser = subparsers.add_parser('ls', help='List volumes')
+  parser.add_argument('-l', action='store_true', help='List detailed information about volumes')
+  choices=['created-by', 'created', 'last-attached', 'datastore', 'policy', 'capacity',
+      'used', 'attached-to']
+  parser.add_argument('-c', nargs='+', help='Only display given columns', choices=choices)
+  parser.set_defaults(func=ls)
+
+def add_df_parser(subparsers):
+  parser = subparsers.add_parser('df', help='Show datastore usage and availability')
+  parser.set_defaults(func=df)
+
+def add_policy_parsers(subparsers):
+  parser = subparsers.add_parser('policy', help='Configure and display storage policy information')
+  policy_subparsers = parser.add_subparsers();
+  add_policy_create_parser(policy_subparsers)
+  add_policy_rm_parser(policy_subparsers)
+  add_policy_ls_parser(policy_subparsers)
+
+def add_policy_create_parser(subparsers):
+  parser = subparsers.add_parser('create', help='Create a storage policy')
+  parser.add_argument('--name', help='The name of the policy', required=True)
+  parser.add_argument('--content', help='The VSAN policy string', required=True)
+  parser.set_defaults(func=policy_create)
+
+def add_policy_rm_parser(subparsers):
+  parser = subparsers.add_parser('rm', help='Remove a storage policy')
+  parser.add_argument('name', help='Policy name')
+  parser.set_defaults(func=policy_rm)
+
+def add_policy_ls_parser(subparsers):
+  parser = subparsers.add_parser('ls',
+      help='List storage policies and volumes using those policies')
+  parser.set_defaults(func=policy_ls)
+
+def ls(args):
+  print "Called ls with args {0}".format(args)
+
+def df(args):
+  print "Called df with args {0}".format(args)
+
+def policy_create(args):
+  print "Called policy_create with args {0}".format(args)
+
+def policy_rm(args):
+  print "Called policy_rm with args {0}".format(args)
+
+def policy_ls(args):
+  print "Called policy_ls with args {0}".format(args)
+
+if __name__ == "__main__":
+  main()

--- a/vmdkops-esxsrv/vmdkops_admin_tests.py
+++ b/vmdkops-esxsrv/vmdkops_admin_tests.py
@@ -1,0 +1,79 @@
+import unittest
+import sys
+import vmdkops_admin
+
+class TestParsing(unittest.TestCase):
+
+  def setUp(self):
+    self.parser = vmdkops_admin.create_parser()
+
+  def test_parse_ls_no_options(self):
+    args = self.parser.parse_args(['ls'])
+    self.assertEqual(args.func, vmdkops_admin.ls)
+    self.assertEqual(args.l, False)
+    self.assertEqual(args.c, None)
+
+  def test_parse_ls_dash_l(self):
+    args = self.parser.parse_args('ls -l'.split())
+    self.assertEqual(args.func, vmdkops_admin.ls)
+    self.assertEqual(args.l, True)
+    self.assertEqual(args.c, None)
+
+  def test_parse_ls_dash_c(self):
+    args = self.parser.parse_args('ls -c created-by created last-attached'.split())
+    self.assertEqual(args.func, vmdkops_admin.ls)
+    self.assertEqual(args.l, False)
+    self.assertEqual(args.c, ['created-by', 'created', 'last-attached'])
+
+  def test_parse_ls_dash_c_invalid_argument(self):
+    self.assert_parse_error('ls -c personality')
+
+  def test_df(self):
+    args = self.parser.parse_args('df'.split())
+    self.assertEqual(args.func, vmdkops_admin.df)
+
+  def test_df_badargs(self):
+    self.assert_parse_error('df -l')
+
+  def test_policy_no_args_fails(self):
+    self.assert_parse_error('policy')
+
+  def test_policy_create_no_args_fails(self):
+    self.assert_parse_error('policy create')
+
+  def test_policy_create(self):
+    content = 'some policy content'
+    cmd = 'policy create --name=testPolicy --content'.split()
+    cmd.append("some policy content")
+    args = self.parser.parse_args(cmd)
+    self.assertEqual(args.content, 'some policy content')
+    self.assertEqual(args.func, vmdkops_admin.policy_create)
+    self.assertEqual(args.name, 'testPolicy')
+
+  def test_policy_rm(self):
+    args = self.parser.parse_args('policy rm testPolicy'.split())
+    self.assertEqual(args.func, vmdkops_admin.policy_rm)
+    self.assertEqual(args.name, 'testPolicy')
+
+  def test_policy_rm_no_args_fails(self):
+    self.assert_parse_error('policy rm')
+
+  def test_policy_ls(self):
+    args = self.parser.parse_args('policy ls'.split())
+    self.assertEqual(args.func, vmdkops_admin.policy_ls)
+
+  def test_policy_ls_badargs(self):
+    self.assert_parse_error('policy ls --name=yo')
+
+# Usage is always printed on a parse error. It's swallowed to prevent clutter.
+  def assert_parse_error(self, command):
+      with open('/dev/null', 'w') as f:
+        sys.stdout = f
+        sys.stderr = f
+        with self.assertRaises(SystemExit):
+          args = self.parser.parse_args(command.split())
+      sys.stdout = sys.__stdout__
+      sys.stdin = sys.__stdin__
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
This commit contains parsers and tests for ls, df, and policy commands.
These parsers and tests still need to be written for role and status.

No functionality is currently implemented, but the function stubs exist
that get called with the parsed arguments when a command is parsed.

I also added vmdkops_admin.py to the VIB. The test is currently not run
anywhere, but as it only relies on argparse it can be run anywhere right
now.
