### PR TITLE
Select files that have a vmdk extension and size up to max vmdk descriptor size.

### DIFF
--- a/esx_service/utils/vmdk_utils.py
+++ b/esx_service/utils/vmdk_utils.py
@@ -75,12 +75,7 @@ def vmdk_is_a_descriptor(filepath):
     and has a size less than MAX_DESCR_SIZE is a desciptor file.
     """
     if filepath.endswith('.vmdk') and os.stat(filepath).st_size < MAX_DESCR_SIZE:
-        try:
-            with open(filepath) as f:
-                line = f.readline()
-                return line.startswith('# Disk DescriptorFile')
-        except:
-            logging.exception("Failed to open %s for descriptor check", filepath)
+       return True
 
     return False
 


### PR DESCRIPTION
vmdk_utils.py:vmdk_is_a_descriptor() fixed to ignore the step to read the file to detemine its a vmdk descriptor. As long as the file has a vmdk extension and sized not more than a max descriptor file size its considered ok.