### PR TITLE
Deserialize and handle request execution with threads in vmdk_ops.py

### DIFF
--- a/esx_service/utils/auth.py
+++ b/esx_service/utils/auth.py
@@ -140,6 +140,7 @@ def get_total_storage_used(tenant_uuid, datastore):
         by querying auth DB.
 
     """
+    _auth_mgr = get_auth_mgr()
     total_storage_used = 0
     try:
         cur = _auth_mgr.conn.execute(
@@ -310,6 +311,8 @@ def authorize(vm_uuid, datastore, cmd, opts):
 
 def add_volume_to_volumes_table(tenant_uuid, datastore, vol_name, vol_size_in_MB):
     """ Insert volume to volumes table. """
+    _auth_mgr = get_auth_mgr()
+
     logging.debug("add to volumes table(%s %s %s %s)", tenant_uuid, datastore,
                   vol_name, vol_size_in_MB)
     try:              

--- a/esx_service/utils/auth.py
+++ b/esx_service/utils/auth.py
@@ -277,7 +277,7 @@ def authorize(vm_uuid, datastore, cmd, opts):
     logging.debug("Authorize: opt=%s", opts)
     
     try:
-        connect_auth_db()
+        get_auth_mgr()
     except auth_data.DbConnectionError, e:
         error_info = "Failed to connect auth DB({0})".format(e)
         return error_info, None, None

--- a/esx_service/utils/auth.py
+++ b/esx_service/utils/auth.py
@@ -34,17 +34,15 @@ CMD_DETACH = 'detach'
 
 SIZE = 'size'
 
-_auth_mgr = None
-def connect_auth_db():
+def get_auth_mgr():
     """ Get a connection to auth DB. """
-    global _auth_mgr
-    if not _auth_mgr:
-        _auth_mgr = auth_data.AuthorizationDataManager()
-        _auth_mgr.connect()
+    _auth_mgr = auth_data.AuthorizationDataManager()
+    _auth_mgr.connect()
+    return _auth_mgr
        
 def get_tenant(vm_uuid):
     """ Get tenant which owns this VM by querying the auth DB. """
-    global _auth_mgr
+    _auth_mgr = get_auth_mgr()
     try:
         cur = _auth_mgr.conn.execute(
                     "SELECT tenant_id FROM vms WHERE vm_id = ?",
@@ -82,7 +80,7 @@ def get_privileges(tenant_uuid, datastore):
         querying the auth DB.
 
     """
-    global _auth_mgr
+    _auth_mgr = get_auth_mgr()
     privileges = []
     logging.debug("get_privileges tenant_uuid=%s datastore=%s", tenant_uuid, datastore)
     try:
@@ -201,7 +199,7 @@ def check_privileges_for_command(cmd, opts, tenant_uuid, datastore, privileges):
 
 def tables_exist():
     """ Check tables needed for authorization exist or not. """
-    global _auth_mgr
+    _auth_mgr = get_auth_mgr()
 
     try:
         cur = _auth_mgr.conn.execute("SELECT name FROM sqlite_master WHERE type = 'table' and name = 'tenants';")

--- a/esx_service/utils/auth.py
+++ b/esx_service/utils/auth.py
@@ -23,6 +23,7 @@ import sqlite3
 import convert
 import auth_data_const
 import volume_kv as kv
+import threading
 
 # All supported vmdk commands
 CMD_CREATE = 'create'
@@ -34,12 +35,17 @@ CMD_DETACH = 'detach'
 
 SIZE = 'size'
 
+# thread local storage
+thread_local = threading.local()
+
 def get_auth_mgr():
     """ Get a connection to auth DB. """
-    _auth_mgr = auth_data.AuthorizationDataManager()
-    _auth_mgr.connect()
-    return _auth_mgr
-       
+    global thread_local
+    if not hasattr(thread_local, '_auth_mgr'):
+        thread_local._auth_mgr = auth_data.AuthorizationDataManager()
+        thread_local._auth_mgr.connect()
+    return thread_local._auth_mgr
+
 def get_tenant(vm_uuid):
     """ Get tenant which owns this VM by querying the auth DB. """
     _auth_mgr = get_auth_mgr()

--- a/esx_service/utils/kvESX.py
+++ b/esx_service/utils/kvESX.py
@@ -252,7 +252,8 @@ def load(volpath):
             break
         except Exception as open_error:
             # This is a workaround to the timing/locking with metadata files issue #626
-            if open_error.errno == errno.EBUSY and retry_count <= EBUSY_RETRY_COUNT:
+            if (hasattr(open_error, "errno") and
+                    (open_error.errno == errno.EBUSY and retry_count <= EBUSY_RETRY_COUNT)):
                 logging.warning("Meta file %s busy for load(), retrying...", meta_file)
                 retry_count += 1
                 time.sleep(EBUSY_RETRY_TIME)
