### PR TITLE
Only use VSAN policies on VSAN datastores

### DIFF
--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -19,11 +19,16 @@ import argparse
 import os
 import subprocess
 import sys
+
+import vmdk_ops
+# vmdkops python utils are in PY_LOC, so add to path.
+sys.path.insert(0, vmdk_ops.PY_LOC)
+
 import volume_kv as kv
 import cli_table
 import vsan_policy
 import vmdk_utils
-import vmdk_ops
+import vsan_info
 
 
 def main():
@@ -383,7 +388,10 @@ def generate_ls_dash_l_rows():
         if volOpts and 'vsan-policy-name' in volOpts:
             policy = volOpts['vsan-policy-name']
         else:
-            policy = '[VSAN default]'
+            if vsan_info.is_on_vsan(path):
+                policy = '[VSAN default]'
+            else:
+                policy = 'N/A'
         size_info = get_vmdk_size_info(path)
         rows.append([name, v['datastore'], 'N/A', 'N/A', 'N/A', attached_to,
                      policy, size_info['capacity'], size_info['used']])

--- a/esx_service/cli/vmdkops_admin_sanity_test.py
+++ b/esx_service/cli/vmdkops_admin_sanity_test.py
@@ -1,0 +1,61 @@
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Ensure that actually running /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py
+
+import subprocess
+import unittest
+import os
+
+admin_cli = '/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py'
+
+class TestVmdkopsAdminSanity(unittest.TestCase):
+    """ Test output from running vmdkops_admin.py """
+
+    def setUp(self):
+        os.chdir('/')
+        self.devnull = open('/dev/null', 'w')
+
+    def tearDown(self):
+        self.devnull.close()
+
+    def test_ls(self):
+        cmd = '{0} ls'.format(admin_cli)
+        # Don't print errors about stty using a bad ioctl (we aren't attached to
+        # a tty here)
+        output = subprocess.check_output(cmd, shell=True, stderr=self.devnull)
+        lines = output.split('\n')
+        header1, header2 = lines[0].split()
+        self.assertEqual(header1, 'Volume')
+        self.assertEqual(header2, 'Datastore')
+        for string in lines[1].split():
+            self.assertTrue(all_dashes(string))
+
+    def test_policy_ls(self):
+        cmd = '{0} policy ls'.format(admin_cli)
+        # Don't print errors about stty using a bad ioctl (we aren't attached to
+        # a tty here)
+        output = subprocess.check_output(cmd, shell=True, stderr=self.devnull)
+        lines = output.split('\n')
+        headers = lines[0].split()
+        self.assertEqual(['Policy', 'Name', 'Policy', 'Content', 'Active'],
+                         headers)
+        for string in lines[1].split():
+            self.assertTrue(all_dashes(string))
+
+def all_dashes(string):
+    return all(map(lambda char: char == '-', string))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/esx_service/utils/vmdk_utils.py
+++ b/esx_service/utils/vmdk_utils.py
@@ -18,6 +18,7 @@
 import os
 import logging
 import pyVim.connect
+import vsan_info
 
 # datastores should not change during 'vmdkops_admin' run,
 # so using global to avoid multiple scans of /vmfs/volumes
@@ -48,12 +49,16 @@ def get_datastores():
     return datastores
 
 
-def get_vsan_datastore():
+def get_vsan_dockvols_path():
     """
     Return the VSAN datastore dockvols path for a given cluster. Default to the
     first datastore for now, so we can test without VSAN.
     """
-    return get_datastores()[0][1]
+    datastore = vsan_info.get_vsan_datastore()
+    if datastore:
+        return os.path.join(datastore.info.url, 'dockvols')
+    else:
+        return None
 
 
 def get_volumes():

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -25,8 +25,9 @@ import os, os.path
 
 import vmdk_ops
 import log_config
-import volume_kv as kv
+import volume_kv
 import vsan_policy
+import vsan_info
 
 # will do creation/deletion in this folder:
 global path
@@ -75,6 +76,8 @@ class VmdkCreateRemoveTestCase(unittest.TestCase):
         logging.info(err)
         self.assertNotEqual(err, None, err)
 
+    @unittest.skipIf(not vsan_info.get_vsan_datastore(),
+                    "VSAN is not found - skipping vsan_info tests")
     def testPolicy(self):
         # info for testPolicy
         testInfo = [
@@ -100,6 +103,9 @@ class VmdkCreateRemoveTestCase(unittest.TestCase):
 
 class ValidationTestCase(unittest.TestCase):
     """ Test validation of -o options on create """
+
+    @unittest.skipIf(not vsan_info.get_vsan_datastore(),
+                     "VSAN is not found - skipping vsan_info tests")
 
     def setUp(self):
         """ Create a bunch of policies """
@@ -139,7 +145,7 @@ class ValidationTestCase(unittest.TestCase):
 
 if __name__ == '__main__':
     log_config.configure()
-    kv.init()
+    volume_kv.init()
 
     # Calculate the path
     paths = glob.glob("/vmfs/volumes/[a-z]*/dockvols")

--- a/esx_service/vsan_policy_test.py
+++ b/esx_service/vsan_policy_test.py
@@ -16,14 +16,18 @@ import unittest
 import os, os.path
 import vsan_policy
 import vmdk_utils
-import volume_kv as kv
+import volume_kv
+import vsan_info
 
 
 class TestVsanPolicy(unittest.TestCase):
     """ Test VSAN Policy code """
 
+    @unittest.skipIf(not vsan_info.get_vsan_datastore(),
+                     "VSAN is not found - skipping vsan_info tests")
+
     def setUp(self):
-        self.policy_path = os.path.join(vmdk_utils.get_vsan_datastore(),
+        self.policy_path = os.path.join(vmdk_utils.get_vsan_dockvols_path(),
                                         'policies/test_policy')
         self.name = 'test_policy'
         self.content = ('(("proportionalCapacity" i50) '
@@ -66,5 +70,5 @@ class TestVsanPolicy(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    kv.init()
+    volume_kv.init()
     unittest.main()


### PR DESCRIPTION
 Fixes #334, #335

 Addresses various comments from PR #331
- Rename vmdk_utils.get_vsan_datastore() to vmdk_utils.get_vsan_dockvols_path()
  and return the real VSAN path using vsan_info.get_vsan_datastore()
- Only allow using -o vsan-policy-name when creating volumes on VSAN datastore
- Return early from vsan_policy functions if VSAN datastore doesn't exist
- Only run policy tests if a VSAN datastore is available
- On vmdkops_admin.py ls -l show `N/A` for policy if not on VSAN datastore and
  `VSAN default` if on a VSAN datastore
- Fix keyword names in tests to use underscore_names
- Set path in vmdkops_admin.py so it works again
