### PR TITLE
Fix Description and move to hub fpm image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ DOCKER = $(DEBUG) docker
 .PHONY: fpm-docker
 fpm-docker:
 	@echo "Building FPM container. It could take a while, please stand by..."
-	$(DOCKER) build -t vmware/fpm -f dockerfiles/Dockerfile.fpm . > /dev/null
+	$(DOCKER) build -t kerneltime/fpm -f dockerfiles/Dockerfile.fpm . > /dev/null
 
 .PHONY: pkg
 pkg: dockerdeb dockerrpm
@@ -161,14 +161,14 @@ pkg: dockerdeb dockerrpm
 package: pkg
 
 .PHONY: dockerdeb
-dockerdeb: fpm-docker pkg-post
+dockerdeb: pkg-post
 	$(BUILD) deb
 
 .PHONY: dockerrpm pkg-post
-dockerrpm: fpm-docker
+dockerrpm:
 	$(BUILD) rpm
 
-DESCRIPTION := "VMDK Volume Plugin for Docker"
+DESCRIPTION := "Docker Volume Driver for vSphere"
 FPM_COMMON := -p $(BIN) \
 	-C $(PACKAGE) \
 	-s dir \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -71,7 +71,8 @@ fi
 plugin=docker-volume-vsphere
 plugin_container_version=0.5
 plug_container=kerneltime/vibauthor-and-go:$plugin_container_version
-plug_pkg_container=vmware/fpm
+plug_pkg_container_version=latest
+plug_pkg_container=kerneltime/fpm:$plug_pkg_container_version
 dockerfile=Dockerfile.vibauthor-and-go
 DOCKER="$DEBUG docker"
 


### PR DESCRIPTION
To keep dev experience smooth, use the fpm image from the docker hub.
Fix the Descrition for rpm and deb to match the one used for rename.

Testing: Build works fine my dev box. Changes are build related.
