### PR TITLE
Fixed exception happening after handling of vim.fault.NotAuthenticated

### DIFF
--- a/drone-scripts/cleanup.sh
+++ b/drone-scripts/cleanup.sh
@@ -15,6 +15,6 @@
 
 
 stop_build() {
-  make clean-esx clean-vm TEST_VOL_NAME=vol-build$BUILD_NUMBER
+  make clean-vm clean-esx TEST_VOL_NAME=vol-build$BUILD_NUMBER
   $SSH $VM1 /tmp/lock.sh unlock $BUILD_NUMBER
 }

--- a/sanity_test.go
+++ b/sanity_test.go
@@ -65,7 +65,7 @@ func init() {
 	flag.StringVar(&driverName, "d", "vmdk", "Driver name. We refcount volumes on this driver")
 	flag.Parse()
 
-	usingConfigFile := logInit(logLevel, logFile, configFile)
+	usingConfigFileDefaults := logInit(logLevel, logFile, configFile)
 
 	reconnectSleepInterval = time.Duration(*waitSec) * time.Second
 	defaultHeaders = map[string]string{"User-Agent": "engine-api-client-1.0"}
@@ -76,7 +76,7 @@ func init() {
 		"log_level":       *logLevel,
 		"log_file":        *logFile,
 		"conf_file":       *configFile,
-		"using_conf_file": usingConfigFile,
+		"using_conf_file_defaults": usingConfigFileDefaults,
 	}).Info("VMDK plugin tests started ")
 }
 


### PR DESCRIPTION
Issue #280

`vim.fault.NotAuthenticated` handler was saving `si` in local var so it caused
exceptions down the line, specifically in wait_for_tasks, due to empty si passed into it.
made sure 'si' is global in all cases

Also fixed refcount test to properly clean up volume (it was causing CI failures),
and added a bit more info to logs - it was needed to find out why CI was failing on this one.

Test: `make all` and CI. CI used to fail due to volumes not cleaned up, now it passes.
No special testing for adding global - just visual code check.
