### PR TITLE
Add proper PVSCSI controller/disks create() automation

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -876,7 +876,7 @@ def disk_attach(vmdk_path, vm):
     if (disk_slot is None):
         disk_slot = 0  # starting on a fresh controller
         if len(controllers) >= max_scsi_controllers:
-            msg = "Failed to place new disk - out of disk slots"
+            msg = "Failed to place new disk - out of disk slots due to no slot to add a new controller"
             logging.error(msg + " VM=%s", vm.config.uuid)
             return err(msg)
 

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -721,7 +721,6 @@ def getStatusAttached(vmdk_path):
         uuid = None
     return attached, uuid, attach_as
 
-<<<<<<< 5c74db18b272bb8c7cf8d4aadd0d999f18f673e0
 def handle_stale_attach(vmdk_path, kv_uuid):
        '''
        Clear volume state for cases where the VM that attached the disk
@@ -759,7 +758,6 @@ def handle_stale_attach(vmdk_path, kv_uuid):
           if ret:
              return ret
 
-=======
 def add_pvscsi_controller(vm, controllers, max_scsi_controllers, offset_from_bus_number):
     ''' 
     Add a new PVSCSI controller, return (controller_key, err) pair
@@ -841,9 +839,9 @@ def disk_attach(vmdk_path, vm):
     # If the volume is attached then check if the attach is stale (VM is powered off).
     # Otherwise, detach the disk from the VM it's attached to.
     if kv_status_attached and kv_uuid != vm.config.uuid:
-       err = handle_stale_attach(vmdk_path, kv_uuid)
-       if err:
-          return err
+       ret_err = handle_stale_attach(vmdk_path, kv_uuid)
+       if ret_err:
+          return ret_err
 
     # NOTE: vSphere is very picky about unit numbers and controllers of virtual
     # disks. Every controller supports 15 virtual disks, and the unit
@@ -896,7 +894,7 @@ def disk_attach(vmdk_path, vm):
     if (disk_slot is None):
         disk_slot = 0  # starting on a fresh controller
         if len(controllers) >= max_scsi_controllers:
-            msg = "Failed to place new disk - out of disk slots and out of slots for new controllers"
+            msg = "Failed to place new disk - The maximum number of supported volumes has been reached."
             logging.error(msg + " VM=%s", vm.config.uuid)
             return err(msg)
 

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -623,11 +623,11 @@ def findDeviceByPath(vmdk_path, vm):
 
 # Find the PCI slot number
 def get_controller_pci_slot(vm, pvscsi, key_offset):
-    if pvscsi[0].slotInfo:
-       return str(pvscsi[0].slotInfo.pciSlotNumber)
+    if pvscsi.slotInfo:
+       return str(pvscsi.slotInfo.pciSlotNumber)
     else:
        # Slot number is got from from the VM config
