### PR TITLE
Don't crash admin cli on ls -l if metadata isn't available

### DIFF
--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -394,12 +394,10 @@ def get_creation_info(metadata):
     """
     Return the creation time and creation vm for a volume given its metadata
     """
-    # If created exists, then so does created-by
-    if kv.CREATED in metadata:
+    try:
         return (metadata[kv.CREATED], metadata[kv.CREATED_BY])
-
-    # For backwards compatibility
-    return (NOT_AVAILABLE, NOT_AVAILABLE)
+    except:
+        return (NOT_AVAILABLE, NOT_AVAILABLE)
 
 
 def get_attached_to(metadata):


### PR DESCRIPTION
Fixes #412

Tested via removing the sidecar file for a volume and running `ls -l` on esx

```
[root@localhost:/vmfs/volumes/5707ef9a-d9ce2869-9313-000c29e1b7a2/dockvols] ls
ayo-84b25ea7eb0f1fbf.vmfd        ayo.vmdk                         large-vol-flat.vmdk              policies                         vol-flat.vmdk
ayo-flat.vmdk                    large-vol-4aea49a74bbb032b.vmfd  large-vol.vmdk                   vol-6d812701b9f8e2bf.vmfd        vol.vmdk
[root@localhost:/vmfs/volumes/5707ef9a-d9ce2869-9313-000c29e1b7a2/dockvols] rm ayo-
ayo-84b25ea7eb0f1fbf.vmfd  ayo-flat.vmdk
[root@localhost:/vmfs/volumes/5707ef9a-d9ce2869-9313-000c29e1b7a2/dockvols] rm ayo-84b25ea7eb0f1fbf.vmfd
[root@localhost:/vmfs/volumes/5707ef9a-d9ce2869-9313-000c29e1b7a2/dockvols] /usr/
bin/      lib/      lib64/    libexec/  sbin/     share/
[root@localhost:/vmfs/volumes/5707ef9a-d9ce2869-9313-000c29e1b7a2/dockvols] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py ls -l
Volume     Datastore   Created By    Created                   Attached To  Policy  Capacity  ggUsed
---------  ----------  ------------  ------------------------  -----------  ------  --------  -------
large-vol  datastore1  Ubuntu_15.10  Sat Apr 16 13:34:12 2016  detached     N/A     1.00GB    25.00MB
vol        datastore1  Ubuntu_15.10  Sat Apr 16 20:13:18 2016  detached     N/A     100.00MB  14.00MB
ayo        datastore1  N/A           N/A                       detached     N/A     4.00MB    2.00MB
```

Mounting the file recreates the sidecar and makes it 'attached', but obviously doesn't fix the lost attributes

```
ajs@ajs-virtual-machine:~/go/src/github.com/vmware/docker-volume-vsphere$ docker run -it -v ayo:/mnt/vol busybox sh
```

```
[root@localhost:/vmfs/volumes/5707ef9a-d9ce2869-9313-000c29e1b7a2/dockvols] ls
ayo-84b25ea7eb0f1fbf.vmfd        ayo.vmdk                         large-vol-flat.vmdk              policies                         vol-flat.vmdk
ayo-flat.vmdk                    large-vol-4aea49a74bbb032b.vmfd  large-vol.vmdk                   vol-6d812701b9f8e2bf.vmfd        vol.vmdk
[root@localhost:/vmfs/volumes/5707ef9a-d9ce2869-9313-000c29e1b7a2/dockvols] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py ls -l
Volume     Datastore   Created By    Created                   Attached To   Policy  Capacity  Used
---------  ----------  ------------  ------------------------  ------------  ------  --------  -------
large-vol  datastore1  Ubuntu_15.10  Sat Apr 16 13:34:12 2016  detached      N/A     1.00GB    25.00MB
vol        datastore1  Ubuntu_15.10  Sat Apr 16 20:13:18 2016  detached      N/A     100.00MB  14.00MB
ayo        datastore1  N/A           N/A                       Ubuntu_15.10  N/A     4.00MB    2.00MB
```
