### PR TITLE
Add automated test for PVSCSI controller controller/disk create()

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -927,7 +927,7 @@ def disk_attach(vmdk_path, vm):
                                                         offset_from_bus_number)
 
         if (ret_err):
-           return ret_err    
+            return ret_err    
             
         # Find the controller just added
         devices = vm.config.hardware.device

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -661,7 +661,7 @@ def get_controller_pci_slot(vm, pvscsi, key_offset):
     else:
        # Slot number is got from from the VM config
        key = 'scsi{0}.pciSlotNumber'.format(pvscsi.key -
-                                            key_offset)
+                                            key_offset)                
        slot = [cfg for cfg in vm.config.extraConfig \
                if cfg.key == key]
        # If the given controller exists
@@ -927,7 +927,7 @@ def disk_attach(vmdk_path, vm):
                                                         offset_from_bus_number)
 
         if (ret_err):
-            return ret_err    
+           return ret_err    
             
         # Find the controller just added
         devices = vm.config.hardware.device
@@ -936,7 +936,7 @@ def disk_attach(vmdk_path, vm):
                  d.key == controller_key]
         pci_slot_number = get_controller_pci_slot(vm, pvsci[0],
                                                   offset_from_bus_number)
-        logging.info("Added a PVSCSI controller, controller_key=%d pci_slot_number=%d",
+        logging.info("Added a PVSCSI controller, controller_key=%d pci_slot_number=%s",
                       controller_key, pci_slot_number)
     
     # add disk as independent, so it won't be snapshotted with the Docker VM

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -271,7 +271,7 @@ class VmdkAttachDetachTestCase(unittest.TestCase):
         self.cleanup()
         
         if (not self.datastore_name):
-            datastores = [d for d in vmdk_utils.get_datastores()]
+            datastores = vmdk_utils.get_datastores()
             datastore = datastores[0]
             if (not datastore):
                 logging.error("Cannot find a valid datastore")


### PR DESCRIPTION
Fixes #581 
Add automated test for PVSCSI controller controller/disk create()
The following is the steps and result of this automated test:


- Setup:

(a) do cleanup if needed (remove VM and VMDK files).  Those cleanup should have been done
in the tear down path of last run. But if for some reason, the cleanup did not happen in the tear
down path of last run, we can do it here. 
```
8/09/16 03:52:26 353502 [MainThread] [INFO   ] Directory used in test - /vmfs/volumes/datastore1/dockvols
08/09/16 03:52:26 353502 [MainThread] [DEBUG  ] VMDKAttachDetachTest setUp path =/vmfs/volumes/datastore1/dockvols
08/09/16 03:52:26 353502 [MainThread] [DEBUG  ] Found: VM test-vm
08/09/16 03:52:26 353502 [MainThread] [DEBUG  ] Attempting to power off test-vm
08/09/16 03:52:27 353502 [MainThread] [DEBUG  ] Trying to destroy VM test-vm
08/09/16 03:52:27 353502 [MainThread] [INFO   ] *** removeVMDK: /vmfs/volumes/57473702-8b550986-70c0-000c290799f4/dockvols/VmdkAttachDetachTestVol1.vmdk
08/09/16 03:52:27 353502 [MainThread] [DEBUG  ] Running cmd /sbin/vmkfstools -U  /vmfs/volumes/57473702-8b550986-70c0-000c290799f4/dockvols/VmdkAttachDetachTestVol1.vmdk
...

8/09/16 03:52:34 353502 [MainThread] [DEBUG  ] Running cmd /sbin/vmkfstools -U  /vmfs/volumes/57473702-8b550986-70c0-000c290799f4/dockvols/VmdkAttachDetachTestVol61.vmdk
```
 (b) create a dummy vm and 61 VMDK files

```
08/09/16 03:52:34 353502 [MainThread] [DEBUG  ] Found: VM test-vm
08/09/16 03:52:34 353502 [MainThread] [DEBUG  ] Attempting to power on test-vm
08/09/16 03:52:34 353502 [MainThread] [INFO   ] *** createVMDK: /vmfs/volumes/datastore1/dockvols/VmdkAttachDetachTestVol1.vmdk opts = {}
08/09/16 03:52:34 353502 [MainThread] [DEBUG  ] Setting vmdk size to 100mb for /vmfs/volumes/datastore1/dockvols/VmdkAttachDetachTestVol1.vmdk
08/09/16 03:52:34 353502 [MainThread] [DEBUG  ] Setting vmdk disk allocation format to thin for /vmfs/volumes/datastore1/dockvols/VmdkAttachDetachTestVol1.vmdk
08/09/16 03:52:34 353502 [MainThread] [DEBUG  ] Running cmd /sbin/vmkfstools -d thin -c 100mb /vmfs/volumes/datastore1/dockvols/VmdkAttachDetachTestVol1.vmdk
08/09/16 03:52:35 353502 [MainThread] [DEBUG  ] Running cmd /usr/lib/vmware/vmdkops/bin/mkfs.ext4 -qF -L  VmdkAttachDetachTestVol1 /vmfs/volumes/datastore1/dockvols/VmdkAttachDetachTestVol1-flat.vmdk 
...
08/09/16 03:52:48 353502 [MainThread] [DEBUG  ] Running cmd /sbin/vmkfstools -d thin -c 100mb /vmfs/volumes/datastore1/dockvols/VmdkAttachDetachTestVol61.vmdk
08/09/16 03:52:48 353502 [MainThread] [DEBUG  ] Running cmd /usr/lib/vmware/vmdkops/bin/mkfs.ext4 -qF -L  VmdkAttachDetachTestVol61 /vmfs/volumes/datastore1/dockvols/VmdkAttachDetachTestVol61-flat.vmdk
```

- call disk_attach to to attach 60 VMDK files, which all should succeed

```
08/09/16 03:52:48 353502 [MainThread] [DEBUG  ] Start VMDKAttachDetachTest

08/09/16 03:52:49 353502 [MainThread] [INFO   ] Disk /vmfs/volumes/datastore1/dockvols/VmdkAttachDetachTestVol1.vmdk successfully attached. controller pci_slot_number=160, disk_slot=0

...

08/09/16 03:53:52 353502 [MainThread] [INFO   ] Disk /vmfs/volumes/datastore1/dockvols/VmdkAttachDetachTestVol60.vmdk successfully attached. controller pci_slot_number=256, disk_slot=15
08/09/16 03:53:52 353502 [MainThread] [INFO   ] Attaching /vmfs/volumes/datastore1/dockvols/VmdkAttachDetachTestVol61.vmdk as independent_persistent
```

- call disk_attach to attach 61th VMDK file, which should fail since the maximum number of support disks has been reached
```
08/09/16 03:53:52 353502 [MainThread] [INFO   ] Attaching /vmfs/volumes/datastore1/dockvols/VmdkAttachDetachTestVol61.vmdk as independent_persistent
08/09/16 03:53:52 353502 [MainThread] [DEBUG  ] findDeviceByPath: Looking for device /vmfs/volumes/datastore1/dockvols/VmdkAttachDetachTestVol61.vmdk
...
08/09/16 03:53:52 353502 [MainThread] [ERROR  ] Failed to place new disk - The maximum number of supported volumes has been reached. VM=564d6f56-d276-99a1-33e3-1db1f20a
```
- call disk_attach to detach first 60VMDK files, which all should succeed
```
08/09/16 03:53:54 353502 [MainThread] [INFO   ] Disk detached /vmfs/volumes/datastore1/dockvols/VmdkAttachDetachTestVol1.vmdk

...

08/09/16 03:54:18 353502 [MainThread] [INFO   ] Disk detached /vmfs/volumes/datastore1/dockvols/VmdkAttachDetachTestVol60.vmdk
```
- Tear down: do cleanup (remove the vm and all the VMDK files)
```
08/09/16 03:54:18 353502 [MainThread] [DEBUG  ] VMDKAttachDetachTest tearDown path
08/09/16 03:54:18 353502 [MainThread] [DEBUG  ] Found: VM test-vm
08/09/16 03:54:18 353502 [MainThread] [DEBUG  ] Attempting to power off test-vm
08/09/16 03:54:19 353502 [MainThread] [DEBUG  ] Trying to destroy VM test-vm
08/09/16 03:54:19 353502 [MainThread] [INFO   ] *** removeVMDK: /vmfs/volumes/57473702-8b550986-70c0-000c290799f4/dockvols/VmdkAttachDetachTestVol1.vmdk

...

/vmfs/volumes/57473702-8b550986-70c0-000c290799f4/dockvols/VmdkAttachDetachTestVol61.vmdk
```