### PR TITLE
On create, reject volume or datastore names > 100 chars.

### DIFF
--- a/doc/VolumeNames.md
+++ b/doc/VolumeNames.md
@@ -1,17 +1,19 @@
 # Short Volume names
-Short Volume Name can contain alphanumeric characters, underscores and dots. Examples: `MyVolume_fast.12` or `_12SuperStorage`.
-Volume name is limited to 100 characters. 
+Short Volume Name start with a letter or underscore and can contain alphanumeric characters, underscores and dots.
+Examples: `MyVolume_fast.12` or `_12SuperStorage`. Volume name length is limited to 100 characters. 
 
 # Full volume names
 Full volume name is a combination of Short Volume name and datastore name, separated by @ sign.
-Datastore name is a vSphere Datastore , e.g. vsanDatastore. Examples: `BigFatDisk@vsanDatastore` or `myVol123.33@datastore255`
+Datastore name is a vSphere Datastore , e.g. vsanDatastore. Examples: `BigFatDisk@vsanDatastore` or `myVol123.33@datastore255`.
+Datastore name length is also limited to 100 characters, and datastore name should start with a letter or underscore and can contain 
+alphanumeric characters, underscores, hyphens and dots.
 
 
 # Default datastore 
 
 Our approach is `if you do not care about specific datastore, use just the volume name and the rest will be taken care of`.
 
-If datastore Name is ommited, the name of the datastore where Docker VM is located will be used.
+If datastore name is omitted, the name of the datastore where Docker VM is located will be used.
 E.g. if Docker VM is located on `vsanDatastore`, then 
 `myVolume@vsanDatastore` is the same as `myVolume`. 
 
@@ -20,7 +22,7 @@ Full volume names are unique, but short volume names are unique only within a sp
 to `myVolume@datastore266` - which are different volumes. However, in both VMs `myVolume@vsanDatastore` and `myvolume@datastore266` can be used to 
 uniquely identify the volume.
 
-Note that `docker volume ls` command will strip Datastore from the volumes on the VM datastore. For example, if the Docker VM runs on `datastore266`
+Note that `docker volume ls` command will strip datastore name from the volumes on the Docker VM datastore. For example, if the Docker VM runs on `datastore266`
 and there are 2 volumes on this datastore, and there are also 2 volumes with the same names on vsanDatastore, then 'docker volume ls' will show
 the following:
 ```

--- a/doc/VolumeNames.md
+++ b/doc/VolumeNames.md
@@ -1,11 +1,11 @@
 # Short Volume names
-Short Volume Name start with a letter or underscore and can contain alphanumeric characters, underscores and dots.
-Examples: `MyVolume_fast.12` or `_12SuperStorage`. Volume name length is limited to 100 characters. 
+Short Volume Name can contain up to a 100 of alphanumeric characters, underscores and dots.
+Examples: `MyVolume_fast.12` or `_12SuperStorage`.
 
 # Full volume names
 Full volume name is a combination of Short Volume name and datastore name, separated by @ sign.
 Datastore name is a vSphere Datastore , e.g. vsanDatastore. Examples: `BigFatDisk@vsanDatastore` or `myVol123.33@datastore255`.
-Datastore name length is also limited to 100 characters, and datastore name should start with a letter or underscore and can contain 
+Datastore name length is also limited to 100 characters, and datastore name can contain
 alphanumeric characters, underscores, hyphens and dots.
 
 

--- a/doc/VolumeNames.md
+++ b/doc/VolumeNames.md
@@ -1,17 +1,17 @@
 # Short Volume names
 Short Volume Name can contain alphanumeric characters, underscores and dots. Examples: `MyVolume_fast.12` or `_12SuperStorage`.
-Volume name is limited to 128 characters. 
+Volume name is limited to 100 characters. 
 
 # Full volume names
-Full volume name is a combination of Short Volume name and Datastore name, separated by @ sign.
-Datastore name is a vSphere datastore , e.g. vsanDatastore. Examples: `BigFatDisk@vsanDatastore` or `myVol123.33@datastore255`
+Full volume name is a combination of Short Volume name and datastore name, separated by @ sign.
+Datastore name is a vSphere Datastore , e.g. vsanDatastore. Examples: `BigFatDisk@vsanDatastore` or `myVol123.33@datastore255`
 
 
 # Default datastore 
 
 Our approach is `if you do not care about specific datastore, use just the volume name and the rest will be taken care of`.
 
-If Datastore Name is ommited, the name of the datastore where Docker VM is located will be used.
+If datastore Name is ommited, the name of the datastore where Docker VM is located will be used.
 E.g. if Docker VM is located on `vsanDatastore`, then 
 `myVolume@vsanDatastore` is the same as `myVolume`. 
 
@@ -27,7 +27,7 @@ the following:
 $ docker volume ls
 DRIVER       VOLUME NAME
 vmdk         volume1
-vmdk         volume 2
+vmdk         volume2
 vmdk         volume1@vsanDatastore
 vmdk         volume2@vsanDatastore
 ```
