### PR TITLE
Add vmdkops_admin.py status

### DIFF
--- a/doc/vmdkops-admin-cli-spec.md
+++ b/doc/vmdkops-admin-cli-spec.md
@@ -116,18 +116,18 @@ simplest implementation and isolation of admin information inside a single scrip
 
 #### `Status`
 Show any interesting information about the service. This includes file paths of config files, version
-information, and location of running service. A simple example is shown here, although it's likely
+information, and PID of running service. A simple example is shown here, although it's possible
 that the exact format may be somewhat different.
 
 ```
->vmdkops-admin service status
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py status
+Version: 1.0.0-0.0.1
 Status: Running
-Health: Healthy
-Version: 1.0.0
-LogFile: /var/log/vmdkops.log
-LogLevel: Debug
-Datastore: DS1, Size: 100GB, Used: 10GB
-Datastore: DS2, Size: 50GB, Used: 0GB
+Pid: 73114
+Port: 1019
+LogConfigFile: /etc/vmware/vmdkops/log_config.json
+LogFile: /var/log/vmware/vmdk_ops.log
+LogLevel: INFO
 ```
 
 #### `help`

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -557,7 +557,7 @@ def get_listening_port(pid):
 def get_version():
     """ Return the version of the installed VIB """
     try:
-        cmd = 'esxcli software vib list | grep esx-vmdkops-service'
+        cmd = 'localcli software vib list | grep esx-vmdkops-service'
         return subprocess.check_output(cmd, shell=True).split()[1]
     except:
         return NOT_AVAILABLE

--- a/esx_service/cli/vmdkops_admin_sanity_test.py
+++ b/esx_service/cli/vmdkops_admin_sanity_test.py
@@ -18,7 +18,7 @@ import subprocess
 import unittest
 import os
 
-admin_cli = '/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py'
+ADMIN_CLI = '/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py'
 
 class TestVmdkopsAdminSanity(unittest.TestCase):
     """ Test output from running vmdkops_admin.py """
@@ -31,7 +31,7 @@ class TestVmdkopsAdminSanity(unittest.TestCase):
         self.devnull.close()
 
     def test_ls(self):
-        cmd = '{0} ls'.format(admin_cli)
+        cmd = '{0} ls'.format(ADMIN_CLI)
         # Don't print errors about stty using a bad ioctl (we aren't attached to
         # a tty here)
         output = subprocess.check_output(cmd, shell=True, stderr=self.devnull)
@@ -42,7 +42,7 @@ class TestVmdkopsAdminSanity(unittest.TestCase):
             self.assertTrue(all_dashes(string))
 
     def test_policy_ls(self):
-        cmd = '{0} policy ls'.format(admin_cli)
+        cmd = '{0} policy ls'.format(ADMIN_CLI)
         # Don't print errors about stty using a bad ioctl (we aren't attached to
         # a tty here)
         output = subprocess.check_output(cmd, shell=True, stderr=self.devnull)
@@ -52,6 +52,18 @@ class TestVmdkopsAdminSanity(unittest.TestCase):
                          headers)
         for string in lines[1].split():
             self.assertTrue(all_dashes(string))
+
+    def test_status(self):
+        cmd = '{0} status'.format(ADMIN_CLI)
+        output = subprocess.check_output(cmd, shell=True, stderr=self.devnull)
+        # Remove the last "line" which is just the empty string from the split
+        lines = output.split('\n')[:-1]
+        self.assertEqual(len(lines), 7)
+        expected_headers = ['Version', 'Status', 'Pid', 'Port', 'LogConfigFile',
+                           'LogFile', 'LogLevel']
+        headers = map(lambda s: s.split(': ')[0], lines)
+        self.assertEqual(expected_headers, headers)
+
 
 def all_dashes(string):
     return all(map(lambda char: char == '-', string))

--- a/esx_service/utils/log_config.py
+++ b/esx_service/utils/log_config.py
@@ -30,6 +30,8 @@ import os.path
 # since we rely on it to locate log file name after config is loaded.
 LOG_CONFIG_FILE = "/etc/vmware/vmdkops/log_config.json"
 
+LOG_LEVEL_DEFAULT = 'INFO'
+
 # Defaults for log files - used to generate conf file if it is missing
 # Note: log file location should be synced with CI and 'make'
 LOG_FILE = "/var/log/vmware/vmdk_ops.log"
@@ -110,6 +112,18 @@ def configure(config_file=LOG_CONFIG_FILE):
     if generatedConf:
         logging.info("Log configuration generated - '%s'." % config_file)
     return log
+
+
+def get_log_level(config_file=LOG_CONFIG_FILE):
+    """ Return the configured log level """
+    try:
+        with open(config_file) as f:
+            conf = json.load(f)
+        return conf['loggers']['']['level']
+    except:
+        # The log config file doesn't currently exist. Use the default.
+        return LOG_LEVEL_DEFAULT
+
 
 # manual test: "sudo python log_config.py"
 if __name__ == "__main__":


### PR DESCRIPTION
Add a status command to the admin CLI.

Tested via manual run with output:

```
[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py status
Version: 1.0.0-0.0.1
Status: Running
Pid: 82287
Port: 1019
LogConfigFile: /etc/vmware/vmdkops/log_config.json
LogFile: /var/log/vmware/vmdk_ops.log
LogLevel: INFO
```

Also tested with an addition to vmdkops_admin_sanity_test.

Fixes #359