### PR TITLE
Support plugin server options --datastore, --log-level, misc fixes in volume KV

### DIFF
--- a/vmdkops-esxsrv/kvESX.py
+++ b/vmdkops-esxsrv/kvESX.py
@@ -59,25 +59,25 @@ def kvESXInit():
 
     # Define all of the functions we are interested in
     lib.DiskLib_OpenWithInfo.argtypes = [c_char_p, c_int32, POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32)]
-    lib.DiskLib_OpenWithInfo.restype = c_uint32
+    lib.DiskLib_OpenWithInfo.restype = int
 
     lib.DiskLib_Close.argtypes = [c_uint32]
-    lib.DiskLib_Close.restype = c_uint32
+    lib.DiskLib_Close.restype = int
 
     # Check if this library supports create API
     try: 
        lib.DiskLib_SidecarCreate.argtypes = [c_uint32, c_char_p, c_uint64, c_int32, POINTER(c_uint32)]
-       lib.DiskLib_SidecarCreate.restype = c_uint32
+       lib.DiskLib_SidecarCreate.restype = int
        useSideCarCreate = True
     except:
        # do nothing
        logging.debug ("ESX version doesn't support create API, using open instead.")
 
     lib.DiskLib_SidecarOpen.argtypes = [c_uint32, c_char_p, c_int32, POINTER(c_uint32)]
-    lib.DiskLib_SidecarOpen.restype = c_uint32
+    lib.DiskLib_SidecarOpen.restype = int
 
     lib.DiskLib_SidecarClose.argtypes = [c_uint32, c_char_p, POINTER(c_uint32)]
-    lib.DiskLib_SidecarClose.restype = c_uint32
+    lib.DiskLib_SidecarClose.restype = int
 
     lib.DiskLib_SidecarMakeFileName.argtypes = [c_char_p, c_char_p]
     lib.DiskLib_SidecarMakeFileName.restype = c_char_p
@@ -103,7 +103,6 @@ def volOpenPath(volpath):
    ihandle = c_uint32(0)
    key = c_uint32(0)
    objHandle = c_uint32(0)
-   res = c_uint32(0)
 
    res = lib.DiskLib_OpenWithInfo(volpath, vmdkOpenFlags, pointer(key), pointer(dhandle), pointer(ihandle))
 
@@ -116,7 +115,6 @@ def volOpenPath(volpath):
 def create(volpath, kvDict):
    disk = c_uint32(0)
    objHandle = c_uint32(0)
-   res = c_uint32(0)
 
    disk = volOpenPath(volpath)
 
@@ -141,7 +139,6 @@ def create(volpath, kvDict):
 # Delete the the side car for the given volume
 def delete(volpath):
    disk = c_uint32(0)
-   res = c_uint32(0)
 
    disk = volOpenPath(volpath)
 

--- a/vmdkops-esxsrv/volumeKVStore.py
+++ b/vmdkops-esxsrv/volumeKVStore.py
@@ -62,7 +62,8 @@ def getAll(volPath):
 def setAll(volPath, volMeta):
    if volMeta:
        return kvESX.save(volPath, volMeta)
-   return None
+   # No data to save .
+   return True
 
 # Set a string value for a given key(index)
 def set(volPath, key, val):


### PR DESCRIPTION
1. Support options for plugin server - --datastore (or -d) and --log-level. The default is None for the datastore and info for the log level.
   - if user doesn't provide a datastore then we use the same datastore as the requesting VM. Else the given datastore is used.
   - If given datastore doesn't exist or badly formed then volumes aren't created, as expected.
   - considering an option of exiting the server if the given datastore is invalid or missing. Added this then removed it, will add it up when handling any comments. Otherwise, the daemon will be returning errors at run time. May be better to report the error up front.
2. Misc. fixes in kvESX.py to use the data type (int) that python is returning from disklib calls.
3. Fixed setAll in volumeKVStore.py to return true if dict passed in is null, nothing to do so return True.
