### PR TITLE
Don't call get_si() in wait_for_tasks()

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -1319,11 +1319,10 @@ Helper module for task operations.
 """
 
 
-def wait_for_tasks(service_instance, tasks):
+def wait_for_tasks(si, tasks):
     """Given the service instance si and tasks, it returns after all the
    tasks are complete
    """
-    si = get_si()
     task_list = [str(task) for task in tasks]
     property_collector = si.content.propertyCollector
     pcfilter = getTaskList(property_collector, tasks)


### PR DESCRIPTION
Don't call get_si() in wait_for_tasks(), it is passed as an argument by the caller.
This is a minor fix to the previous commits.