### PR TITLE
Mount only after the OS is done discovering new dev.

### DIFF
--- a/vmdk_plugin/utils/fs/fs.go
+++ b/vmdk_plugin/utils/fs/fs.go
@@ -55,21 +55,13 @@ func Mkdir(path string) error {
 
 // Mount discovers which devices are for which volume using blkid.
 // It then mounts the filesystem (`fs`) on the device at the given mountpoint.
-func Mount(mountpoint string, devSpec []byte, fs string) error {
-	var device string
-	if devSpec == nil {
-		return fmt.Errorf("No device to mount.")
-	}
-	device, err := GetDevicePath(devSpec)
-	if err != nil {
-		return err
-	}
+func Mount(mountpoint string, fs string, device string) error {
 	log.WithFields(log.Fields{
 		"device":     device,
 		"mountpoint": mountpoint,
 	}).Debug("Calling syscall.Mount() ")
 
-	err = syscall.Mount(device, mountpoint, fs, 0, "")
+	err := syscall.Mount(device, mountpoint, fs, 0, "")
 	if err != nil {
 		return fmt.Errorf("Failed to mount device %s at %s: %s", device, mountpoint, err)
 	}


### PR DESCRIPTION
This is a continuation of https://github.com/vmware/docker-volume-vsphere/pull/517
There is a race between the plugin completing the attach command and
it requesting the OS to mount before the OS discovers the new device.
Add support to be notified when the device is attached.

Testing:
On my local box, the mount was triggered only after the device was
detected.
Tested timeout by watching on an incorrect path.
Tested looping by watching /dev
Each run command part of CI will run this code.