@@ -35,5 +35,5 @@ vmdk         volume2@vsanDatastore
 # Volume name usage
 volume@datastore can be used anywhere where `volume name` is needed - i.e. in 'docker run -v **volume**:/path ...' ,
 'docker volume create', 'docker volume rm', docker volume inspect'. In all cases, using short volume name (with no datastore) will refer to the volume 
-with the given name located on the same datastore where the Docker VM is located
+with the given name located on the same datastore where the Docker VM is located.
 

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -165,7 +165,7 @@ def make_create_cmd(opts, vmdk_path):
         # datastore is not VSAN
         policy_file = vsan_policy.policy_path(opts[kv.VSAN_POLICY_NAME])
         return "{0} -d {1} -c {2} --policyFile {3} {4}".format(VMDK_CREATE_CMD, format, size,
-                                                    policy_file, vmdk_path)
+                                                               policy_file, vmdk_path)
     else:
         return "{0} -d {1} -c {2} {3}".format(VMDK_CREATE_CMD, format, size, vmdk_path)
 
@@ -390,7 +390,7 @@ def parse_vol_name(full_vol_name):
     On parse errors raises ValidationError with syntax explanation
     """
     # note: \w in regexp is [a-zA-Z0-9_]
-    groups = re.match(r"\A([a-zA-Z_][\w\_.]+)(@([a-zA-Z_][\w\_\-.]+))?$", full_vol_name)
+    groups = re.match(r"\A([a-zA-Z_][\w\_.]*)(@([a-zA-Z_][\w\_\-.]*))?$", full_vol_name)
     if not groups:
         raise ValidationError("Invalid syntax: '{0}'.\n"
                               "Valid syntax is volume@datastore, where 'volume' or 'datastore' "
@@ -837,19 +837,19 @@ def main():
     signal.signal(signal.SIGINT, signal_handler_stop)
     signal.signal(signal.SIGTERM, signal_handler_stop)
     try:
-        port=1019
+        port = 1019
         opts, args = getopt.getopt(sys.argv[1:], 'hp:')
     except getopt.error, msg:
         if msg:
             print >> sys.stderr, msg
         usage()
-        return(1)
-    for a,v in opts:
+        return 1
+    for a, v in opts:
         if a == '-p':
-            port=int(v)
+            port = int(v)
         if a == '-h':
             usage()
-            return(0)
+            return 0
 
     try:
         kv.init()

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -389,14 +389,16 @@ def parse_vol_name(full_vol_name):
     Parses volume[@datastore] and returns (volume, datastore)
     On parse errors raises ValidationError with syntax explanation
     """
