### PR TITLE
Pass the kill switch into docker and nested Makefiles.

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -109,6 +109,7 @@ else
   docker_socket=/var/run/docker.sock
   $DOCKER run --privileged --rm -it \
     -e "PKG_VERSION=$PKG_VERSION" \
+    -e "INCLUDE_UI=$INCLUDE_UI" \
     -v $docker_socket:$docker_socket  \
     -v $PWD/..:$dir -w $dir $plug_container $MAKE $1
 fi

--- a/vmdk_plugin/Makefile
+++ b/vmdk_plugin/Makefile
@@ -28,6 +28,8 @@ PKG_VERSION ?= $(shell \
 	       git log --pretty=format:'%h' -n 1)
 
 export PKG_VERSION
+export INCLUDE_UI
+
 EPOCH := 0
 
 # Place binaries here


### PR DESCRIPTION
The kill switch is to avoid UI code from being built and packaged
by default. This kill switch will be in place till UI is ready to
be consumed. Once the UI code is ready and integrated with the
VMODL APIs, the kill switch can be removed.