### PR TITLE
Update vmdk-opsd start order

### DIFF
--- a/esx_service/vmdk-opsd
+++ b/esx_service/vmdk-opsd
@@ -1,5 +1,5 @@
 #!/bin/sh
-# chkconfig: on 20 20
+# chkconfig: on 90 90
 
 #
 # Start and stop the storage operations daemon.


### PR DESCRIPTION
vmdk-opsd fails to start after reboot with 503 service unavailable error. Change start order to start service after hostd/vpxa. See more details in #516

Testing Done:
Reproduced issue i.e. vmdk-opsd wasn't running after restarting ESX. With this change, service was running after ESX reboot.

Fixes #516