-    # note: \w in regexp is [a-zA-Z0-9_]
-    groups = re.match(r"\A([a-zA-Z_][\w\_.]*)(@([a-zA-Z_][\w\_\-.]*))?$", full_vol_name)
+    # Parse volume name with regexp package
+    # Note: we do not want '-' in volume name to make sure names like 'disk-0001.vmdk' cannot
+    # be created using this API.
+    # on regexp:  '\w'' in regexp is [a-zA-Z0-9_]
+    groups = re.match(r"\A([\w\_.]+)(@([\w\_.\-]+))?$", full_vol_name)
     if not groups:
         raise ValidationError("Invalid syntax: '{0}'.\n"
                               "Valid syntax is volume@datastore, where 'volume' or 'datastore' "
-                              "should start with a letter or _,  and contain only "
-                              "allowed characters ([a-zA-Z0-9_.])"
-                              .format(full_vol_name))
+                              "contain up to {1} of allowed characters ([a-zA-Z0-9_.]) each"
+                              .format(full_vol_name, MAX_VOL_NAME_LEN))
     vol_name, ds_name = groups.groups()[0], groups.groups()[2]
     if len(vol_name) > MAX_VOL_NAME_LEN:
         raise ValidationError("Volume name is too long (max len is {0})".format(MAX_VOL_NAME_LEN))

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -45,7 +45,7 @@ class VolumeNamingTestCase(unittest.TestCase):
             ["MyVolume123_a_.vol@vsanDatastore_11", "MyVolume123_a_.vol", "vsanDatastore_11", True],
             ["a1@x",                            "a1",                  "x",             True],
             ["a1",                              "a1",                  None,            True],
