### PR TITLE
Workaround older versions of e2fsprogs

### DIFF
--- a/vmdk_plugin/utils/fs/fs.go
+++ b/vmdk_plugin/utils/fs/fs.go
@@ -36,6 +36,8 @@ const pciAddrLen = 10                     // Length of PCI dev addr
 
 // FstypeDefault contains the default FS when not specified by the user
 const FstypeDefault = "ext4"
+// Search paths for filesystem utilities
+var BinSearchPaths = [4]string {"/bin", "/sbin", "/usr/bin", "/usr/sbin"}
 
 // VolumeDevSpec - volume spec returned from the server on an attach
 type VolumeDevSpec struct {
@@ -72,10 +74,13 @@ func Mkfs(mkfscmd string, label string, device string) error {
 
 // MkfsLookup finds existent filesystem tools
 func MkfsLookup() map[string]string {
-	mkftools, _ := filepath.Glob("/sbin/mkfs.*")
 	supportedFs := make(map[string]string)
-	for _, mkfs := range mkftools {
-		supportedFs[strings.Split(mkfs, ".")[1]] = mkfs
+
+	for _,sp := range BinSearchPaths {
+		mkftools, _ := filepath.Glob(sp+"/mkfs.*")
+		for _, mkfs := range mkftools {
+			supportedFs[strings.Split(mkfs, ".")[1]] = mkfs
+		}
 	}
 	return supportedFs
 }

--- a/vmdk_plugin/utils/fs/fs.go
+++ b/vmdk_plugin/utils/fs/fs.go
@@ -36,8 +36,9 @@ const pciAddrLen = 10                     // Length of PCI dev addr
 
 // FstypeDefault contains the default FS when not specified by the user
 const FstypeDefault = "ext4"
-// Search paths for filesystem utilities
-var BinSearchPaths = [4]string {"/bin", "/sbin", "/usr/bin", "/usr/sbin"}
+
+// BinSearchPath contains search paths for host binaries
+var BinSearchPath = []string{"/bin", "/sbin", "/usr/bin", "/usr/sbin"}
 
 // VolumeDevSpec - volume spec returned from the server on an attach
 type VolumeDevSpec struct {
@@ -64,7 +65,17 @@ func Mkdir(path string) error {
 
 // Mkfs creates a filesystem at the specified device
 func Mkfs(mkfscmd string, label string, device string) error {
-	out, err := exec.Command(mkfscmd, "-L", label, device).CombinedOutput()
+	var err error
+	var out []byte
+
+	// Workaround older versions of e2fsprogs, issue 629.
+	// If mkfscmd is of an ext* filesystem use -F flag
+	// to avoid having mkfs command to expect user confirmation.
+	if strings.Split(mkfscmd, ".")[1][0:3] == "ext" {
+		out, err = exec.Command(mkfscmd, "-F", "-L", label, device).CombinedOutput()
+	} else {
+		out, err = exec.Command(mkfscmd, "-L", label, device).CombinedOutput()
+	}
 	if err != nil {
 		return fmt.Errorf("Failed to create filesystem on %s: %s. Output = %s",
 			device, err, out)
@@ -76,8 +87,8 @@ func Mkfs(mkfscmd string, label string, device string) error {
 func MkfsLookup() map[string]string {
 	supportedFs := make(map[string]string)
 
-	for _,sp := range BinSearchPaths {
-		mkftools, _ := filepath.Glob(sp+"/mkfs.*")
+	for _, sp := range BinSearchPath {
+		mkftools, _ := filepath.Glob(sp + "/mkfs.*")
 		for _, mkfs := range mkftools {
 			supportedFs[strings.Split(mkfs, ".")[1]] = mkfs
 		}


### PR DESCRIPTION
Issue #629 

This commit workaround the error of creating ext/2/3/4 filesystems when using older versions of e2fsprogs. Those versions had an broken check and asks for confirmation when creating a filesystem using the whole block device (eg. /dev/sdb)

It also Broaden search path for filesystem utilities. Some distributions place filesystem utilities outside /sbin.