### PR TITLE
Make the vsocket port configurable.

### DIFF
--- a/esx_service/vmci/vmci_server.c
+++ b/esx_service/vmci/vmci_server.c
@@ -38,7 +38,7 @@
 // Returns vSocket to listen on, or -1.
 // errno indicates the reason for a failure, if any.
 int
-vmci_init(void)
+vmci_init(unsigned int port)
 {
    struct sockaddr_vm addr;
    socklen_t addrLen;
@@ -70,7 +70,7 @@ vmci_init(void)
    memset(&addr, 0, sizeof addr);
    addr.svm_family = af;
    addr.svm_cid = VMADDR_CID_ANY;
-   addr.svm_port = 15000;
+   addr.svm_port = port;
    ret = bind(socket_fd, (const struct sockaddr *) &addr, sizeof addr);
    if (ret == -1) {
       saved_errno = errno;

--- a/esx_service/vmdk-opsd
+++ b/esx_service/vmdk-opsd
@@ -18,8 +18,6 @@ OPSD_GROUP_NAME="vmdkops"
 OPSD_GROUP="$OPSD_GROUP_PATH/$OPSD_GROUP_NAME"
 OPSD_SCHED_PARAM="++memreliable,group=$OPSD_GROUP"
 
-# Pass these params to service.
-OPSD_PARAMS="--log-level=info"
 
 LOCAL_CLI_SCHED="localcli --plugin-dir=/usr/lib/vmware/esxcli/int sched group"
 
@@ -29,6 +27,14 @@ MAX_RETRY=10
 MAX_QUICK_FAILURES=5
 SIGTERM=15
 SIGKILL=9
+
+# Config
+VMDK_OPSD_PORT=1019 # Override using CONFIG_FILE
+
+# Create the following file if defaults need to be overridden
+# Example:
+# export VMDK_OPSD_PORT=1020
+CONFIG_FILE=/etc/vmware/vmdkops/service_config.sh
 
 # The numbers below are to setup the framework for
 # resource limits but not setting them up. -1 is unlimited
@@ -47,6 +53,12 @@ getpid() {
 }
 
 start() {
+   if [ -f $CONFIG_FILE ]
+   then
+      echo "Loading $CONFIG_FILE"
+      . $CONFIG_FILE
+   fi
+
    local PID=$(getpid)
    if [ -n "${PID}" ]; then
       echo "Failed to start. $OPSD_TAG already running."
@@ -64,6 +76,9 @@ start() {
       fi
    fi
 
+
+   # Pass these params to service.
+   OPSD_PARAMS="-p $VMDK_OPSD_PORT"
 
    ${LOCAL_CLI_SCHED} setmemconfig -g ${OPSD_GROUP} --min=${MINMEM} --max=${MAXMEM} --minlimit=${MINLIMIT} -u mb
    ${LOCAL_CLI_SCHED} setcpuconfig -g ${OPSD_GROUP} --min=${MINCPU} --max=${MAXCPU} -u pct
@@ -111,13 +126,13 @@ stop() {
          check_running_status
          exit 4
       fi
-   fi 
+   fi
 
    check_running_status
    if [ $? -eq 0 ]; then
       echo "Failed to stop $OPSD_TAG"
       exit 5
-   fi 
+   fi
    return 0
 }
 

--- a/misc/scripts/install/docker-volume-vsphere.conf
+++ b/misc/scripts/install/docker-volume-vsphere.conf
@@ -7,4 +7,4 @@ respawn
 
 kill timeout 20
 
-exec /usr/local/bin/$UPSTART_JOB
+exec /usr/local/bin/$UPSTART_JOB -port 1019

--- a/misc/scripts/install/docker-volume-vsphere.service
+++ b/misc/scripts/install/docker-volume-vsphere.service
@@ -4,7 +4,7 @@ Before=docker.service
 Requires=docker.service
 
 [Service]
-ExecStart=/usr/local/bin/docker-volume-vsphere
+ExecStart=/usr/local/bin/docker-volume-vsphere -port 1019
 Restart=always
 
 [Install]

--- a/vmdk_plugin/main.go
+++ b/vmdk_plugin/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/go-plugins-helpers/volume"
 	"github.com/natefinch/lumberjack"
 	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/config"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/vmdkops"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -90,17 +91,19 @@ func logInit(logLevel *string, logFile *string, configFile *string) bool {
 // Parses flags, inits mount refcounters and finally services Docker requests
 func main() {
 	// connect to this socket
-	port := flag.Int("port", 15000, "Default port for vmci")
+	port := flag.Int("port", 1019, "Default port for vmci")
 	useMockEsx := flag.Bool("mock_esx", false, "Mock the ESX server")
 	logLevel := flag.String("log_level", "debug", "Logging Level")
 	configFile := flag.String("config", config.DefaultConfigPath, "Configuration file path")
 	flag.Parse()
 
+	vmdkops.EsxPort = *port
+
 	logInit(logLevel, nil, configFile)
 
 	log.WithFields(log.Fields{
 		"version":   version,
-		"port":      *port,
+		"port":      vmdkops.EsxPort,
 		"mock_esx":  *useMockEsx,
 		"log_level": *logLevel,
 		"config":    *configFile,

--- a/vmdk_plugin/vmdkops/esx_vmdkcmd.go
+++ b/vmdk_plugin/vmdkops/esx_vmdkcmd.go
@@ -38,7 +38,6 @@ import "C"
 type EsxVmdkCmd struct{}
 
 const (
-	vmciEsxPort     int    = 15000 // port we are connecting on
 	commBackendName string = "vsocket"
 )
 
@@ -57,6 +56,8 @@ type VolumeInfo struct {
 type vmciError struct {
 	Error string `json:",omitempty"`
 }
+
+var EsxPort int
 
 // Run command Guest VM requests on ESX via vmdkops_serv.py listening on vSocket
 // *
@@ -83,7 +84,7 @@ func (vmdkCmd EsxVmdkCmd) Run(cmd string, name string, opts map[string]string) (
 	defer C.free(unsafe.Pointer(ans))
 
 	// connect, send command, get reply, disconnect - all in one shot
-	_, err = C.Vmci_GetReply(C.int(vmciEsxPort), cmdS, beS, ans)
+	_, err = C.Vmci_GetReply(C.int(EsxPort), cmdS, beS, ans)
 
 	if err != nil {
 		var errno syscall.Errno


### PR DESCRIPTION
The port is passed in as a command line param.
VM: Customer can use standard techniques for systemd and upstart to
change the startup scripts for port.
ESX: Since the init scripts are readonly, an optional file is read
which exports the port number override.

Testing: Running basic commands on dev box using the new port.
CI will use new ports as well.