### PR TITLE
Confusing error message from volume.create when datastore is not writ…

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -492,20 +492,22 @@ def get_vol_path(datastore, tenant_name=None):
         logging.debug("Found %s, returning", path)
         return path, None
 
-    cmd = None
     if not os.path.isdir(dock_vol_path):
         # The osfs tools are usable for DOCK_VOLS_DIR on all datastores
         cmd = "{0} {1}".format(OSFS_MKDIR_CMD, dock_vol_path)
-    if tenant_name and not os.path.isdir(path):
-        cmd = "{0} {1}".format(MKDIR_CMD, path)
-    rc, out = RunCommand(cmd)
-    if rc != 0:
-        if tenant_name:
-            errMsg = "Failed to initialize volume path {0}".format(path)
-        else:
+        rc, out = RunCommand(cmd)
+        if rc != 0:
             errMsg = "{0} creation failed - {1} on {2}".format(DOCK_VOLS_DIR, os.strerror(rc), datastore)
-        logging.warning(errMsg)
-        return None, err(errMsg)
+            logging.warning(errMsg)
+            return None, err(errMsg)
+    if tenant_name and not os.path.isdir(path):
+        # The mkdir command is used to create "tenant_name" folder inside DOCK_VOLS_DIR on "datastore"
+        cmd = "{0} {1}".format(MKDIR_CMD, path)
+        rc, out = RunCommand(cmd)
+        if rc != 0:
+            errMsg = "Failed to initialize volume path {0}".format(path)
+            logging.warning(errMsg)
+            return None, err(errMsg)
 
     logging.info("Created %s", path)
     return path, None

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -505,7 +505,7 @@ def get_vol_path(datastore, tenant_name=None):
         cmd = "{0} {1}".format(MKDIR_CMD, path)
         rc, out = RunCommand(cmd)
         if rc != 0:
-            errMsg = "Failed to initialize volume path {0}".format(path)
+            errMsg = "Failed to initialize volume path {0} - {1}".format(path, out)
             logging.warning(errMsg)
             return None, err(errMsg)
 

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -494,28 +494,20 @@ def get_vol_path(datastore, tenant_name=None):
         logging.debug("Found %s, returning", path)
         return path, None
 
+    cmd = None
     if not os.path.isdir(dock_vol_path):
         # The osfs tools are usable for DOCK_VOLS_DIR on all datastores
         cmd = "{0} {1}".format(OSFS_MKDIR_CMD, dock_vol_path)
-        rc, out = RunCommand(cmd)
-        errMsg = None
-        if rc == ERR_OSFS_MKDIR_READONLY:
-            errMsg = "{0} creation failed - {1} not writable".format(DOCK_VOLS_DIR, datastore)
-        elif rc == ERR_OSFS_MKDIR_NOPERMISSION:
-            errMsg = "{0} creation failed - Permission denied on {1}".format(DOCK_VOLS_DIR, datastore)
-        else:
-            logging.warning("Failed to initialize volume path %s", path)
-            errMsg = "Failed to initialize volume path {0}".format(path)
-        #creation of dockvols directory failed.
-        if errMsg is not None:
-            return None, err(errMsg)
     if tenant_name and not os.path.isdir(path):
         cmd = "{0} {1}".format(MKDIR_CMD, path)
-        rc, out = RunCommand(cmd)
-        if rc != 0:
-           logging.warning("Failed to initialize volume path %s", path)
-           errMsg = "Failed to initialize volume path {0}".format(path)
-           return None, err(errMsg)
+    rc, out = RunCommand(cmd)
+    if rc != 0:
+        if tenant_name:
+            errMsg = "Failed to initialize volume path {0}".format(path)
+        else:
+            errMsg = "{0} creation failed - {1} on {2}".format(DOCK_VOLS_DIR, os.strerror(rc), datastore)
+        logging.warning(errMsg)
+        return None, err(errMsg)
 
     logging.info("Created %s", path)
     return path, None

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -107,8 +107,6 @@ MAX_SKIP_COUNT = 16       # max retries on VMCI Get Ops failures
 # Error codes
 VMCI_ERROR = -1 # VMCI C code uses '-1' to indicate failures
 ECONNABORTED = 103 # Error on non privileged client
-ERR_OSFS_MKDIR_READONLY = 30 # Error on creating a dockvols directory on a non-writable datastore
-ERR_OSFS_MKDIR_NOPERMISSION = 13 # Error on creating a dockvols directory on a datastore where permissions are denied
 
 # Volume data returned on Get request
 CAPACITY = 'capacity'


### PR DESCRIPTION
Handled both scenarios as outlined below:

datastore is not writable
permission denied to create dockvols directory in datastore.
This is extension to #705 and is part of fix for #568. Addressed Mark's comments over here.

+CC @pdhamdhere @msterin 

osfs-mkdir -n returns different error codes when it is not able to create the dockvols directory in /vmfs/volumes/<datastore-name>. It returns error codes 30 and 13 for scenarios 1 and 2 described above. These error codes are used to give a proper errorMsg to the user.