### PR TITLE
attach / detach delta disks handling fix

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -558,13 +558,14 @@ def connectLocal():
 
 
 def findDeviceByPath(vmdk_path, vm):
+    logging.debug("findDeviceByPath: Looking for device {0}".format(vmdk_path))
     for d in vm.config.hardware.device:
         if type(d) != vim.vm.device.VirtualDisk:
             continue
 
         # Disks of all backing have a backing object with a filename attribute.
         # The filename identifies the virtual disk by name and can be used
-        # to match with the given name.
+        # to match with the given volume name.
         # Filename format is as follows:
         #   "[<datastore name>] <parent-directory>/<vmdk-descriptor-name>"
         backing_disk = d.backing.fileName.split(" ")[1]
@@ -758,10 +759,12 @@ def disk_attach(vmdk_path, vm):
     except vim.fault.VimFault as ex:
         msg = ex.msg
         # Use metadata (KV) for extra logging
-        if kv_status_attached and kv_uuid != vm.config.uuid:
+        if kv_status_attached:
             # KV  claims we are attached to a different VM'.
             msg += " disk {0} already attached to VM={1}".format(vmdk_path,
                                                                  kv_uuid)
+            if kv_uuid == vm.config.uuid:
+                msg += "(Current VM)"
         return err(msg)
 
     setStatusAttached(vmdk_path, vm)

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -86,7 +86,7 @@ DOCKER="$DEBUG docker"
 
 if [ "$1" == "rpm" ] || [ "$1" == "deb" ]
 then
-  $DOCKER run --rm  \
+  $DOCKER run --rm  -it \
     -e "PKG_VERSION=$PKG_VERSION" \
     -v $PWD/..:$dir \
     -w $dir \
@@ -100,7 +100,7 @@ then
   $DOCKER run --rm -it -v $PWD/..:$dir -w $dir -p 8000:8000 $docs_container bash 
 else
   docker_socket=/var/run/docker.sock
-  $DOCKER run --privileged --rm \
+  $DOCKER run --privileged --rm -it \
     -e "PKG_VERSION=$PKG_VERSION" \
     -v $docker_socket:$docker_socket  \
     -v $PWD/..:$dir -w $dir $plug_container $MAKE $1

--- a/vmdk_plugin/plugin.go
+++ b/vmdk_plugin/plugin.go
@@ -180,7 +180,7 @@ loop:
 		case <-time.After(devWaitTimeout):
 			log.WithFields(
 				log.Fields{"name": name, "timeout": devWaitTimeout, "device": device},
-			).Error("Reached timeout while waiting for device ")
+			).Warning("Reached timeout while waiting for device, trying to mount anyways ")
 			break loop
 		}
 	}


### PR DESCRIPTION
Fixes #554 

When looking for full path of the VMDK representing a docker volume,
take in account (potential) existence of delta disks.
Also made `make` interruptible  when running docker (added '-it') and added a few debug messages

Tested:
* make all, CI
* Manual: followed steps in #554 . all worked
* Manual: created multiple snapshots, erased some , created more (to break numbering sequence), checked docker volume ls  and docker run with the volume - all works (correct filenames are reported in the logs too)
