### PR TITLE
Pass current name of the VM thats attached a disk on Get() 

### DIFF
--- a/esx_service/volume_kv.py
+++ b/esx_service/volume_kv.py
@@ -35,8 +35,6 @@ DETACHED = 'detached'
 CREATED = 'created'
 # Name of the VM that created the volume
 CREATED_BY = 'created-by'
-# The name of the VM that the volume is attached to
-ATTACHED_VM_NAME = 'attachedVMName'
 # The UUID of the VM that the volume is attached to
 ATTACHED_VM_UUID = 'attachedVMUuid'
 


### PR DESCRIPTION
If volume is attached then get the current name of the VM using the disk and return that on Get()

Testing:

a. Start container
administrator@hte-1s-eng-dhcp98:~$ docker run --rm -it -w /data -v vm-name:/data busybox
/data #

b. Get volume data
administrator@hte-1s-eng-dhcp98:~$ docker volume inspect vm-name
```
[
    {
        "Name": "vm-name",
        "Driver": "vmdk",
        "Mountpoint": "/mnt/vmdk/vm-name",
        "Status": {
            "access": "read-write",
            "attach-as": "independent_persistent",
            "attached to VM": "ubuntu.16.04",
            "capacity": {
                "allocated": "15MB",
                "size": "100MB"
            },
            "created": "Wed Nov  9 06:33:03 2016",
            "created by VM": "Ubuntu-1604",
            "datastore": "bigone",
            "diskformat": "thin",
            "fstype": "ext4",
            "status": "attached"
        },
        "Labels": {},
        "Scope": "global"
    }
]
```
c. < updated VM name in VC>

d. Get volume data.
```
administrator@hte-1s-eng-dhcp98:~$ docker volume inspect vm-name
[
    {
        "Name": "vm-name",
        "Driver": "vmdk",
        "Mountpoint": "/mnt/vmdk/vm-name",
        "Status": {
            "access": "read-write",
            "attach-as": "independent_persistent",
            "attached to VM": "Ubuntu-16-04",
            "capacity": {
                "allocated": "15MB",
                "size": "100MB"
            },
            "created": "Wed Nov  9 06:33:03 2016",
            "created by VM": "Ubuntu-1604",
            "datastore": "bigone",
            "diskformat": "thin",
            "fstype": "ext4",
            "status": "attached"
        },
        "Labels": {},
        "Scope": "global"
    }
]
```
Ran pylint on vmdk_ops.py the errors are to do with the indentation of most of the code in vmdk_ops.py that will have to be changed for the entire file. The new changes are not creating any new type of errors.
```
W:380, 0: Bad indentation. Found 7 spaces, expected 8 (bad-indentation)
W:381, 0: Bad indentation. Found 7 spaces, expected 8 (bad-indentation)
W:382, 0: Bad indentation. Found 10 spaces, expected 12 (bad-indentation)
W:384, 0: Bad indentation. Found 7 spaces, expected 8 (bad-indentation)
W:385, 0: Bad indentation. Found 10 spaces, expected 12 (bad-indentation)
W:386, 0: Bad indentation. Found 7 spaces, expected 8 (bad-indentation)
W:387, 0: Bad indentation. Found 10 spaces, expected 12 (bad-indentation)
C:387, 0: Line too long (81/80) (line-too-long)
W:388, 0: Bad indentation. Found 7 spaces, expected 8 (bad-indentation)
W:389, 0: Bad indentation. Found 10 spaces, expected 12 (bad-indentation)
C:389, 0: Line too long (93/80) (line-too-long)
W:390, 0: Bad indentation. Found 7 spaces, expected 8 (bad-indentation)
W:391, 0: Bad indentation. Found 10 spaces, expected 12 (bad-indentation)
W:392, 0: Bad indentation. Found 7 spaces, expected 8 (bad-indentation)
W:393, 0: Bad indentation. Found 10 spaces, expected 12 (bad-indentation)
W:394, 0: Bad indentation. Found 7 spaces, expected 8 (bad-indentation)
W:395, 0: Bad indentation. Found 10 spaces, expected 12 (bad-indentation)
W:396, 0: Bad indentation. Found 7 spaces, expected 8 (bad-indentation)
W:397, 0: Bad indentation. Found 10 spaces, expected 12 (bad-indentation)
W:398, 0: Bad indentation. Found 7 spaces, expected 8 (bad-indentation)
W:399, 0: Bad indentation. Found 10 spaces, expected 12 (bad-indentation)
```
