### PR TITLE
More fixes to admin_tools testing

### DIFF
--- a/vmdkops-esxsrv/vmdkops_admin.py
+++ b/vmdkops-esxsrv/vmdkops_admin.py
@@ -259,11 +259,12 @@ def get_volumes():
         try:
             files = os.listdir(path)
         except OSError as e:
-            # dockvols may not exists on a volume, so skip it
+            # dockvols may not exists on a datastore, so skip it
             pass
-        for f in files:
-            if f.endswith('.vmdk') and not f.endswith('-flat.vmdk'):
-                volumes.append((path, f, datastore))
+        else:
+            for f in files:
+                if f.endswith('.vmdk') and not f.endswith('-flat.vmdk'):
+                    volumes.append((path, f, datastore))
     return volumes
 
 def get_metadata(volPath):


### PR DESCRIPTION
It failed on my box (I have a few NFSreadonly mounts) so I did this to get unblocked
- made tests skip datastores where dockvols can't be created
- made tests ignore "already exists" for mkdir
- dropped file-based get_datastores and now use pyVmomi based
- fixed the test to properly expect volume count if there are more than one datastore

It now passes on my box and CI also

/CC @andrewjstone 
