### PR TITLE
Add support for upstart for ubuntu customers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ ESXi:
 Docker: 1.9 and higher
 
 VM:
-- Ubuntu 14.04 64 bit (using systemd)
+- Ubuntu 14.04 64 bit (needs Upstart or systemctl)
 - Photon
 
 ## Installation
@@ -57,9 +57,9 @@ plugin. For manual steps not using rpm or deb file please refer
 
 ```
 # DEB
-sudo dpkg -i docker-vmdk-plugin_v0.1.pre-tp_amd64.deb
+sudo dpkg -i docker-vmdk-plugin_0.1.0.pre-tp_amd64.deb
 # RPM
-sudo rpm -ivh docker-vmdk-plugin-v0.1.pre_tp-1.x86_64.rpm
+sudo rpm -ivh docker-vmdk-plugin-0.1.0.pre_tp-1.x86_64.rpm
 ```
 
 ## Using the plugin.

--- a/scripts/install/docker-vmdk-plugin.conf
+++ b/scripts/install/docker-vmdk-plugin.conf
@@ -1,0 +1,10 @@
+description "Docker Volume Driver for vSphere"
+
+start on starting docker
+stop on stopped docker RESULT=ok
+
+respawn
+
+kill timeout 20
+
+exec /usr/bin/$UPSTART_JOB

--- a/scripts/install/systemd-after-install.sh
+++ b/scripts/install/systemd-after-install.sh
@@ -13,7 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-systemctl daemon-reload
-systemctl enable docker-vmdk-plugin.service
-systemctl start docker-vmdk-plugin.service
+stat /proc/1/exe | grep File | grep systemd
+if [ $? -eq 0 ]
+then
+  systemctl daemon-reload
+  systemctl enable docker-vmdk-plugin.service
+  systemctl start docker-vmdk-plugin.service
+else
+  service docker-vmdk-plugin start
+fi

--- a/scripts/install/systemd-after-remove.sh
+++ b/scripts/install/systemd-after-remove.sh
@@ -14,4 +14,8 @@
 # limitations under the License.
 
 
-systemctl daemon-reload
+stat /proc/1/exe | grep File | grep systemd
+if [ $? -eq 0 ]
+then
+  systemctl daemon-reload
+fi

--- a/scripts/install/systemd-before-remove.sh
+++ b/scripts/install/systemd-before-remove.sh
@@ -14,5 +14,11 @@
 # limitations under the License.
 
 
-systemctl stop docker-vmdk-plugin.service
-systemctl disable docker-vmdk-plugin.service
+stat /proc/1/exe | grep File | grep systemd
+if [ $? -eq 0 ]
+then
+  systemctl stop docker-vmdk-plugin.service
+  systemctl disable docker-vmdk-plugin.service
+else
+  service docker-vmdk-plugin stop
+fi


### PR DESCRIPTION
Older versions of 14.04 still use upstart. This adds support for
upstart. On ubuntu with systemd.

service docker-vmdk-plugin <command> still uses systemd on newer
versions of ubuntu.

Photon (rpm) only uses systemd.

Testing: Installed on 14.04.1 service started up cleanly and respawned on kill. Docker commands worked.
