### PR TITLE
Disk allocation format

### DIFF
--- a/esx_service/volume_kv.py
+++ b/esx_service/volume_kv.py
@@ -45,7 +45,16 @@ VSAN_POLICY_NAME = 'vsan-policy-name'
 # The size of the volume
 SIZE = 'size'
 
+# The disk allocation format for vmdk
+DISK_ALLOCATION_FORMAT = 'diskformat'
+
+VALID_ALLOCATION_FORMATS = ["zeroedthick", "thin", "eagerzeroedthick"]
+
+DEFAULT_ALLOCATION_FORMAT = 'thin'
+
 ## Values for given keys
+
+
 
 ## Value for VSAN_POLICY_NAME
 DEFAULT_VSAN_POLICY = '[VSAN default]'


### PR DESCRIPTION
Fixes #427 

Added option for user to select disk allocation format. Example:
```
docker volume create --driver=vmdk --name=vol -o diskformat=eagerzeroedthick
```
format choices:
"zeroedthick", "thin" (default), "eagerzeroedthick"

Tested: `make all` and CI
