### PR TITLE
Fix for Dockerfile.vmdk-plugin* to use new locations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Copy-paste relevant snippets from log file, code. Use github markdown language f
 Use `make` or `make dockerbuild` to build.
 
 Build environment is described in README.md. The result of the build is a set
-of binaries in ./bin directory.
+of binaries in ./build directory.
 
 In order to test locally, you'd need a test setup. Local test setup automation is planned but but not done yet, so currently the environment has to be set up manually.
 

--- a/dockerfiles/Dockerfile.vmdk-plugin
+++ b/dockerfiles/Dockerfile.vmdk-plugin
@@ -2,6 +2,6 @@ FROM alpine
 
 MAINTAINER cna-storage@vmware.com
 
-ADD ./bin/docker-volume-vsphere /usr/local/bin/docker-volume-vsphere
+ADD ./build/docker-volume-vsphere /usr/local/bin/docker-volume-vsphere
 
 ENTRYPOINT ["/usr/local/bin/docker-volume-vsphere"]

--- a/dockerfiles/Dockerfile.vmdk-plugin.debug
+++ b/dockerfiles/Dockerfile.vmdk-plugin.debug
@@ -2,7 +2,7 @@ FROM alpine
 
 MAINTAINER cna-storage@vmware.com
 
-RUN mkdir -p /build-output/bin /build-output/logs
+RUN mkdir -p /build-output/build /build-output/logs
 
-COPY ./bin /build-output/bin
+COPY ./build /build-output/build
 COPY ./run.log /build-output/logs


### PR DESCRIPTION
It turns out there is an additional `docker build` step which we run for merges to master, and it is NOT tested by CI run in Pull Request. So this step was failing because the related Dockerfiles were not patched in "reorg GO files" commit.

This change corrects this.

tested by manually running  `docker build --pull=true --rm=true -f dockerfiles/Dockerfile.vmdk-plugin -t test:latest .` on my dev machine. .

/CC @kerneltime 
