### PR TITLE
Fixes admin cli to print the help message when no args provided.

### DIFF
--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -36,7 +36,8 @@ NOT_AVAILABLE = 'N/A'
 def main():
     kv.init()
     args = parse_args()
-    args.func(args)
+    if args:
+       args.func(args)
 
 
 def commands():
@@ -306,7 +307,11 @@ def build_argparse_opts(opts):
 
 def parse_args():
     parser = create_parser()
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args != argparse.Namespace():
+       return args
+    else:
+       parser.print_help()
 
 
 def comma_seperated_string(string):


### PR DESCRIPTION
Print the help message if no args are provided, below is the message we get if the admin CLI is run without args.

python ./vmdkops_admin.py
usage: vmdkops_admin.py [-h] {ls,status,role,policy,set} ...

Manage VMDK Volumes

positional arguments:
  {ls,status,role,policy,set}
    ls                  List volumes
    status              Show the status of the vmdk_ops service
    role                Administer and monitor volume access control
    policy              Configure and display storage policy information
    set                 Edit settings for a given volume

optional arguments:
  -h, --help            show this help message and exit
