### PR TITLE
Log exceptions in ESX service

### DIFF
--- a/esx_service/utils/kvESX.py
+++ b/esx_service/utils/kvESX.py
@@ -173,6 +173,7 @@ def load(volpath):
     try:
         fh = open(metaFile, "r+")
     except IOError:
+        logging.exception("Failed to open %s", metaFile);
         return None
 
     kvDict = json.load(fh)
@@ -189,6 +190,7 @@ def save(volpath, kvDict):
     try:
         fh = open(metaFile, "w+")
     except IOError:
+        logging.exception("Failed to open %s", metaFile);
         return False
 
     json.dump(kvDict, fh)

--- a/esx_service/utils/vmdk_utils.py
+++ b/esx_service/utils/vmdk_utils.py
@@ -94,7 +94,7 @@ def vmdk_is_a_descriptor(filepath):
                 line = f.readline()
                 return line.startswith('# Disk DescriptorFile')
         except:
-            logging.warning("Failed to open %s for descriptor check", filepath)
+            logging.exception("Failed to open %s for descriptor check", filepath)
 
     return False
 

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -309,6 +309,7 @@ def find_child(vm_name):
     try:
         vm = FindChild(GetVmFolder(), vm_name)
     except Exception as e:
+        logging.exception("Failed to find vm: %s", vm_name) 
         vm = None
     return vm, e
 

--- a/esx_service/vsan_policy.py
+++ b/esx_service/vsan_policy.py
@@ -16,6 +16,7 @@
 # Module for VSAN storage policy creation and configuration
 
 import os
+import logging
 import vmdk_utils
 import volume_kv as kv
 
@@ -67,6 +68,7 @@ def create_policy_file(filename, content):
             f.write(content)
             f.write('\n')
     except:
+        logging.exception("Failed to open %s for writing", filename)
         return 'Error: Failed to open {0} for writing'.format(filename)
 
     return None
@@ -87,6 +89,7 @@ def delete(name):
     try:
         os.remove(policy_path(name))
     except:
+        logging.exception("Failed to remove %s policy file", name)
         return 'Error: {0} does not exist'.format(name)
 
     return None

--- a/vmdk_plugin/vmdkops/esx_vmdkcmd.go
+++ b/vmdk_plugin/vmdkops/esx_vmdkcmd.go
@@ -57,6 +57,7 @@ type vmciError struct {
 	Error string `json:",omitempty"`
 }
 
+// EsxPort used to connect to ESX, passed in as command line param
 var EsxPort int
 
 // Run command Guest VM requests on ESX via vmdkops_serv.py listening on vSocket


### PR DESCRIPTION
Log exceptions to make debugging easier. 

**Testing Done:**
Manually verified exceptions in log file for e.g.
- Before
```
[WARNING] Failed to open /vmfs/volumes/4bad174b-b67f5cfc-2fc6-0026b966a303/dockvols/myvol1.vmdk for descriptor check
```
- After
```
[ERROR  ] Failed to open /vmfs/volumes/4bad174b-b67f5cfc-2fc6-0026b966a303/dockvols/myvol1.vmdk for descriptor check
Traceback (most recent call last):
  File "/usr/lib/vmware/vmdkops/Python/vmdk_utils.py", line 96, in vmdk_is_a_descriptor
    with open(filepath) as f:
IOError: [Errno 16] Device or resource busy: '/vmfs/volumes/4bad174b-b67f5cfc-2fc6-0026b966a303/dockvols/myvol1.vmdk'
```