### PR TITLE
Admin CLI and test bugfixes

### DIFF
--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -412,9 +412,10 @@ def get_attached_to(metadata):
 
 def get_policy(metadata, path):
     """ Return the policy for a volume given its volume options """
-    vol_opts = metadata[u'volOpts']
-    if vol_opts and 'vsan-policy-name' in vol_opts:
-        return vol_opts['vsan-policy-name']
+    try:
+        return metadata[u'volOpts']['vsan-policy-name']
+    except:
+        pass
 
     if vsan_info.is_on_vsan(path):
         return '[VSAN default]'

--- a/esx_service/utils/vsan_info_test.py
+++ b/esx_service/utils/vsan_info_test.py
@@ -31,6 +31,7 @@ import vsan_info
 class TestVsanInfo(unittest.TestCase):
     """ Test VSAN Info API """
 
+    VM_NAME = "test-vm"
     VSAN_DS = "/vmfs/volumes/vsanDatastore"
     TEST_DIR = os.path.join(VSAN_DS, "vsan_info_test")
     TEST_VOL = "test_policy_vol"
@@ -48,7 +49,7 @@ class TestVsanInfo(unittest.TestCase):
         """create a vmdk before each test (method) in this class"""
         self.si = vmdk_ops.connectLocal()
         # create VMDK
-        err = vmdk_ops.createVMDK(self.VMDK_PATH, "test_policy_vol")
+        err = vmdk_ops.createVMDK(self.VM_NAME, self.VMDK_PATH, "test_policy_vol")
         self.assertEqual(err, None, err)
 
     def tearDown(self):

--- a/esx_service/vsan_policy.py
+++ b/esx_service/vsan_policy.py
@@ -99,7 +99,7 @@ def get_policies():
     if not path:
         return {}
 
-    path = os.path.join(path, 'policies')
+    path = make_policies_dir(path)
     for name in os.listdir(path):
         with open(os.path.join(path, name)) as f:
             content = f.read()


### PR DESCRIPTION
Fix improper params in createVMDK in tests using VSAN

Create policies dir in admin cli when it doesn't exist

Ensure vmdk_ops.validate takes 2 params

Ensure createVmdk works on vsan in test_policy.

Ensure vmdkops_admin.py:get_policy() succeeds when volOpts does not exist

Fixes #384 

Tested with make all against Mark's box containing VSAN
Also tested CLI on Mark's box. ls, ls -l and policy ls all succeed.
I was unable to test creating a volume with a real policy since I couldn't figure out how to make remote docker work with Mark's box.