@@ -282,7 +283,8 @@ def save(volpath, kv_dict):
             break
         except Exception as open_error:
             # This is a workaround to the timing/locking with metadata files issue #626
-            if open_error.errno == errno.EBUSY and retry_count <= EBUSY_RETRY_COUNT:
+            if (hasattr(open_error, "errno") and
+                    (open_error.errno == errno.EBUSY and retry_count <= EBUSY_RETRY_COUNT)):
                 logging.warning("Meta file %s busy for save(), retrying...", meta_file)
                 retry_count += 1
                 time.sleep(EBUSY_RETRY_SLEEP)

--- a/esx_service/vmci/vmci_server.c
+++ b/esx_service/vmci/vmci_server.c
@@ -35,6 +35,9 @@
 #include "connection_types.h"
 
 
+// SO_QSIZE maximum number of connections (requests) in socket queue.
+int SO_QSIZE = 128;
+
 // Returns vSocket to listen on, or -1.
 // errno indicates the reason for a failure, if any.
 int
@@ -80,6 +83,15 @@ vmci_init(unsigned int port)
       return CONN_FAILURE;
    }
 
+   /*
+    * listen for client connections.
+    */
+   ret = listen(socket_fd, SO_QSIZE);
+   if (ret == -1) {
+      perror("Failed to listen on socket");
+      return CONN_FAILURE;
+   }
+
    return socket_fd;
 }
 
@@ -101,15 +113,6 @@ vmci_get_one_op(const int s,    // socket to listen on
    int af = vsock_get_family(); // socket family for vSockets communication
 
    if (af == -1) {
-      return CONN_FAILURE;
-   }
-
-   /*
-    * listen for client connections.
-    */
-   ret = listen(s, 1);
-   if (ret == -1) {
-      perror("Failed to listen on socket");
       return CONN_FAILURE;
    }
 

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -1210,8 +1210,17 @@ def execRequestThread(client_socket, cartel, request):
             if response == VMCI_ERROR:
                 logging.warning("vmci_reply returned error %s (errno=%d)",
                                 os.strerror(errno), errno)
-    except Exception as e:
-        logging.exception("message")
+    except Exception as ex_thr:
+        logging.exception("Unhandled Exception:")
+
+        ret = err("Server returned an error: {0}".format(repr(ex_thr)))
+        ret_string = json.dumps(ret)
+        response = lib.vmci_reply(client_socket, c_char_p(ret_string.encode()))
+        errno = get_errno()
+        logging.debug("lib.vmci_reply: VMCI replied with errcode %s", response)
+        if response == VMCI_ERROR:
+            logging.warning("vmci_reply returned error %s (errno=%d)",
+                            os.strerror(errno), errno)
 
 # load VMCI shared lib , listen on vSocket in main loop, handle requests
 def handleVmciRequests(port):

--- a/vmdk_plugin/sanity_test.go
+++ b/vmdk_plugin/sanity_test.go
@@ -21,6 +21,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"testing"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
@@ -29,7 +31,6 @@ import (
 	"github.com/docker/engine-api/types/strslice"
 	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/config"
 	"golang.org/x/net/context"
-	"testing"
 )
 
 const (

--- a/vmdk_plugin/sanity_test.go
+++ b/vmdk_plugin/sanity_test.go
@@ -249,7 +249,7 @@ func TestSanity(t *testing.T) {
 	for idx, elem := range clients {
 		go func(idx int, c *client.Client) {
 			for i := 0; i < parallelVolumes; i++ {
-				volName := "volP" + strconv.Itoa(idx) + strconv.Itoa(i)
+				volName := "volTestP" + strconv.Itoa(idx) + strconv.Itoa(i)
 				createRequest.Name = volName
 				_, err := c.VolumeCreate(context.Background(), createRequest)
 				results <- err

--- a/vmdk_plugin/sanity_test.go
+++ b/vmdk_plugin/sanity_test.go
@@ -39,7 +39,7 @@ const (
 	// tests are often run under regular account and have no access to /var/log
 	defaultTestLogPath = "/tmp/test-docker-volume-vsphere.log"
 	// Number of volumes per client for parallel tests
-	parallelVolumes = 5
+	parallelVolumes = 9
 )
 
 var (
@@ -237,7 +237,7 @@ func TestSanity(t *testing.T) {
 
 	fmt.Printf("Running parallel tests on %s and %s (may take a while)...\n", endPoint1, endPoint2)
 	// Create a short buffered channel to introduce random pauses
-	results := make(chan error, 5)
+	results := make(chan error, parallelVolumes)
 	createRequest := types.VolumeCreateRequest{
 		Name:   volumeName,
 		Driver: driverName,


### PR DESCRIPTION
@msterin @kerneltime 
Doing the PR so we can review.

This will be the 1st of 2 patches (the 2 will be the tests).

Changed the design a little, moving away all unnecessary work from the main loop (request fetching) and making locks available globally through getLock().




