### PR TITLE
Fixed to decode result from cmd output for ls.

### DIFF
--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -439,7 +439,8 @@ def get_vmdk_size_info(path):
     try:
         cmd = "vmkfstools --extendedstatinfo {0}".format(path).split()
         output = subprocess.check_output(cmd)
-        lines = output.split('\n')
+        result = output.decode('utf-8')
+        lines = result.split('\n')
         capacity_in_bytes = lines[0].split()[2]
         used_in_bytes = lines[1].split()[2]
         return {'capacity': human_readable(int(capacity_in_bytes)),


### PR DESCRIPTION
Small change to decode command output before using for ls. Tested with the change:

 python ./vmdkops_admin.py ls
Volume      Datastore  Created By VM        Created                   Attached To VM       Policy  Capacity  Used
----------  ---------  -------------------  ------------------------  -------------------  ------  --------  -------
dvol_2      bigone     2                    Tue Aug  2 04:49:32 2016  detached             N/A     100.00MB  14.00MB
dvol_3      bigone     2                    Wed Aug  3 05:14:12 2016  detached             N/A     100.00MB  14.00MB
dvol_4      bigone     2                    Wed Aug  3 05:14:15 2016  detached             N/A     100.00MB  14.00MB
dvol_5      bigone     2                    Thu Aug  4 04:24:38 2016  detached             N/A     100.00MB  14.00MB
......... ...