### PR TITLE
Add parsers and tests for vmdkops-admin role/status

### DIFF
--- a/vmdkops-esxsrv/vmdkops_admin.py
+++ b/vmdkops-esxsrv/vmdkops_admin.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# This is the admin cli for esx vmdk volume management
+# Admin CLI for vmdk_opsd
 
 import argparse
 
@@ -14,6 +14,8 @@ def create_parser():
   add_ls_parser(subparsers)
   add_df_parser(subparsers)
   add_policy_parsers(subparsers)
+  add_role_parsers(subparsers)
+  add_status_parser(subparsers)
   return parser
 
 def parse_args():
@@ -21,12 +23,32 @@ def parse_args():
   args = parser.parse_args()
   args.func(args)
 
+def comma_seperated_string(string):
+  return string.split(',')
+
+def make_list_of_values(allowed):
+  """
+  Take a list of allowed values for an option and return a function that can be
+  used to typecheck a string of given values and ensure they match the allowed
+  values.  This is required to support options that take comma seperated lists
+  such as --rights in 'role set --rights=create,delete,mount'
+  """
+  def list_of_values(string):
+    given = string.split(',')
+    for g in given:
+      if g not in allowed:
+        msg = "invalid choice: {0} (choose from {1})".format(g, allowed)
+        raise argparse.ArgumentTypeError(msg)
+    return given
+  return list_of_values
+
 def add_ls_parser(subparsers):
   parser = subparsers.add_parser('ls', help='List volumes')
   parser.add_argument('-l', action='store_true', help='List detailed information about volumes')
   choices=['created-by', 'created', 'last-attached', 'datastore', 'policy', 'capacity',
       'used', 'attached-to']
-  parser.add_argument('-c', nargs='+', help='Only display given columns', choices=choices)
+  parser.add_argument('-c', help='Only display given columns: Choices = {0}'.format(choices),
+      type=make_list_of_values(choices), metavar='Column1,Column2,...')
   parser.set_defaults(func=ls)
 
 def add_df_parser(subparsers):
@@ -56,6 +78,55 @@ def add_policy_ls_parser(subparsers):
       help='List storage policies and volumes using those policies')
   parser.set_defaults(func=policy_ls)
 
+def add_role_parsers(subparsers):
+  parser = subparsers.add_parser('role', help='Administer and monitor volume access control')
+  role_subparsers = parser.add_subparsers()
+  add_role_create_parser(role_subparsers)
+  add_role_rm_parser(role_subparsers)
+  add_role_ls_parser(role_subparsers)
+  add_role_set_parser(role_subparsers)
+  add_role_get_parser(role_subparsers)
+
+def add_role_create_parser(subparsers):
+  parser = subparsers.add_parser('create', help='Create a new role')
+  parser.add_argument('--name', help='The name of the role', required=True)
+  parser.add_argument('--matches-vm', metavar='Glob1,Glob2,...', required=True,
+      help='Apply this role to VMs with names matching Glob', type=comma_seperated_string)
+  parser.add_argument('--rights', help='Permissions granted to matching VMs', required=True,
+      type=make_list_of_values(['create', 'delete', 'mount']), metavar='create,delete,mount')
+  parser.add_argument('--volume-maxsize', help='Maximum size of the volume that can be created',
+      required=True, metavar='Num{MB,GB,TB} - e.g. 2TB')
+  parser.set_defaults(func=role_create)
+
+def add_role_rm_parser(subparsers):
+  parser = subparsers.add_parser('rm', help='Delete a role')
+  parser.add_argument('name', help='The name of the role')
+  parser.set_defaults(func=role_rm)
+
+def add_role_ls_parser(subparsers):
+  parser = subparsers.add_parser('ls', help='List roles and the VMs they are applied to')
+  parser.set_defaults(func=role_ls)
+
+def add_role_set_parser(subparsers):
+  parser = subparsers.add_parser('set', help='Modify an existing role')
+  parser.add_argument('--name', help='The name of the role', required=True)
+  parser.add_argument('--matches-vm', nargs="*",
+      help='Apply this role to VMs with names matching Glob', metavar='Glob')
+  parser.add_argument('--rights', help='Permissions granted to matching VMs', nargs="*",
+      choices=['create', 'delete', 'mount'])
+  parser.add_argument('--volume-maxsize', help='Maximum size of the volume that can be created',
+      metavar='Num{MB,GB,TB} - e.g. 2TB')
+  parser.set_defaults(func=role_set)
+
+def add_role_get_parser(subparsers):
+  parser = subparsers.add_parser('get', help='Get all roles and permissions for a given VM')
+  parser.add_argument('vm_name', help='The name of the VM')
+  parser.set_defaults(func=role_get)
+
+def add_status_parser(subparsers):
+  parser = subparsers.add_parser('status', help='Show the status of vmdk_ops service')
+  parser.set_defaults(func=status)
+
 def ls(args):
   print "Called ls with args {0}".format(args)
 
@@ -70,6 +141,24 @@ def policy_rm(args):
 
 def policy_ls(args):
   print "Called policy_ls with args {0}".format(args)
