### PR TITLE
Fixes #461: Disk format option on volume create

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -225,8 +225,8 @@ def validate_disk_allocation_format(format):
     """
     Ensure format is valid.
     """
-    if not format.lower() in kv.VALID_ALLOCATION_FORMATS :
-        raise ValidationError('Disk Allocation Format {0} does not exist. Valid options are: {1}'.format(format, kv.VALID_ALLOCATION_FORMATS))
+    if not format in kv.VALID_ALLOCATION_FORMATS :
+        raise ValidationError('Disk Allocation Format \'{0}\' does not exist. Valid options are: {1}'.format(format, kv.VALID_ALLOCATION_FORMATS))
 
 
 def getVMDKUuid(vmdk_path):

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -140,13 +140,10 @@ class ValidationTestCase(unittest.TestCase):
     def test_success(self):
         sizes = ['2gb', '200tb', '200mb', '5kb']
         sizes.extend([s.upper() for s in sizes])
-        
-        diskformats = ["zeroedthick", "thin", "eagerzeroedthick"]
-        diskformats.extend([diskformat.upper() for diskformat in diskformats])
 
         for s in sizes:
             for p in self.policy_names:
-                for d in diskformats:
+                for d in volume_kv.VALID_ALLOCATION_FORMATS:
                 # An exception should not be raised
                     vmdk_ops.validate_opts({volume_kv.SIZE: s, volume_kv.VSAN_POLICY_NAME: p, volume_kv.DISK_ALLOCATION_FORMAT : d},
                                        self.path)
@@ -156,7 +153,7 @@ class ValidationTestCase(unittest.TestCase):
 
     def test_failure(self):
         bad = [{volume_kv.SIZE: '2'}, {volume_kv.VSAN_POLICY_NAME: 'bad-policy'}, 
-        {volume_kv.DISK_ALLOCATION_FORMAT: 'bad-format'}, {volume_kv.SIZE: 'mb'}, {'bad-option': '4'}, {'bad-option': 'what',
+        {volume_kv.DISK_ALLOCATION_FORMAT: 'thiN'}, {volume_kv.SIZE: 'mb'}, {'bad-option': '4'}, {'bad-option': 'what',
                                                              volume_kv.SIZE: '4mb'}]
         for opts in bad:
             with self.assertRaises(vmdk_ops.ValidationError):


### PR DESCRIPTION
Fixes #461

Disk allocation format option to be specified in lowercase only.

Example:

> docker volume create --driver=vmdk --name=vol -o diskformat=eagerzeroedthick

Tested: make all and CI