### PR TITLE
Rename vmware-esx-vmdkops-service to esx-vmdkops-service

### DIFF
--- a/esx_service/descriptor.xml
+++ b/esx_service/descriptor.xml
@@ -20,7 +20,7 @@
 
 <vib version="6.0">
 
-   <name>vmware-esx-vmdkops-service</name>
+   <name>esx-vmdkops-service</name>
    <version>1.0.0-0.0.1</version>
    <vendor>VMWare</vendor>
    <summary>ESX-side daemon supporting basic VMDK operations requested by a guest</summary>

--- a/misc/scripts/deploy-tools.sh
+++ b/misc/scripts/deploy-tools.sh
@@ -45,7 +45,7 @@ SSH="$DEBUG ssh -o StrictHostKeyChecking=no"
 # consts
 
 # We remove VIB by internal name, not file name. See description.xml in VIB
-internal_vib_name=vmware-esx-vmdkops-service
+internal_vib_name=esx-vmdkops-service
 
 script_loc=../misc/scripts
 tmp_loc=/tmp/docker-volume-vsphere

--- a/vmdk_plugin/Makefile
+++ b/vmdk_plugin/Makefile
@@ -302,7 +302,7 @@ clean-vm:
 	$(CLEANVM_SH) "$(VMS)" "$(VM_BINS)" "$(GLOC)"  "$(TEST_VOL_NAME)"
 
 clean-esx:
-	$(CLEANESX_SH) "$(ESX)" vmware-esx-vmdkops-service
+	$(CLEANESX_SH) "$(ESX)" esx-vmdkops-service
 
 # rm ALL containers and volumes. Useful for post-failure force cleanup
 clean-docker:


### PR DESCRIPTION
Fixes #327 
tested: `make all` and CI. 
Also manually validated on ESX: 

```
[root@localhost:~] esxcli software vib list | grep vmdk
esx-vmdkops-service            1.0.0-0.0.1                           VMWare  PartnerSupported  2016-05-03  
```

**NOTE** since it changes the name of VIB package, the old one has to be uninstalled FIRST.
So before `git pull`, we should not forget to `make clean-esx`
