### PR TITLE
vmdkops_admin ls does not work when "-c" option is specified.

### DIFF
--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -314,7 +314,7 @@ def make_list_of_values(allowed):
                 msg = (
 		   'invalid choices: {0} (choices must be a comma separated list of '
                    'only the following words {1}. '  
-		   'No spaces are allowed between choices.)').format(g, allowed)
+		   'No spaces are allowed between choices.)').format(g, repr(allowed).replace(' ', ''))
                 raise argparse.ArgumentTypeError(msg)
         return given
 

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -313,7 +313,7 @@ def make_list_of_values(allowed):
             if g not in allowed:
                 msg = (
 		   'invalid choices: {0} (choices must be a comma separated list of '
-                   'only the following words {1}. '  
+                   'only the following words \n {1}. '  
 		   'No spaces are allowed between choices.)').format(g, repr(allowed).replace(' ', ''))
                 raise argparse.ArgumentTypeError(msg)
         return given

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -311,8 +311,10 @@ def make_list_of_values(allowed):
         given = string.split(',')
         for g in given:
             if g not in allowed:
-                msg = "invalid choice: {0} (choose from {1})".format(g,
-                                                                     allowed)
+                msg = (
+		   'invalid choices: {0} (choices must be a comma separated list of '
+                   'only the following words {1}. '  
+		   'No spaces are allowed between choices.)').format(g, allowed)
                 raise argparse.ArgumentTypeError(msg)
         return given
 
@@ -330,7 +332,6 @@ def ls(args):
     else:
         header = all_ls_headers()
         rows = generate_ls_rows()
-
     print(cli_table.create(header, rows))
 
 
@@ -340,8 +341,9 @@ def ls_dash_c(columns):
     all_rows = generate_ls_rows()
     indexes = []
     headers = []
-    for i in range(len(all_headers)):
-        if format_header_as_arg(all_headers[i]) in columns:
+    choices = commands()['ls']['args']['-c']['choices']
+    for i in range(len(choices)):
+        if (choices[i]) in columns:
             indexes.append(i)
             headers.append(all_headers[i])
     rows = []
@@ -503,7 +505,7 @@ def policy_ls(args):
 
 
 def policy_update(args):
-    output = vsan_policy.update(args.name, args.content)
+    output = vsan_policy.update(args.name,  args.content)
     if output:
         print(output)
     else:

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -352,15 +352,6 @@ def ls_dash_c(columns):
     return (headers, rows)
 
 
-def format_header_as_arg(header):
-    """
-    Take a header formatted as words separated by spaces starting with
-    capitals and convert it to a cli argument friendly format that is all
-    lowercase with words separated by dashes. i.e. 'Created By' -> 'created-by'
-    """
-    return '-'.join(header.lower().split())
-
-
 def all_ls_headers():
     """ Return a list of all header for ls -l """
     return ['Volume', 'Datastore', 'Created By VM', 'Created',


### PR DESCRIPTION
Issue 549: vmdkops_admin ls does not work when "-c" option is specified.
Fixes #549 
Without the fix: 



```
devbox:~ ssh -qt root@$ESX /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py ls -c volume,created-by
Volume    
--------  
MyVolume
```

With the fix: 

```
root@localhost:~] vmdkops_admin ls -h
usage: vmdkops_admin ls [-h] [-c Col1,Col2,...]

optional arguments:
  -h, --help        show this help message and exit
  -c Col1,Col2,...  Display selected columns: Choices = ['volume',
                    'datastore', 'created-by', 'created', 'attached-to',
                    'policy', 'capacity', 'used']
[root@localhost:~] 
[root@localhost:~] 
[root@localhost:~] 
[root@localhost:~] vmdkops_admin ls 
Volume    Datastore   Created By VM  Created                   Attached To VM  Policy  Capacity  Used     
--------  ----------  -------------  ------------------------  --------------  ------  --------  -------  
MyVolume  datastore1  photon         Wed Aug  3 15:38:15 2016  detached        N/A     100.00MB  14.00MB  

[root@localhost:~] 
[root@localhost:~] 
[root@localhost:~] 
[root@localhost:~] vmdkops_admin ls -c 'volume','datastore','created-by','attached-to'
Volume    Datastore   Created By VM  Attached To VM  
--------  ----------  -------------  --------------  
MyVolume  datastore1  photon         detached        

[root@localhost:~] 
[root@localhost:~] vmdkops_admin ls -c 'volume', 'datastore', 'created-by', 'attached-to'
usage: vmdkops_admin ls [-h] [-c Col1,Col2,...]
vmdkops_admin ls: error: argument -c: invalid choices:  (choices must be a comma separated list of only the following words ['volume', 'datastore', 'created-by', 'created', 'attached-to', 'policy', 'capacity', 'used']. No spaces are allowed between choices.)

```

make test-all passed.
CI test passed.
Please review it. 
