### PR TITLE
Allow Mac-based build, and remove useless cleanup

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -4,21 +4,12 @@
 # simple wrapper for check build pre-requisites
 #
 
-# Check prereq first - we need docker
-
 printNQuit() {
    echo $1
    exit 1
 }
 
-# check platform
-#----------------
-
-if [ `uname` != "Linux" ]
-then
-  echo "This build is supported only on Linux."
-  exit 1
-fi
+# dockerbuild needs docker :-)
 
 if [ "$1" == "dockerbuild" ]
 then
@@ -29,8 +20,14 @@ then
    # 1.9 might be ok..?
    printNQuit "Docker is needed to run dockerbuild"
  fi
+ if [ "$(docker version -f '{{.Server.Os}}')" != "linux" ]
+ then
+   printNQuit "This build requires Docker Server running on Linux."
+ fi
  exit 0
 fi
+
+# pgk build just needs FPM (it is taken care of by Dockerfiles/Dockerfile.fpm)
 
 if [ "$1" == "pkg" ]
 then
@@ -42,8 +39,15 @@ then
  exit 0
 fi
 
-# Check GO version and config
-#-----------------------------
+# And all other builds need GO 1.5+ version and proper config
+#------------------------------------------------------------
+
+if [ `uname` != "Linux" ]
+then
+  echo "This build is supported only on Linux."
+  exit 1
+fi
+# Check
 
 GO_REQUIRED=1.5
 

--- a/scripts/deploy-tools.sh
+++ b/scripts/deploy-tools.sh
@@ -34,7 +34,6 @@ internal_vib_name=vmware-esx-vmdkops-service
 
 script_loc=./scripts
 tmp_loc=/tmp/docker-vmdk-plugin
-guest_mount_point=/mnt/vmdk
 
 # ====== define functions =======
 
@@ -167,9 +166,6 @@ function cleanvm {
    
         echo "   Removing binaries and restarting docker..."
         $SSH $target rm -f $remote_binaries
-        $SSH $target rm -rvf $guest_mount_point/$test_vol
-        $SSH $target rm -rvf /tmp/docker-volumes/
-        $SSH $target service docker restart
    done
 }
 


### PR DESCRIPTION
 With Docker 1.11 Beta for Mac, we can now build directly on MAC. This PR enables it.
- Instead of checking OS for all targets, we only check it for GO build.
- For dockerbuild we check the Docker Server is running on correct arch.
- For pkg build we do not check anything as Dockerfile already sets environment
  
  Also dropped unneeded dir removal, and add useful (for manual recovery) "clean-docker" target
  
  Tested by running "make all" on Mac and then on Ubuntu.

I suspect the build  will also work on docker-machine as long as docker daemon is on Linux, but I did not test it 
