### PR TITLE
Increase the range of ports tried for binding

### DIFF
--- a/esx_service/vmci/vmci_client.c
+++ b/esx_service/vmci/vmci_client.c
@@ -53,7 +53,7 @@ typedef struct be_request {
 
 #define MAXBUF 1024 * 1024 // Safety limit. We do not expect json string > 1M
 #define MAX_CLIENT_PORT 1023 // Last privileged port
-#define START_CLIENT_PORT 1000 // Where to start client port
+#define START_CLIENT_PORT 100 // Where to start client port
 
 // Retry entire range on bind failures
 #define BIND_RETRY_COUNT (MAX_CLIENT_PORT - START_CLIENT_PORT)

--- a/vmdk_plugin/utils/fs/fs.go
+++ b/vmdk_plugin/utils/fs/fs.go
@@ -61,7 +61,7 @@ func Mkdir(path string) error {
 }
 
 // Mkfs creates a filesystem at the specified device
-func Mkfs(mkfscmd string, label string, device string) error {	
+func Mkfs(mkfscmd string, label string, device string) error {
 	out, err := exec.Command(mkfscmd, "-L", label, device).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("Failed to create filesystem on %s: %s. Output = %s",


### PR DESCRIPTION
If we have more than 24 operations performed in a tight loop we
run into the issue of ports not being cleaned up and returning
an error. This change increases the range of ports that we bind.

Minor go format change that the build picked up.

Testing:
1. Ran docker volume ls in a tight loop without issues
2. Ran code listed in https://github.com/vmware/docker-volume-vsphere/issues/436 without issues. 