### PR TITLE
Support a read-only option to vsphere volumes to mount volumes as read-only on container run.

### DIFF
--- a/docs/misc/vmdkops-admin-cli-spec.md
+++ b/docs/misc/vmdkops-admin-cli-spec.md
@@ -121,6 +121,20 @@ Show any interesting information about the service. This includes file paths of 
 information, and PID of running service. A simple example is shown here, although it's possible
 that the exact format may be somewhat different.
 
+# Set
+Modify attribute settings on a given volume. The volume is identified by its full path on the datastore,
+for example if the volume name is `container-vol` then the volume is specified as "/vmfs/volumes/<datastore>/dockvols/container-vol.vmdk".
+The attributes to set/modify are specified as a comma separated list as "<attr1>=<value>, <attr2>=<value>....". For example,
+a command line would look like this.
+
+```
+$ vmdkops-admin set --volume=<full path of volume> --options="<attr1>=<value>, <attr2>=<value>, ..."
+```
+
+The volume attributes are set and take effect only the next time the volume attached to a VM. The changes do not impact any VM
+thats currently using the volume. For the present, only the "access" attribute is supported to be modified via this command, and
+can be set to either of the allowed values "read-only" or "read-write".
+
 ```
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py status
 Version: 1.0.0-0.0.1

--- a/docs/user-guide/docker-volume-cli.md
+++ b/docs/user-guide/docker-volume-cli.md
@@ -54,3 +54,11 @@ Currently the following are supported
 
 1. [persistent](http://cormachogan.com/2013/04/16/what-are-dependent-independent-disks-persistent-and-non-persisent-modes/): If the VMDK is attached as persistent it will be part of a VM snapshot. If a VM snapshot has been taken while the Docker volume is attached to a VM, the Docker volume then continues to be attached to the VM that was snapshotted.
 2. [independent_persistent](http://cormachogan.com/2013/04/16/what-are-dependent-independent-disks-persistent-and-non-persisent-modes/): If the VMDK is attached as independent_persistent it will not be part of a VM snapshot. The Docker volume can be attached to any VM that can access the datastore independent of snapshots.
+
+### access
+```
+docker volume create --driver=vmdk --name=MyVolume -o access=read-only -o diskformat=thin
+docker volume create --driver=vmdk --name=MyVolume -o access=read-write -o diskformat=thin (default)
+```
+
+The access mode determines if the volume is modifiable by containers in a VM. The access mode allows to first create a volume with write access and initialize it with binary images, libraries (for exmple), and subsequently change the access to "read-only" (via the admin CLI). Thereby, creating content sharable by all containers in a VM.

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -255,6 +255,20 @@ def commands():
         'status': {
             'func': status,
             'help': 'Show the status of the vmdk_ops service'
+        },
+        'set': {
+            'func': set_vol_opts,
+            'help': 'Edit settings for a given volume',
+            'args': {
+                '--volume': {
+                    'help': 'Full path of the volume',
+                    'required': True
+                },
+                '--options': {
+                    'help': 'Options (specifically, access) to be set on the volume.',
+                    'required': True
+                }
+            }
         }
     }
 
@@ -269,12 +283,12 @@ def create_parser():
 def add_subparser(parser, cmds_dict):
     """ Recursively add subcommand parsers based on a dictionary of commands """
     subparsers = parser.add_subparsers()
-    for cmd, attributes in cmds_dict.iteritems():
+    for cmd, attributes in cmds_dict.items():
         subparser = subparsers.add_parser(cmd, help=attributes['help'])
         if 'func' in attributes:
             subparser.set_defaults(func=attributes['func'])
         if 'args' in attributes:
-            for arg, opts in attributes['args'].iteritems():
+            for arg, opts in attributes['args'].items():
                 opts = build_argparse_opts(opts)
                 subparser.add_argument(arg, **opts)
         if 'cmds' in attributes:
@@ -485,7 +499,7 @@ def policy_ls(args):
         else:
             used_policies[policy_name] = 1
 
-    for name, content in policies.iteritems():
+    for name, content in policies.items():
         if name in used_policies:
             active = 'In use by {0} volumes'.format(used_policies[name])
         else:
@@ -513,6 +527,14 @@ def status(args):
     print("LogConfigFile: {0}".format(log_config.LOG_CONFIG_FILE))
     print("LogFile: {0}".format(log_config.LOG_FILE))
     print("LogLevel: {0}".format(log_config.get_log_level()))
+
+
+def set_vol_opts(args):
+    set_ok = vmdk_ops.edit_vol_opts(args.volume, args.options) 
+    if set_ok:
+        print('Successfully updated settings for : {0}'.format(args.volume))
+    else:
+        print('Failed to update {0} for {1}.'.format(args.options, args.volume))
 
 
 VMDK_OPSD = '/etc/init.d/vmdk-opsd'

--- a/esx_service/cli/vmdkops_admin_test.py
+++ b/esx_service/cli/vmdkops_admin_test.py
@@ -124,6 +124,27 @@ class TestParsing(unittest.TestCase):
         args = self.parser.parse_args(['status'])
         self.assertEqual(args.func, vmdkops_admin.status)
 
+    def test_set_no_args(self):
+        self.assert_parse_error('set')
+
+    def test_set_no_volname(self):
+        self.assert_parse_error('set --options="access=read-only"')
+
+    def test_set_invalid_options(self):
+        self.assert_parse_error('set --options="size=10gb"')
+
+    def test_set_invalid_options(self):
+        self.assert_parse_error('set --options="acces=read-write"')
+
+    def test_set_no_options(self):
+        self.assert_parse_error('set --volume=volume_name')
+
+    def test_set(self):
+        args = self.parser.parse_args('set --volume=vol_name --options="access=read-only"'.split())
+        self.assertEqual(args.func, vmdkops_admin.set_vol_opts)
+        self.assertEqual(args.volume, 'vol_name')
+        self.assertEqual(args.options, '"access=read-only"')
+
     # Usage is always printed on a parse error. It's swallowed to prevent clutter.
     def assert_parse_error(self, command):
         with open('/dev/null', 'w') as f:

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -202,8 +202,10 @@ def validate_opts(opts, vmdk_path):
      * vsan-policy-name - The name of an existing policy to use
      * diskformat - The allocation format of allocated disk
     """
-    valid_opts = [kv.SIZE, kv.VSAN_POLICY_NAME, kv.DISK_ALLOCATION_FORMAT, kv.ATTACH_AS]
-    defaults = [kv.DEFAULT_DISK_SIZE, kv.DEFAULT_VSAN_POLICY, kv.DEFAULT_ALLOCATION_FORMAT, kv.DEFAULT_ATTACH_AS]
+    valid_opts = [kv.SIZE, kv.VSAN_POLICY_NAME, kv.DISK_ALLOCATION_FORMAT, kv.ATTACH_AS, kv.ACCESS]
+    defaults = [kv.DEFAULT_DISK_SIZE, kv.DEFAULT_VSAN_POLICY,\
+                kv.DEFAULT_ALLOCATION_FORMAT, kv.DEFAULT_ATTACH_AS,\
+                kv.DEFAULT_ACCESS]
     invalid = frozenset(opts.keys()).difference(valid_opts)
     if len(invalid) != 0:
         msg = 'Invalid options: {0} \n'.format(list(invalid)) \
@@ -219,6 +221,8 @@ def validate_opts(opts, vmdk_path):
         validate_disk_allocation_format(opts[kv.DISK_ALLOCATION_FORMAT])
     if kv.ATTACH_AS in opts:
         validate_attach_as(opts[kv.ATTACH_AS])
+    if kv.ACCESS in opts:
+        validate_access(opts[kv.ACCESS])
 
 
 def validate_size(size):
@@ -259,6 +263,15 @@ def validate_attach_as(attach_type):
     if not attach_type in kv.ATTACH_AS_TYPES :
         raise ValidationError("Attach type '{0}' is not supported."
                               " Valid options are: {1}".format(attach_type, kv.ATTACH_AS_TYPES))
+
+def validate_access(access_type):
+    """
+    Ensure that we recognize the access type
+    """
+    if not access_type in kv.ACCESS_TYPES :
+       raise ValidationError("Access type '{0}' is not supported."
+                             " Valid options are: {1}".format(access_type,
+                                                              kv.ACCESS_TYPES))
 
 # Returns the UUID if the vmdk_path is for a VSAN backed.
 def get_vsan_uuid(vmdk_path):
@@ -368,11 +381,21 @@ def vol_info(vol_meta, vol_size_info, datastore):
 
     if kv.ATTACHED_VM_NAME in vol_meta:
        vinfo[ATTACHED_TO_VM] = vol_meta[kv.ATTACHED_VM_NAME]
-    if kv.VSAN_POLICY_NAME in vol_meta:
-       vinfo[kv.kv.VSAN_POLICY_NAME] = vol_meta[kv.kv.VSAN_POLICY_NAME]
-    if kv.VOL_OPTS in vol_meta and \
-       kv.DISK_ALLOCATION_FORMAT in vol_meta[kv.VOL_OPTS]:
-       vinfo[kv.DISK_ALLOCATION_FORMAT] = vol_meta[kv.VOL_OPTS][kv.DISK_ALLOCATION_FORMAT]
+    if kv.VOL_OPTS in vol_meta:
+       if kv.VSAN_POLICY_NAME in vol_meta[kv.VOL_OPTS]:
+          vinfo[kv.kv.VSAN_POLICY_NAME] = vol_meta[kv.VOL_OPTS][kv.VSAN_POLICY_NAME]
+       if kv.DISK_ALLOCATION_FORMAT in vol_meta[kv.VOL_OPTS]:
+          vinfo[kv.DISK_ALLOCATION_FORMAT] = vol_meta[kv.VOL_OPTS][kv.DISK_ALLOCATION_FORMAT]
+       else:
+          vinfo[kv.DISK_ALLOCATION_FORMAT] = kv.DEFAULT_ALLOCATION_FORMAT
+       if kv.ATTACH_AS in vol_meta[kv.VOL_OPTS]:
+          vinfo[kv.ATTACH_AS] = vol_meta[kv.VOL_OPTS][kv.ATTACH_AS]
+       else:
+          vinfo[kv.ATTACH_AS] = kv.DEFAULT_ATTACH_AS
+       if kv.ACCESS in vol_meta[kv.VOL_OPTS]:
+          vinfo[kv.ACCESS] = vol_meta[kv.VOL_OPTS][kv.ACCESS]
+       else:
+          vinfo[kv.ACCESS] = kv.DEFAULT_ACCESS
 
     return vinfo
 
@@ -944,6 +967,35 @@ def disk_detach_int(vmdk_path, vm, device):
     logging.info("Disk detached %s", vmdk_path)
     return None
 
+
+# Edit settings for a volume identified by its full path
+def set_vol_opts(vmdk_path, options):
+    # Create a dict of the options, the options are provided as
+    # "access=read-only" and we get a dict like {'access': 'read-only'}
+    opts_list = "".join(options.replace("=", ":").split())
+    opts = dict(i.split(":") for i in opts_list.split(","))
+
+    # For now only allow resetting the access mode.
+    valid_opts = [kv.ACCESS]
+    invalid = frozenset(opts.keys()).difference(valid_opts)
+    if len(invalid) != 0:
+        msg = 'Invalid options: {0} \n'.format(list(invalid)) \
+               + 'Options that can be edited: ' \
+               + '{0}'.format(list(valid_opts))
+        raise ValidationError(msg)
+
+    if not opts[kv.ACCESS] in kv.ACCESS_TYPES:
+       msg = 'Invalid option value {0}.\n'.format(opts[kv.ACCESS]) +\
+             'Supported values are {0}.\n'.format(kv.ACCESS_TYPES)
+       logging.warning(msg)
+       return False
+
+    vol_meta = kv.getAll(vmdk_path)
+    if vol_meta:
+       vol_meta[kv.VOL_OPTS][kv.ACCESS] = opts[kv.ACCESS]
+       return kv.setAll(vmdk_path, vol_meta)
+
+    return False
 
 def signal_handler_stop(signalnum, frame):
     logging.warn("Received signal num: ' %d '", signalnum)

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -75,6 +75,9 @@ class VmdkCreateRemoveTestCase(unittest.TestCase):
 
     volName = "vol_UnitTest_Create"
     badOpts = {u'policy': u'good', volume_kv.SIZE: u'12unknown', volume_kv.DISK_ALLOCATION_FORMAT: u'5disk'}
+    invalid_access_choice = {volume_kv.ACCESS: u'only-read'}
+    invalid_access_opt = {u'acess': u'read-write'}
+    valid_access_opt = {volume_kv.ACCESS: 'read-only'}
     name = ""
     vm_name = 'test-vm'
 
@@ -119,7 +122,32 @@ class VmdkCreateRemoveTestCase(unittest.TestCase):
         logging.info(err)
         self.assertNotEqual(err, None, err)
 
+    def testAccessOpts(self):
+        err = vmdk_ops.createVMDK(vm_name=self.vm_name,
+                                  vmdk_path=self.name,
+                                  vol_name=self.volName,
+                                  opts=self.invalid_access_choice)
+        logging.info(err)
+        self.assertNotEqual(err, None, err)
 
+        err = vmdk_ops.createVMDK(vm_name=self.vm_name,
+                                  vmdk_path=self.name,
+                                  vol_name=self.volName,
+                                  opts=self.invalid_access_opt)
+        logging.info(err)
+        self.assertNotEqual(err, None, err)
+
+        err = vmdk_ops.createVMDK(vm_name=self.vm_name,
+                                  vmdk_path=self.name,
+                                  vol_name=self.volName,
+                                  opts=self.valid_access_opt)
+        logging.info(err)
+        self.assertEqual(err, None, err)
+
+        err = vmdk_ops.removeVMDK(self.name)
+        logging.info(err)
+        self.assertEqual(err, None, err)
+        
     @unittest.skipIf(not vsan_info.get_vsan_datastore(),
                     "VSAN is not found - skipping vsan_info tests")
     def testPolicyUpdate(self):

--- a/esx_service/volume_kv.py
+++ b/esx_service/volume_kv.py
@@ -72,6 +72,13 @@ DEPENDENT   = 'persistent' # does participated in VM snapshot
 DEFAULT_ATTACH_AS = INDEPENDENT
 ATTACH_AS_TYPES = [INDEPENDENT, DEPENDENT]
 
+# Access types
+ACCESS = 'access'
+ACCESS_READONLY = 'read-only'
+ACCESS_READWRITE = 'read-write'
+DEFAULT_ACCESS = ACCESS_READWRITE
+ACCESS_TYPES = [ACCESS_READWRITE, ACCESS_READONLY]
+
 # Create a kv store object for this volume identified by vol_path
 # Create the side car or open if it exists.
 def init():

--- a/vmdk_plugin/refcnt.go
+++ b/vmdk_plugin/refcnt.go
@@ -283,7 +283,16 @@ func (r refCountsMap) syncMountsWithRefCounters(d *vmdkDriver) {
 				// but not using files on the volumes, and the volume is (manually?)
 				// unmounted. Unlikely but possible. Mount !
 				log.WithFields(f).Warning("Initiating recovery mount. ")
-				_, err := d.mountVolume(vol)
+				isReadOnly := false
+				status, err := d.ops.Get(vol)
+				if err != nil {
+					log.Warning("Unable to get volume status - mounting as read-only")
+					isReadOnly = true
+				}
+				if status["access"] == "read-only" {
+					isReadOnly = true
+				}
+				_, err = d.mountVolume(vol, isReadOnly)
 				if err != nil {
 					log.Warning("Failed to mount - manual recovery may be needed")
 				}

--- a/vmdk_plugin/utils/fs/fs.go
+++ b/vmdk_plugin/utils/fs/fs.go
@@ -55,13 +55,17 @@ func Mkdir(path string) error {
 }
 
 // Mount the filesystem (`fs`) on the device at the given mount point.
-func Mount(mountpoint string, fs string, device string) error {
+func Mount(mountpoint string, fs string, device string, isReadOnly bool) error {
 	log.WithFields(log.Fields{
 		"device":     device,
 		"mountpoint": mountpoint,
 	}).Debug("Calling syscall.Mount() ")
 
-	err := syscall.Mount(device, mountpoint, fs, 0, "")
+	flags := 0
+	if isReadOnly {
+		flags = syscall.MS_RDONLY
+	}
+	err := syscall.Mount(device, mountpoint, fs, uintptr(flags), "")
 	if err != nil {
 		return fmt.Errorf("Failed to mount device %s at %s: %s", device, mountpoint, err)
 	}


### PR DESCRIPTION
Added an option to specify an access mode on volume creation, the volume is mounted always as read-only when attached to a container. Which is ok only as long as there is a way to attach the volume to the VM and be able to init. the volume with data. Perfect for pre-initialized volumes being imported into the volume repo on the vsphere side (issue #442 ). 

Tested as below:

1. Create a volume with access=read-only and mount it. Verify it mounts read-only on the client.

administrator@hte-1s-eng-dhcp98:~/vpl-add-ro-vols/docker-volume-vsphere$ docker volume inspect testvol-4
[
    {
        "Name": "testvol-4",
        "Driver": "vmdk",
        "Mountpoint": "/mnt/vmdk/testvol-4",
        "Status": {
            "access": "read-only",
            "capacity": {
                "allocated": "14.0MB",
                "size": "100.0MB"
            },
            "created": "Mon Aug 22 07:27:35 2016",
            "created by VM": "2",
            "datastore": "bigone",
            "status": "detached"
        },
        "Labels": {},
        "Scope": "global"
    }
]
administrator@hte-1s-eng-dhcp98:~/vpl-add-ro-vols/docker-volume-vsphere$ docker run --rm -it -v testvol-4:/data busybox
/ # cd /data
/data # >sdafhwef
sh: can't create sdafhwef: Read-only file system
/data #

And /proc/mounts shows the read-only mount,
/dev/disk/by-path/pci-0000:13:00.0-scsi-0:0:0:0 /mnt/vmdk/testvol-4 ext2 ro,relatime 0 0

2. Try using an invalid access type:

$ docker volume create --driver=vmdk --name=testvol-5 -o "access=access1"
Error response from daemon: create testvol-5: VolumeDriver.Create: Access type 'access1' is not supported. Valid options are: ['read=write', 'read-only']

3. Verify default behavior is to create a read-write volume

$ docker volume create -d vmdk --name testvol-6
testvol-6

$ docker volume inspect testvol-6
[
    {
        "Name": "testvol-6",
        "Driver": "vmdk",
        "Mountpoint": "/mnt/vmdk/testvol-6",
        "Status": {
            "access": "read-write",
            "capacity": {
                "allocated": "14.0MB",
                "size": "100.0MB"
            },
            "created": "Mon Aug 22 11:51:26 2016",
            "created by VM": "2",
            "datastore": "bigone",
            "status": "detached"
        },
        "Labels": {},
        "Scope": "global"
    }
]