-       key = 'scsi{0}.pciSlotNumber'.format(pvscsi[0].key -
+       key = 'scsi{0}.pciSlotNumber'.format(pvscsi.key -
                                             key_offset)
        slot = [cfg for cfg in vm.config.extraConfig \
                if cfg.key == key]
@@ -636,7 +636,6 @@ def get_controller_pci_slot(vm, pvscsi, key_offset):
           return slot[0].value
        else:
           return None
-
 
 def dev_info(unit_number, pci_slot_number):
     '''Return a dictionary with Unit/Bus for the vmdk (or error)'''
@@ -795,7 +794,7 @@ def disk_attach(vmdk_path, vm):
                    if type(d) == vim.ParaVirtualSCSIController and
                       d.key == device.controllerKey]
         return dev_info(device.unitNumber,
-                        get_controller_pci_slot(vm, pvsci,
+                        get_controller_pci_slot(vm, pvsci[0],
                                                 offset_from_bus_number))
 
     # Disk isn't attached, make sure we have a PVSCI and add it if we don't
@@ -807,9 +806,10 @@ def disk_attach(vmdk_path, vm):
     if len(pvsci) > 0:
         disk_slot = None  # need to find out
         controller_key = pvsci[0].key
-        pci_slot_number = get_controller_pci_slot(vm, pvsci,
+        pci_slot_number = get_controller_pci_slot(vm, pvsci[0],
                                                   offset_from_bus_number)
     else:
+        
         logging.warning(
             "Warning: PVSCI adapter is missing - trying to add one...")
         disk_slot = 0  # starting on a fresh controller
@@ -817,7 +817,7 @@ def disk_attach(vmdk_path, vm):
             msg = "Failed to place PVSCI adapter - out of bus slots"
             logging.error(msg + " VM=%s", vm.config.uuid)
             return err(msg)
-
+        
         # find empty bus slot for the controller:
         taken = set([c.busNumber for c in controllers])
         avail = set(range(0, max_scsi_controllers)) - taken
@@ -841,31 +841,90 @@ def disk_attach(vmdk_path, vm):
         except vim.fault.VimFault as ex:
             msg=("Failed to add PVSCSI Controller: %s", ex.msg)
             return err(msg)
+            
         # Find the controller just added
         devices = vm.config.hardware.device
         pvsci = [d for d in devices
                  if type(d) == vim.ParaVirtualSCSIController and
                  d.key == controller_key]
-        pci_slot_number = get_controller_pci_slot(vm, pvsci,
+        pci_slot_number = get_controller_pci_slot(vm, pvsci[0],
                                                   offset_from_bus_number)
 
     # Find a slot on the controller, issue attach task and wait for completion
     if not disk_slot:
-        taken = set([dev.unitNumber
+        idx = 0
+           
+        while ((disk_slot is None) and (idx < len(pvsci))):
+            controller_key = pvsci[idx].key
+            taken = set([dev.unitNumber
                      for dev in devices
                      if type(dev) == vim.VirtualDisk and dev.controllerKey ==
                      controller_key])
-        # search in 15 slots, with unit_number 7 reserved for scsi controller
-        availSlots = (set(range(0, 7)) | set(range(8, 16))) - taken
+            # search in 15 slots, with unit_number 7 reserved for scsi controller
+            availSlots = (set(range(0, 7)) | set(range(8, 16))) - taken
+            logging.debug("idx=%d controller_key=%d availSlots=%d", idx, controller_key, len(availSlots))
 
-        if len(availSlots) == 0:
-            msg = "Failed to place new disk - out of disk slots"
-            logging.error(msg + " VM=%s", vm.config.uuid)
-            return err(msg)
+            if len(availSlots) == 0:
+                idx = idx+1
+            else:     
+                disk_slot = availSlots.pop()
+                pci_slot_number = get_controller_pci_slot(vm, pvsci[idx],
+                                                          offset_from_bus_number)
+                 
+                logging.debug("Find an available slot: controller_key = %d slot = %d", controller_key, disk_slot)
 
-        disk_slot = availSlots.pop()
-        logging.debug("controller_key = %d slot = %d", controller_key, disk_slot)
+        # search through all the existing pvscsi controller, and cannot find a slot
+        # try to add another pvscsi controller if possible        
+        if ((disk_slot is None) and (len(availSlots) == 0)):
+            disk_slot = 0  # starting on a fresh controller
+            if len(controllers) >= max_scsi_controllers:
+                msg = "Failed to place new disk - out of disk slots"
+                logging.error(msg + " VM=%s", vm.config.uuid)
+                return err(msg)
+                    
+            # find empty bus slot for the controller:
+            taken = set([c.busNumber for c in controllers])
+            avail = set(range(0, max_scsi_controllers)) - taken
 
+            key = avail.pop()  # bus slot
+            controller_key = key + offset_from_bus_number
+            controller_spec = vim.VirtualDeviceConfigSpec(
+            operation='add',
+            device=vim.ParaVirtualSCSIController(key=controller_key,
+                                                 busNumber=key,
+                                                 sharedBus='noSharing', ), )
+            # changes spec content goes here
+            pvscsi_change = []
+            pvscsi_change.append(controller_spec)
+            spec = vim.vm.ConfigSpec()
+            spec.deviceChange = pvscsi_change
+
+            try:
+                wait_for_tasks(si, [vm.ReconfigVM_Task(spec=spec)])
+            except vim.fault.VimFault as ex:
+                msg=("Failed to add PVSCSI Controller: %s", ex.msg)
+                return err(msg)
+            
+            logging.info("Add a new pvscsi controller, id=%d", controller_key) 
+
+            # get all the pvscsi controller
+            devices = vm.config.hardware.device
+            pvsci = [d for d in devices
+              if type(d) == vim.ParaVirtualSCSIController and
+                 d.key == controller_key]
+
+            new_idx = None  
+            for x in range (0, len(pvsci)):
+                if (pvsci[x].key == controller_key):
+                    new_idx = x
+                    break
+                     
+            # get the pci_slot_number of newly added pvscsi controller  
+            logging.debug("idx for newly added pvscsi controller is %d", new_idx)
+            pci_slot_number = get_controller_pci_slot(vm, pvsci[new_idx],
+                                                          offset_from_bus_number)
+ 
+  
     # add disk as independent, so it won't be snapshotted with the Docker VM
     disk_spec = vim.VirtualDeviceConfigSpec(
         operation='add',


### PR DESCRIPTION
Fixes #38 

The testing are done manually with simple scripts which create docker volume/run docker 
container with given volume/destroy docker volume.

Before this fix, since it can only allocate 1 PVSCSI controller, the maximum number of disks which can attach to the VM is 15.
In the test, we create 15 volumes nameed "testvol0" ... "testvol15", and try to create docker container with those 15 volumes. Attaching volume "testvol0"... "testvol14" succeeded, but attaching "testvol15" failed since no available disk slot left.

```
...
08/05/16 14:36:47 34727 [photon] [INFO   ] Attaching /vmfs/volumes/datastore1/dockvols/testvol15.vmdk as independent_persistent
08/05/16 14:36:47 34727 [photon] [ERROR  ] Failed to place new disk - out of disk slots VM=564dcc0a-3711-142c-961f-cdd59ba48e63
08/05/16 14:36:47 34727 [photon] [INFO   ] executeRequest 'attach' completed with ret={u'Error': 'Failed to place new disk - out of disk slots'}
08/05/16 14:36:47 34727 [photon] [INFO   ] *** detachVMDK: /vmfs/volumes/datastore1/dockvols/testvol15.vmdk from photon VM uuid = 564dcc0a-3711-142c-961f-cdd59ba48e63
08/05/16 14:36:47 34727 [photon] [WARNING] *** Detach failed: disk=/vmfs/volumes/datastore1/dockvols/testvol15.vmdk not found. VM=564dcc0a-3711-142c-961f-cdd59ba48e63
```
 
With this fix, more than one PVSCSI controller can be created if needed. When try to search 
an available disk slot, it will try to search all the existing PVSCSI controllers instead of just the
first one.

* Configuration:
Before attaching any disk, we have 1 PVSCSI controller with controller_id = 1001, and we also have a LSI controller 

Step 1: attach 15 disks ("t1" ... "t15")

Step2: attach another 15 disks ("t16 ... "t30")
A new PVSCSI controller with controller_id=1002 is created
```
...
08/06/16 17:17:49 84969 [photon1] [INFO   ] Add a new pvscsi controller, id=1002
08/06/16 17:17:49 84969 [photon1] [DEBUG  ] idx for newly added pvscsi controller is 0
08/06/16 17:17:50 84969 [photon1] [DEBUG  ] Set status=attached disk=/vmfs/volumes/datastore1/dockvols/t16.vmdk VM name=photon1 uuid=564d89a6-e012-61b4-6175-a7f1ddc3c6b9
08/06/16 17:17:50 84969 [photon1] [INFO   ] Disk /vmfs/volumes/datastore1/dockvols/t16.vmdk successfully attached. controller pci_slot_number=160, disk_slot=0
08/06/16 17:17:50 84969 [photon1] [INFO   ] executeRequest 'attach' completed with ret={'ControllerPciSlotNumber': '160', 'Unit': '0'}
```
Step 3: attach another 15 disks  ("t31" .. "t45")
A new PVSCSI controller is created with controller_id = 1003
```
....
08/06/16 17:22:04 84969 [photon1] [DEBUG  ] idx=0 controller_key=1001 availSlots=0
08/06/16 17:22:04 84969 [photon1] [DEBUG  ] idx=1 controller_key=1002 availSlots=0
08/06/16 17:22:05 84969 [photon1] [INFO   ] Add a new pvscsi controller, id=1003
08/06/16 17:22:05 84969 [photon1] [DEBUG  ] idx for newly added pvscsi controller is 0
08/06/16 17:22:05 84969 [photon1] [DEBUG  ] Set status=attached disk=/vmfs/volumes/datastore1/dockvols/t31.vmdk VM name=photon1 uuid=564d89a6-e012-61b4-6175-a7f1ddc3c6b9
08/06/16 17:22:05 84969 [photon1] [INFO   ] Disk /vmfs/volumes/datastore1/dockvols/t31.vmdk successfully attached. controller pci_slot_number=256, disk_slot=0
08/06/16 17:22:05 84969 [photon1] [INFO   ] executeRequest 'attach' completed with ret={'ControllerPciSlotNumber': '256', 'Unit': '0'}
...
```

Step4:
  There is no slot left to add another PVSCSI controller, and no disk slot available in any existing PVSCSI controller
Try to add another disk, and it failed as expected
```
08/06/16 17:23:22 84969 [photon1] [DEBUG  ] lib.vmci_get_one_op returns 4, buffer '{"cmd":"attach","details":{"Name":"t46"}}'
08/06/16 17:23:22 84969 [photon1] [DEBUG  ] get_datastore_name: path=57473702-8b550986-70c0-000c290799f4 name=['datastore1']
08/06/16 17:23:22 84969 [photon1] [DEBUG  ] Found /vmfs/volumes/datastore1/dockvols, returning
08/06/16 17:23:22 84969 [photon1] [INFO   ] *** attachVMDK: /vmfs/volumes/datastore1/dockvols/t46.vmdk to photon1 VM uuid = 564d89a6-e012-61b4-6175-a7f1ddc3c6b9
08/06/16 17:23:22 84969 [photon1] [INFO   ] Attaching /vmfs/volumes/datastore1/dockvols/t46.vmdk as independent_persistent
08/06/16 17:23:22 84969 [photon1] [DEBUG  ] findDeviceByPath: Looking for device /vmfs/volumes/datastore1/dockvols/t46.vmdk
08/06/16 17:23:22 84969 [photon1] [DEBUG  ] idx=0 controller_key=1001 availSlots=0
08/06/16 17:23:22 84969 [photon1] [DEBUG  ] idx=1 controller_key=1002 availSlots=0
08/06/16 17:23:22 84969 [photon1] [DEBUG  ] idx=2 controller_key=1003 availSlots=0
08/06/16 17:23:22 84969 [photon1] [ERROR  ] Failed to place new disk - out of disk slots VM=564d89a6-e012-61b4-6175-a7f1ddc3c6b9
08/06/16 17:23:22 84969 [photon1] [INFO   ] executeRequest 'attach' completed with ret={u'Error': 'Failed to place new disk - out of disk slots'}

```


