### PR TITLE
[TRIVIAL] Made test refcnt test script exit on first failure

### DIFF
--- a/misc/scripts/refcnt_test.sh
+++ b/misc/scripts/refcnt_test.sh
@@ -27,6 +27,13 @@
 # For now (TP) we still need basic validation
 #
 
+# make sure all vars are set before usage
+set -o nounset
+
+# make sure scripts terminate (and test fails) on first failure
+set -e
+
+
 DIR=$(dirname ${BASH_SOURCE[0]})
 . $DIR/wait_for.sh
 


### PR DESCRIPTION
Trivial fix to maker sure refcnt script exits if things like 'docker volume create' fail
test: none, waiting for CI to come back
//CC @kerneltime 