### PR TITLE
Add additional logging for vmci failures. Fixes #207

### DIFF
--- a/vmdk_plugin/vmdkops/esx_vmdkcmd.go
+++ b/vmdk_plugin/vmdkops/esx_vmdkcmd.go
@@ -92,7 +92,8 @@ func (vmdkCmd EsxVmdkCmd) Run(cmd string, name string, opts map[string]string) (
 		errno = err.(syscall.Errno)
 		msg := fmt.Sprintf("'%s' failed: %v (errno=%d).", cmd, err, int(errno))
 		if errno == syscall.ECONNRESET {
-			msg += " Check that ESX service is running."
+			msg += " Hit communication issue with ESX (vmci or ESX service)\n"
+			msg += " Please refer to the FAQ https://github.com/vmware/docker-volume-vsphere/wiki#faq"
 		}
 		log.Warnf(msg)
 		return nil, errors.New(msg)


### PR DESCRIPTION
Since the cause of communication failures need more info than what can be packed into a log message. Forward the customer to the FAQ.

```
2016-06-11 00:15:06.869406637 +0530 IST [WARNING] 'list' failed: connection reset by peer (errno=104). Hit communication issue with ESX (vmci or ESX service)
     Please refer to the FAQ https://github.com/vmware/docker-volume-vsphere/wiki#faq
```
Testing:
* Installed plugin with no vmware tools
* Insured no /dev/vsock (rmmod)
* Ran docker volume ls