### PR TITLE
Print the VM name for which request is being processed.

### DIFF
--- a/esx_service/utils/log_config.py
+++ b/esx_service/utils/log_config.py
@@ -51,7 +51,7 @@ LOG_CONFIG_DEFAULT = {
     "formatters": {
         "standard": {
             "format":
-            "%(asctime)-12s %(process)d [%(levelname)-7s] %(message)s",
+            "%(asctime)-12s %(process)d [%(threadName)s] [%(levelname)-7s] %(message)s",
             "datefmt": "%x %X",
         }
     },

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -40,6 +40,7 @@ import re
 import signal
 import subprocess
 import sys
+import threading
 import time
 from ctypes import *
 
@@ -702,6 +703,7 @@ def handleVmciRequests(port):
         else:
             details = req["details"]
             opts = details["Opts"] if "Opts" in details else {}
+            threading.currentThread().setName(vm_name)
             ret = executeRequest(vm_name, cfg_path, req["cmd"],
                                  details["Name"], opts)
             logging.info("executeRequest '%s' completed with ret=%s",


### PR DESCRIPTION
This change prints the name for the VM that issued the request being served.

Testing:
make sure /etc/vmware/vmdkops/log_config.json is deleted
make deploy-esx
run docker volume ls
```
[root@promc-2n-dhcp24:~] 06/10/16 21:56:26 2795426 [Ubuntu 64-bit] [INFO   ] executeRequest 'list' completed with ret=[{u'Attributes': {}, u'Name': 'MyVolume'}, {u'Attributes': {}, u'Name': 'rg'}, {u'Attributes': {}, u'Name': 'radio2016'}, {u'Attributes': {}, u'Name': 'MyVolume2'}]
```