### PR TITLE
Handle invalid FS type on mount.

### DIFF
--- a/vmdk_plugin/plugin.go
+++ b/vmdk_plugin/plugin.go
@@ -366,7 +366,15 @@ func (d *vmdkDriver) Mount(r volume.MountRequest) volume.Response {
 		isReadOnly = true
 	}
 
-	mountpoint, err := d.mountVolume(r.Name, status["fstype"].(string), isReadOnly)
+	fstype, exists := status["fstype"].(string)
+
+	if !exists {
+		msg := fmt.Sprintf("Got invalid filesystem type for %s, attempting mount with type ext2.", r.Name)
+		log.WithFields(log.Fields{"name": r.Name, "error": msg}).Error("")
+		// Fail back to a default version that we can try with.
+		fstype = "ext2"
+	}
+	mountpoint, err := d.mountVolume(r.Name, fstype, isReadOnly)
 	if err != nil {
 		log.WithFields(
 			log.Fields{"name": r.Name, "error": err.Error()},


### PR DESCRIPTION
Handle invalid FS type returned by a GET call to the plugin server and fail back to using ext2 as FS type in such a case. This handles both any corruption on the server side plus makes a best effort to mount a volume with a default FS type.