### PR TITLE
Use go lang container to run gvt for vendoring.

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -73,7 +73,7 @@ plug_container=cnastorage/vibauthor-and-go:$plugin_container_version
 plug_pkg_container_version=latest
 plug_pkg_container=cnastorage/fpm:$plug_pkg_container_version
 dockerfile=Dockerfile.vibauthor-and-go
-
+go_container=golang
 # mount point within the container.
 dir=/go/src/github.com/vmware/docker-volume-vsphere
 # We need to mount this into the container:
@@ -93,7 +93,7 @@ then
     $MAKE $1
 elif [ "$1" == "gvt" ]
 then
-  $DOCKER run --rm -it -v $PWD/..:$dir -w $dir $plug_container bash
+  $DOCKER run --rm -it -v $PWD/..:$dir -w $dir $go_container bash -c "go get -u github.com/FiloSottile/gvt; bash"
 else
   docker_socket=/var/run/docker.sock
   $DOCKER run --privileged --rm \


### PR DESCRIPTION
The centos image used for building the plugin has an older version
of git that does not work for the latest version of gvt.
Switch to using the golang container for running gvt.

Test:
make gvt
gvt update github.com/docker/go-plugins-helpers/volume (used to fail with cent os 6.6)