### PR TITLE
Only process requests from clients with privilege

### DIFF
--- a/esx_service/vmci/connection_types.h
+++ b/esx_service/vmci/connection_types.h
@@ -25,6 +25,9 @@
 // 0 is usually success. Note: sometimes we return socket FD on success
 #define CONN_SUCCESS  (0)
 
+// First non privileged port
+#define START_NON_PRIVILEGED_PORT 1024
+
 /*
  * This function acquires and returns address family for vSockets.
  * On failure returns -1 an sets errno (if not set by VMCISock_GetAFValue ())

--- a/esx_service/vmci/vmci_server.c
+++ b/esx_service/vmci/vmci_server.c
@@ -120,6 +120,13 @@ vmci_get_one_op(const int s,    // socket to listen on
       return CONN_FAILURE;
    }
 
+   if (addr.svm_port >= START_NON_PRIVILEGED_PORT) {
+      fprintf(stderr, "Connection from non root port=%d, cid=%d\n", addr.svm_port, addr.svm_cid);
+      close(client_socket);
+      errno=ECONNABORTED;
+      return CONN_FAILURE;
+   }
+
    // get VMID. We really get CartelID for VM, but it will make do
    socklen_t len = sizeof(*vmid);
    if (getsockopt(client_socket, af, SO_VMCI_PEER_HOST_VM_ID, vmid, &len) == -1 || len


### PR DESCRIPTION
To be able to bind a port below 1024 on the client side, the plugin
needs to be run as root or given neccessary privileges. This change
enforces the policy of only allowing privileged clients.

To keep things simple the client port to bind is the same as the server.

Testing:
1. Install client without code change to use priviledge port
2. Validate that docker requests fail and log messages are generated.
3. Upgrade to client with code change for priviledge port
4. Validate that docker requests pass

Will be filling a separate issue to resolve the std out logging
on ESX. We need to invest a bit more to override the std out buffer
and redirect it to a log file.