+
+def role_create(args):
+  print "Called role_create with args {0}".format(args)
+
+def role_rm(args):
+  print "Called role_rm with args {0}".format(args)
+
+def role_ls(args):
+  print "Called role_ls with args {0}".format(args)
+
+def role_set(args):
+  print "Called role_set with args {0}".format(args)
+
+def role_get(args):
+  print "Called role_get with args {0}".format(args)
+
+def status(args):
+  print "Called status with args {0}".format(args)
 
 if __name__ == "__main__":
   main()

--- a/vmdkops-esxsrv/vmdkops_admin_tests.py
+++ b/vmdkops-esxsrv/vmdkops_admin_tests.py
@@ -20,7 +20,7 @@ class TestParsing(unittest.TestCase):
     self.assertEqual(args.c, None)
 
   def test_parse_ls_dash_c(self):
-    args = self.parser.parse_args('ls -c created-by created last-attached'.split())
+    args = self.parser.parse_args('ls -c created-by,created,last-attached'.split())
     self.assertEqual(args.func, vmdkops_admin.ls)
     self.assertEqual(args.l, False)
     self.assertEqual(args.c, ['created-by', 'created', 'last-attached'])
@@ -65,15 +65,65 @@ class TestParsing(unittest.TestCase):
   def test_policy_ls_badargs(self):
     self.assert_parse_error('policy ls --name=yo')
 
-# Usage is always printed on a parse error. It's swallowed to prevent clutter.
+  def test_role_create(self):
+    cmd = 'role create --name=carl --volume-maxsize=2TB ' + \
+          '--matches-vm test*,qa* --rights=create,mount'
+    args = self.parser.parse_args(cmd.split())
+    self.assertEqual(args.func, vmdkops_admin.role_create)
+    self.assertEqual(args.name, 'carl')
+    self.assertEqual(args.volume_maxsize, '2TB')
+    self.assertEqual(args.matches_vm, ['test*', 'qa*'])
+    self.assertEqual(args.rights, ['create', 'mount'])
+
+  def test_role_create_missing_option_fails(self):
+    cmd = 'role create --name=carl --volume-maxsize=2TB --matches-vm=test*,qa*'
+    self.assert_parse_error(cmd)
+
+  def test_role_rm(self):
+    args = self.parser.parse_args('role rm myRole'.split())
+    self.assertEqual(args.func, vmdkops_admin.role_rm)
+    self.assertEqual(args.name, 'myRole')
+
+  def test_role_rm_missing_name(self):
+    self.assert_parse_error('role rm')
+
+  def test_role_ls(self):
+    args = self.parser.parse_args('role ls'.split())
+    self.assertEqual(args.func, vmdkops_admin.role_ls)
+
+  def test_role_set(self):
+    cmds = [
+        'role set --name=carl --volume-maxsize=4TB',
+        'role set --name=carl --rights create mount',
+        'role set --name=carl --matches-vm marketing*',
+        'role set --name=carl --volume-maxsize=2GB --rights create mount delete'
+        ]
+    for cmd in cmds:
+      args = self.parser.parse_args(cmd.split())
+      self.assertEqual(args.func, vmdkops_admin.role_set)
+      self.assertEqual(args.name, 'carl')
+
+  def test_role_set_missing_name_fails(self):
+    self.assert_parse_error('role set --volume-maxsize=4TB')
+
+  def test_role_get(self):
+    args = self.parser.parse_args('role get testVm'.split())
+    self.assertEqual(args.func, vmdkops_admin.role_get)
+    self.assertEqual(args.vm_name, 'testVm')
+
+  def test_status(self):
+    args = self.parser.parse_args(['status'])
+    self.assertEqual(args.func, vmdkops_admin.status)
+
+  # Usage is always printed on a parse error. It's swallowed to prevent clutter.
   def assert_parse_error(self, command):
       with open('/dev/null', 'w') as f:
         sys.stdout = f
         sys.stderr = f
         with self.assertRaises(SystemExit):
           args = self.parser.parse_args(command.split())
-      sys.stdout = sys.__stdout__
-      sys.stdin = sys.__stdin__
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Sample Output:

```
andrewstone-mbp:vmdkops-esxsrv andrewstone$ ./vmdkops_admin.py -h
usage: vmdkops_admin.py [-h] {ls,df,policy,role,status} ...

Manage VMDK Volumes

positional arguments:
  {ls,df,policy,role,status}
    ls                  List volumes
    df                  Show datastore usage and availability
    policy              Configure and display storage policy information
    role                Administer and monitor volume access control
    status              Show the status of vmdk_ops service

optional arguments:
  -h, --help            show this help message and exit
```

```
andrewstone-mbp:vmdkops-esxsrv andrewstone$ ./vmdkops_admin.py role -h
usage: vmdkops_admin.py role [-h] {create,rm,ls,set,get} ...

positional arguments:
  {create,rm,ls,set,get}
    create              Create a new role
    rm                  Delete a role
    ls                  List roles and the VMs they are applied to
    set                 Modify an existing role
    get                 Get all roles and permissions for a given VM

optional arguments:
  -h, --help            show this help message and exit
```

```
andrewstone-mbp:vmdkops-esxsrv andrewstone$ ./vmdkops_admin.py role ls
Called role_ls with args Namespace(func=<function role_ls at 0x109d78d70>)
None
andrewstone-mbp:vmdkops-esxsrv andrewstone$ ./vmdkops_admin.py status
Called status with args Namespace(func=<function status at 0x10f0ef5f0>)
None
```
