### PR TITLE
Refresh devices on adding a PVSCSI controller

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -842,6 +842,7 @@ def disk_attach(vmdk_path, vm):
             msg=("Failed to add PVSCSI Controller: %s", ex.msg)
             return err(msg)
         # Find the controller just added
+        devices = vm.config.hardware.device
         pvsci = [d for d in devices
                  if type(d) == vim.ParaVirtualSCSIController and
                  d.key == controller_key]


### PR DESCRIPTION
Restoring change that got removed by PR #573.

Retested with the change on the current code, server logs:
08/18/16 10:36:11 3225508 [1] [INFO   ] Found VM name=1, id=4225d240-b7f5-3825-e1c4-e69a08844980
08/18/16 10:36:11 3225508 [1] [INFO   ] *** attachVMDK: /vmfs/volumes/bigone/dockvols/testvol-1.vmdk to 1 VM uuid = 4225d240-b7f5-3825-e1c4-e69a08844980
08/18/16 10:36:11 3225508 [1] [INFO   ] Attaching /vmfs/volumes/bigone/dockvols/testvol-1.vmdk as independent_persistent
08/18/16 10:36:11 3225508 [1] [WARNING] Warning: PVSCI adapter is missing - trying to add one...
08/18/16 10:36:12 3225508 [1] [INFO   ] Disk /vmfs/volumes/bigone/dockvols/testvol-1.vmdk successfully attached. controller pci_slot_number=224, disk_slot=0
08/18/16 10:36:12 3225508 [1] [INFO   ] executeRequest 'attach' completed with ret={'ControllerPciSlotNumber': '224', 'Unit': '0'}
08/18/16 10:36:13 3225508 [1] [INFO   ] *** detachVMDK: /vmfs/volumes/bigone/dockvols/testvol-1.vmdk from 1 VM uuid = 4225d240-b7f5-3825-e1c4-e69a08844980
08/18/16 10:36:13 3225508 [1] [INFO   ] Disk detached /vmfs/volumes/bigone/dockvols/testvol-1.vmdk
08/18/16 10:36:13 3225508 [1] [INFO   ] executeRequest 'detach' completed with ret=None
