### PR TITLE
auth.py must import import sqlite3

### DIFF
--- a/esx_service/utils/auth.py
+++ b/esx_service/utils/auth.py
@@ -15,6 +15,7 @@
 """ Module to provide APIs for authorization checking for VMDK ops.
 
 """
+import sqlite3
 import random
 import logging
 import auth_data


### PR DESCRIPTION
This is needed to avoid undefined globals in exception handling.
Fixes #654 