### PR TITLE
Show all columns in vmdkops_admin.py ls (remove -l)

### DIFF
--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -113,15 +113,10 @@ def commands():
             'func': ls,
             'help': 'List volumes',
             'args': {
-                '-l': {
-                    'help': 'List detailed information about volumes',
-                    'action': 'store_true'
-                },
                 '-c': {
                     'help': 'Display selected columns',
                     'choices': ['volume', 'datastore', 'created-by', 'created',
-                                'last-attached', 'attached-to', 'policy',
-                                'capacity', 'used'],
+                                'attached-to', 'policy', 'capacity', 'used'],
                     'metavar': 'Col1,Col2,...'
                 }
             }
@@ -315,38 +310,18 @@ def ls(args):
     If args.c is not empty only display columns given in args.c (implies -l).
     """
     if args.c:
-        (header, data) = ls_dash_c(args.c)
-    elif args.l:
-        (header, data) = ls_dash_l()
+        (header, rows) = ls_dash_c(args.c)
     else:
-        (header, data) = ls_no_args()
-    print cli_table.create(header, data)
+        header = all_ls_headers()
+        rows = generate_ls_rows()
 
-
-def ls_no_args():
-    """
-    Collect all volume names and their datastores as lists,
-    stripping the '.vmdk' from the volume name
-    """
-    header = ['Volume', 'Datastore']
-    data = [[vmdk_utils.strip_vmdk_extension(v['filename']), v['datastore']]
-            for v in vmdk_utils.get_volumes()]
-    return (header, data)
-
-
-def ls_dash_l():
-    """
-    List all volumes and relevant metadata
-    """
-    header = all_ls_headers()
-    rows = generate_ls_dash_l_rows()
-    return (header, rows)
+    print cli_table.create(header, rows)
 
 
 def ls_dash_c(columns):
     """ Return only the columns requested in the format required for table construction """
     all_headers = all_ls_headers()
-    all_rows = generate_ls_dash_l_rows()
+    all_rows = generate_ls_rows()
     indexes = []
     headers = []
     for i in range(len(all_headers)):
@@ -374,7 +349,7 @@ def all_ls_headers():
             'Attached To', 'Policy', 'Capacity', 'Used']
 
 
-def generate_ls_dash_l_rows():
+def generate_ls_rows():
     """ Gather all volume metadata into rows that can be used to format a table """
     rows = []
     for v in vmdk_utils.get_volumes():

--- a/esx_service/cli/vmdkops_admin_sanity_test.py
+++ b/esx_service/cli/vmdkops_admin_sanity_test.py
@@ -36,10 +36,9 @@ class TestVmdkopsAdminSanity(unittest.TestCase):
         # a tty here)
         output = subprocess.check_output(cmd, shell=True, stderr=self.devnull)
         lines = output.split('\n')
-        header1, header2 = lines[0].split()
-        self.assertEqual(header1, 'Volume')
-        self.assertEqual(header2, 'Datastore')
-        for string in lines[1].split():
+        divider_columns = lines[1].split()
+        self.assertEqual(8, len(divider_columns))
+        for string in divider_columns:
             self.assertTrue(all_dashes(string))
 
     def test_policy_ls(self):

--- a/esx_service/cli/vmdkops_admin_test.py
+++ b/esx_service/cli/vmdkops_admin_test.py
@@ -33,21 +33,13 @@ class TestParsing(unittest.TestCase):
     def test_parse_ls_no_options(self):
         args = self.parser.parse_args(['ls'])
         self.assertEqual(args.func, vmdkops_admin.ls)
-        self.assertEqual(args.l, False)
-        self.assertEqual(args.c, None)
-
-    def test_parse_ls_dash_l(self):
-        args = self.parser.parse_args('ls -l'.split())
-        self.assertEqual(args.func, vmdkops_admin.ls)
-        self.assertEqual(args.l, True)
         self.assertEqual(args.c, None)
 
     def test_parse_ls_dash_c(self):
         args = self.parser.parse_args(
-            'ls -c created-by,created,last-attached'.split())
+            'ls -c created-by,created'.split())
         self.assertEqual(args.func, vmdkops_admin.ls)
-        self.assertEqual(args.l, False)
-        self.assertEqual(args.c, ['created-by', 'created', 'last-attached'])
+        self.assertEqual(args.c, ['created-by', 'created'])
 
     def test_parse_ls_dash_c_invalid_argument(self):
         self.assert_parse_error('ls -c personality')
@@ -196,11 +188,12 @@ class TestLs(unittest.TestCase):
 
     def test_ls_no_args(self):
         volumes = vmdk_utils.get_volumes()
-        (header, data) = vmdkops_admin.ls_no_args()
-        self.assertEqual(2, len(header))
-        self.assertEqual(len(volumes), len(data))
+        header = vmdkops_admin.all_ls_headers()
+        rows = vmdkops_admin.generate_ls_rows()
+        self.assertEqual(8, len(header))
+        self.assertEqual(len(volumes), len(rows))
         for i in range(len(volumes)):
-            self.assertEqual(volumes[i]['filename'], data[i][0] + '.vmdk')
+            self.assertEqual(volumes[i]['filename'], rows[i][0] + '.vmdk')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Columns shown with ls -l are now the default and the -l option has been removed.
Fixed tests to reflect this and also removed the unused 'last-attached' choice
from the ls -c options.

Tested with make all and CI as well as manually via CLI on ESX.

Fixes #417

```
[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py ls
Volume     Datastore   Created By    Created                   Attached To  Policy  Capacity  Used
---------  ----------  ------------  ------------------------  -----------  ------  --------  -------
large-vol  datastore1  Ubuntu_15.10  Sat Apr 16 13:34:12 2016  detached     N/A     1.00GB    25.00MB
vol        datastore1  Ubuntu_15.10  Sat Apr 16 20:13:18 2016  detached     N/A     100.00MB  14.00MB
ayo        datastore1  N/A           N/A                       detached     N/A     4.00MB    2.00MB
```
