### PR TITLE
Add volume capacity and use to vmdkops_admin ls -l

### DIFF
--- a/doc/vmdkops-admin-cli-spec.md
+++ b/doc/vmdkops-admin-cli-spec.md
@@ -52,16 +52,6 @@ vmdkops-admin ls -f 'LastAttachedTime > 2016-03-11'
 vmdkops-admin ls -f 'AttachedTo = Test*'
 ```
 
-#### `df`
-List storage usage/availability for each datastore. Show the following attributes.
-
- * Datastore
- * Available Space (Capacity)
- * Allocated Space
- * Used Space
-
-Also list a summary including total space and volume count.
-
 ##### `policy`
 Create, configure and show the storage policy names and their corresponding vsan policies. Also show which datastores they
 apply to.

--- a/vmdkops-esxsrv/vmdkops_admin_tests.py
+++ b/vmdkops-esxsrv/vmdkops_admin_tests.py
@@ -50,13 +50,6 @@ class TestParsing(unittest.TestCase):
     def test_parse_ls_dash_c_invalid_argument(self):
         self.assert_parse_error('ls -c personality')
 
-    def test_df(self):
-        args = self.parser.parse_args('df'.split())
-        self.assertEqual(args.func, vmdkops_admin.df)
-
-    def test_df_badargs(self):
-        self.assert_parse_error('df -l')
-
     def test_policy_no_args_fails(self):
         self.assert_parse_error('policy')
 


### PR DESCRIPTION
Properly report volume capacity and used space in vmdkops_admin.py ls -l via a call to vmdkfstools.
Note that in the future this will be changed to rely on disklib directly.

Remove support for the `df` command and any reference to it in the documentation. Users can use the
ESX installed df command instead.

Testing was done manually.

Sample output:

```
[root@localhost:/usr/lib/vmware/vmdkops/bin] ./vmdkops_admin.py ls -l
Volume     Datastore  Created..  Created  Last At..  Attache..  Policy  Capacity   Used
---------  ---------  ---------  -------  ---------  ---------  ------  ---------  --------
9421467..  datasto..  N/A        N/A      N/A        detached   N/A     104857600  14680064
d81815b..  datasto..  N/A        N/A      N/A        detached   N/A     209715200  27262976
```
