### PR TITLE
Use VM Name instead of UUID in admin cli ls -l

### DIFF
--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -404,8 +404,10 @@ def get_creation_info(metadata):
 
 def get_attached_to(metadata):
     """ Return which VM a volume is attached to based on its metadata """
-    if metadata[u'status'] == u'attached':
-        return metadata[u'attachedVMUuid']
+    try:
+        return metadata['attachedVMName']
+    except:
+        return NOT_AVAILABLE
 
     return 'detached'
 


### PR DESCRIPTION
In the Attached To column show the name of the VM attached instead of its UUID.

Sample output:

```
[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py ls -l
Volume     Datastore   Created By    Created                   Attached To   Policy  Capacity  Used
---------  ----------  ------------  ------------------------  ------------  ------  --------  ------
large-vol  datastore1  Ubuntu_15.10  Sat Apr 16 13:34:12 2016  detached      N/A     1.00GB    25.00MB
vol        datastore1  Ubuntu_15.10  Sat Apr 16 20:13:18 2016  Ubuntu_15.10  N/A     100.00MB  14.00MB

```

Tested with `make all` and CI