-            ["1",                                None,                 None,            False],
+            ["1",                                "1",                 None,             True],
             ["no-dashes-please@datastore",       None,                 None,            False],
             ["Spaces NotGood@vsan",              None,                 None,            False],
             ["GoodVolume@bad ds with spaces",    None,                 None,            False],

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -41,14 +41,17 @@ class VolumeNamingTestCase(unittest.TestCase):
         """checks name parsing and error checks
         'volume[@datastore]' -> volume and datastore"""
         testInfo = [
-            #    full_name                       vol_name   datastore  success ?
+            #  [ full_name. expected_vol_name, expected_datastore_name,  expected_success? ]
             ["MyVolume123_a_.vol@vsanDatastore_11", "MyVolume123_a_.vol", "vsanDatastore_11", True],
             ["a1@x",                            "a1",                  "x",             True],
             ["a1",                              "a1",                  None,            True],
-            ["1",                               None,                  None,            False],
+            ["1",                                None,                 None,            False],
             ["no-dashes-please@datastore",       None,                 None,            False],
             ["Spaces NotGood@vsan",              None,                 None,            False],
-            ["SGoodVold@bad ds with spaces",     None,                 None,            False],
+            ["GoodVolume@bad ds with spaces",    None,                 None,            False],
+            ["TooLong0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789", None, None, False],
+            ["Just100Chars0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567", 
+                           "Just100Chars0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567", None, True],
             ["Volume.123@dots.dot",              "Volume.123",        "dots.dot",       True],
             ["simple_volume",                    "simple_volume",      None,            True],
         ]

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -41,10 +41,11 @@ class VolumeNamingTestCase(unittest.TestCase):
         'volume[@datastore]' -> volume and datastore"""
         testInfo = [
             #    full_name                       vol_name   datastore  success ?
-            ["MyVolume123-a_.vol@vsanDatastore", "MyVolume123-a_.vol", "vsanDatastore", True],
+            ["MyVolume123_a_.vol@vsanDatastore_11", "MyVolume123_a_.vol", "vsanDatastore_11", True],
+            ["no-dashes-please@datastore",       None,                 None,            False],
             ["Spaces NotGood@vsan",              None,                 None,            False],
             ["SGoodVold@bad ds with spaces",     None,                 None,            False],
-            ["Volume-123@dots.dot",              "Volume-123",        "dots.dot",       True],
+            ["Volume.123@dots.dot",              "Volume.123",        "dots.dot",       True],
             ["simple_volume",                    "simple_volume",      None,            True],
         ]
         for unit in testInfo:

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -21,7 +21,8 @@ import unittest
 import sys
 import logging
 import glob
-import os, os.path
+import os
+import os.path
 
 import vmdk_ops
 import log_config
@@ -42,6 +43,9 @@ class VolumeNamingTestCase(unittest.TestCase):
         testInfo = [
             #    full_name                       vol_name   datastore  success ?
             ["MyVolume123_a_.vol@vsanDatastore_11", "MyVolume123_a_.vol", "vsanDatastore_11", True],
+            ["a1@x",                            "a1",                  "x",             True],
+            ["a1",                              "a1",                  None,            True],
+            ["1",                               None,                  None,            False],
             ["no-dashes-please@datastore",       None,                 None,            False],
             ["Spaces NotGood@vsan",              None,                 None,            False],
             ["SGoodVold@bad ds with spaces",     None,                 None,            False],
@@ -53,13 +57,14 @@ class VolumeNamingTestCase(unittest.TestCase):
             try:
                 vol, ds = vmdk_ops.parse_vol_name(full_name)
                 self.assertTrue(expected_result,
-                          "Expected volume name parsing to succeed for '%s'" % full_name)
-                self.assertEqual(vol, expected_vol_name,
-                                 "Vol name mismatch '%s' expected '%s'" % (vol, expected_vol_name))
-                self.assertEqual(vol, expected_vol_name,
-                                 "Datastore name mismatch '%s' expected '%s'" % (ds, expected_ds_name))
+                                "Expected volume name parsing to fail for '{0}'".format(full_name))
+                self.assertEqual(vol, expected_vol_name, "Vol name mismatch '{0}' expected '{1}'" \
+                                                         .format(vol, expected_vol_name))
+                self.assertEqual(vol, expected_vol_name, "Datastore name: '{0}' expected: '{1}'" \
+                                                         .format(ds, expected_ds_name))
             except vmdk_ops.ValidationError as ex:
-                self.assertFalse(expected_result, "Expected volume name parsing to fail for '%s'" % full_name)
+                self.assertFalse(expected_result, "Expected vol name parsing to succeed for '{0}'"
+                                 .format(full_name))
 
 
 class VmdkCreateRemoveTestCase(unittest.TestCase):

--- a/misc/drone-scripts/cleanup.sh
+++ b/misc/drone-scripts/cleanup.sh
@@ -15,6 +15,6 @@
 
 
 stop_build() {
-  make clean-vm clean-esx TEST_VOL_NAME=vol-build$BUILD_NUMBER
+  make clean-vm clean-esx TEST_VOL_NAME=vol.build$BUILD_NUMBER
   $SSH $ESX "sh /tmp/lock.sh unlock $BUILD_NUMBER"
 }

--- a/misc/drone-scripts/deploy-and-test-wrapper.sh
+++ b/misc/drone-scripts/deploy-and-test-wrapper.sh
@@ -83,7 +83,7 @@ truncate_esx_logs
 
 log "starting deploy and test"
 
-if make deploy-esx deploy-vm testasroot testremote TEST_VOL_NAME=vol-build$BUILD_NUMBER;
+if make deploy-esx deploy-vm testasroot testremote TEST_VOL_NAME=vol.build$BUILD_NUMBER;
 then
   dump_esx_info $ESX
   dump_vm_info $VM1

--- a/vmdk_plugin/plugin.go
+++ b/vmdk_plugin/plugin.go
@@ -17,7 +17,7 @@ package main
 //
 // VMWare VMDK Docker Data Volume plugin.
 //
-// Provide suport for --driver=vmdk in Docker, when Docker VM is running under ESX.
+// Provide support for --driver=vmdk in Docker, when Docker VM is running under ESX.
 //
 // Serves requests from Docker Engine related to VMDK volume operations.
 // Depends on vmdk-opsd service to be running on hosting ESX
@@ -26,13 +26,14 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/go-plugins-helpers/volume"
 	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/fs"
 	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/vmdkops"
-	"path/filepath"
-	"sync"
-	"time"
 )
 
 const (
@@ -164,7 +165,7 @@ func (d *vmdkDriver) Remove(r volume.Request) volume.Response {
 
 	// Docker is supposed to block 'remove' command if the volume is used. Verify.
 	if d.getRefCount(r.Name) != 0 {
-		msg := fmt.Sprintf("Remove faiure - volume is still mounted. "+
+		msg := fmt.Sprintf("Remove failure - volume is still mounted. "+
 			" volume=%s, refcount=%d", r.Name, d.getRefCount(r.Name))
 		log.Error(msg)
 		return volume.Response{Err: msg}


### PR DESCRIPTION
Fixes #284 

Test: adjusted name tests, run 'make all' and CI and manual (generated long names and made sure the error is issued)

Note that CI is now failing badly for other reasons ("out of resources") , but the naming tests pass 