### PR TITLE
Change the lock to ESX in preparation for adding vSAN VMs

### DIFF
--- a/misc/drone-scripts/cleanup.sh
+++ b/misc/drone-scripts/cleanup.sh
@@ -16,5 +16,5 @@
 
 stop_build() {
   make clean-vm clean-esx TEST_VOL_NAME=vol-build$BUILD_NUMBER
-  $SSH $VM1 /tmp/lock.sh unlock $BUILD_NUMBER
+  $SSH $ESX "sh /tmp/lock.sh unlock $BUILD_NUMBER"
 }

--- a/misc/drone-scripts/deploy-and-test-wrapper.sh
+++ b/misc/drone-scripts/deploy-and-test-wrapper.sh
@@ -39,10 +39,11 @@ USER=root
 . ./misc/drone-scripts/cleanup.sh
 . ./misc/scripts/commands.sh
 
-$SCP ./misc/drone-scripts/lock.sh $VM1:/tmp/
+echo "Setting up lock on $ESX"
+$SCP ./misc/drone-scripts/lock.sh $ESX:/tmp/
 
 # Unlock performed in stop_build in cleanup.sh
-until $SSH $USER@$VM1 /tmp/lock.sh lock $BUILD_NUMBER
+until $SSH $USER@$ESX "sh /tmp/lock.sh lock $BUILD_NUMBER"
  do
   sleep 30
   log "Retrying acquire lock"


### PR DESCRIPTION
Commented out the refcount test. 
Filed https://github.com/vmware/docker-volume-vsphere/issues/411 to track this.
Testing: 
- CI is the main customer for this. Ran 2 builds one blocked on the lock behind the other.
