### PR TITLE
Refresh VM devices when a PVSCSI controller is added before searching.

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -778,6 +778,7 @@ def disk_attach(vmdk_path, vm):
             msg=("Failed to add PVSCSI Controller: %s", ex.msg)
             return err(msg)
         # Find the controller just added
+        devices = vm.config.hardware.device
         pvsci = [d for d in devices
                  if type(d) == vim.ParaVirtualSCSIController and
                  d.key == controller_key]


### PR DESCRIPTION
Reinitialize "devices" in disk_attach() before searching for the newly added pvscsi controller. Ran the VM after removing the PVSCSI controller and able to see the disk attached ok

Testing:
Before fix,

08/04/16 06:08:17 282371 [Ubuntu-14.04-64] [WARNING] Warning: PVSCI adapter is missing - trying to add one...
08/04/16 06:08:17 282371 [Ubuntu-14.04-64] [ERROR  ] list index out of range
Traceback (most recent call last):
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 995, in main
    handleVmciRequests(port)
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 952, in handleVmciRequests
    opts=opts)
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 564, in executeRequest
    response = attachVMDK(vmdk_path, vm_uuid)
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 436, in attachVMDK
    return disk_attach(vmdk_path, vm)
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 780, in disk_attach
    offset_from_bus_number)
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 618, in get_controller_pci_slot
    if pvscsi[0].slotInfo:
IndexError: list index out of range


With fix:

08/04/16 07:57:06 442750 [2] [INFO   ] *** attachVMDK: /vmfs/volumes/bigone/dockvols/dvol_2.vmdk to 2 VM uuid = 564d392b-3cb8-5a4a-862a-3df7a590d97e
08/04/16 07:57:06 442750 [2] [INFO   ] Attaching /vmfs/volumes/bigone/dockvols/dvol_2.vmdk as independent_persistent
08/04/16 07:57:06 442750 [2] [WARNING] Warning: PVSCI adapter is missing - trying to add one...
08/04/16 07:57:07 442750 [2] [INFO   ] Disk /vmfs/volumes/bigone/dockvols/dvol_2.vmdk successfully attached. controller pci_slot_number=224, disk_slot=0
08/04/16 07:57:07 442750 [2] [INFO   ] executeRequest 'attach' completed with ret={'ControllerPciSlotNumber': '224', 'Unit': '0'}
08/04/16 07:57:08 442750 [2] [INFO   ] *** detachVMDK: /vmfs/volumes/bigone/dockvols/dvol_2.vmdk from 2 VM uuid = 564d392b-3cb8-5a4a-862a-3df7a590d97e
08/04/16 07:57:09 442750 [2] [INFO   ] Disk detached /vmfs/volumes/bigone/dockvols/dvol_2.vmdk
08/04/16 07:57:09 442750 [2] [INFO   ] executeRequest 'detach' completed with ret=None
