### PR TITLE
Fixes to admin CLI set command

### DIFF
--- a/docs/misc/vmdkops-admin-cli-spec.md
+++ b/docs/misc/vmdkops-admin-cli-spec.md
@@ -122,13 +122,13 @@ information, and PID of running service. A simple example is shown here, althoug
 that the exact format may be somewhat different.
 
 # Set
-Modify attribute settings on a given volume. The volume is identified by its full path on the datastore,
-for example if the volume name is `container-vol` then the volume is specified as "/vmfs/volumes/<datastore>/dockvols/container-vol.vmdk".
+Modify attribute settings on a given volume. The volume is identified by its name and datastore, 
+for example if the volume name is `container-vol` then the volume is specified as "container-vol@datastore-name".
 The attributes to set/modify are specified as a comma separated list as "<attr1>=<value>, <attr2>=<value>....". For example,
 a command line would look like this.
 
 ```
-$ vmdkops-admin set --volume=<full path of volume> --options="<attr1>=<value>, <attr2>=<value>, ..."
+$ vmdkops-admin set --volume=<volume@datastore> --options="<attr1>=<value>, <attr2>=<value>, ..."
 ```
 
 The volume attributes are set and take effect only the next time the volume attached to a VM. The changes do not impact any VM

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -261,7 +261,7 @@ def commands():
             'help': 'Edit settings for a given volume',
             'args': {
                 '--volume': {
-                    'help': 'Full path of the volume',
+                    'help': 'Volume to set options for, specified as "volume@datastore".',
                     'required': True
                 },
                 '--options': {
@@ -531,7 +531,7 @@ def status(args):
 
 
 def set_vol_opts(args):
-    set_ok = vmdk_ops.edit_vol_opts(args.volume, args.options) 
+    set_ok = vmdk_ops.set_vol_opts(args.volume, args.options) 
     if set_ok:
         print('Successfully updated settings for : {0}'.format(args.volume))
     else:


### PR DESCRIPTION
Fixed the call from admin cli to vmdk_ops. Also updated to use volume@datastore as the way to specify the volume to the set command.

Testing:

/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py set --volume=dvol_2@bigone -options=access=read-only
Successfully updated settings for : dvol_2@bigone


/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py set --volume=dvol_2@bigoe --options=access=read-only
WARNING:root:Failed to create /vmfs/volumes/bigoe/dockvols
WARNING:root:Failed to get datastore path None
Failed to update access=read-only for dvol_2@bigoe.

/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py set --volume=dvol_2 --options=access=read-only
WARNING:root:Invalid datastore 'None'.

Failed to update access=read-only for dvol_2.


/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py set --volume=dvol_@bigone --options=access=read-only
WARNING:root:Volume dvol_ not found.
Failed to update access=read-only for dvol_@bigone.
