### PR TITLE
Don't use metdata[u'volOpts'] if it's None

### DIFF
--- a/vmdkops-esxsrv/vmdkops_admin.py
+++ b/vmdkops-esxsrv/vmdkops_admin.py
@@ -358,7 +358,11 @@ def generate_ls_dash_l_rows():
            attached_to = metadata[u'attachedVMUuid']
        else:
            attached_to = 'detached'
-       capacity = metadata[u'volOpts'][u'size']
+       volOpts = metadata[u'volOpts']
+       if volOpts and u'size' in volOpts:
+           capacity = volOpts[u'size']
+       else:
+           capacity = vmdk_ops.DefaultDiskSize
        rows.append([name, v['datastore'], 'N/A', 'N/A', 'N/A', attached_to, 'N/A', capacity, 'N/A'])
    return rows
 


### PR DESCRIPTION
In admin script, don't look for the capacity in volOpts if it's None. Use the default instead.

This fixes the following error:

```
root@localhost:/usr/lib/vmware/vmdkops/bin] ./vmdkops_admin.py ls -l
Traceback (most recent call last):
    File "./vmdkops_admin.py", line 446, in <module>
      main()
    File "./vmdkops_admin.py", line 31, in main
      args.func(args)
    File "./vmdkops_admin.py", line 300, in ls
      (header, data) = ls_dash_l()
    File "./vmdkops_admin.py", line 319, in ls_dash_l
      rows = generate_ls_dash_l_rows()
    File "./vmdkops_admin.py", line 361, in generate_ls_dash_l_rows
      capacity = metadata[u'volOpts'][u'size']
TypeError: 'NoneType' object has no attribute '__getitem__'
```

Tested manually by creating a volume with and without -o size and listing them with `ls -l` from admin cli on esx.
