### PR TITLE
Add volume cloning support -o clone-from=volname

### DIFF
--- a/docs/user-guide/docker-volume-cli.md
+++ b/docs/user-guide/docker-volume-cli.md
@@ -71,3 +71,11 @@ docker volume create --driver=vmdk --name=MyVolume -o size=10gb -o fstype=ext4 (
 
 Specifies which filesystem will be created on the new volume. vSphere Docker Volume Service will search for a existing /sbin/mkfs.**fstype** on the docker host to create the filesystem, and if not found it will return a list of filesystems for which it has found a corresponding mkfs. The specified filesystem must be supported by the running kernel and support labels (-L flag for mkfs). Defaults to ext4 if not specified. 
 
+### clone-from
+```
+docker volume create --driver=vmdk --name=CloneVolume -o clone-from=MyVolume -o access=read-only
+docker volume create --driver=vmdk --name=CloneVolume -o clone-from=MyVolume -o diskformat=thin (default)
+```
+
+Specifies a volume to be cloned when creating a new volume. The created clone is completely independent from the original volume and will inherit the same options, which can be changed with the exception of the size and fstype.
+ 

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -491,7 +491,7 @@ def all_ls_headers():
     """ Return a list of all header for ls -l """
     return ['Volume', 'Datastore', 'Created By VM', 'Created',
             'Attached To VM', 'Policy', 'Capacity', 'Used',
-            'Filesystem Type', 'Access', 'Attach As']
+            'Disk Format', 'Filesystem Type', 'Access', 'Attach As']
 
 def generate_ls_rows(tenant_reg):
     """ Gather all volume metadata into rows that can be used to format a table """
@@ -504,12 +504,13 @@ def generate_ls_rows(tenant_reg):
         policy = get_policy(metadata, path)
         size_info = get_vmdk_size_info(path)
         created, created_by = get_creation_info(metadata)
+        diskformat = get_diskformat(metadata)
         fstype = get_fstype(metadata)
         access = get_access(metadata)
         attach_as = get_attach_as(metadata)
         rows.append([name, v['datastore'], created_by, created, attached_to,
                      policy, size_info['capacity'], size_info['used'],
-                     fstype, access, attach_as])
+                     diskformat, fstype, access, attach_as])
     return rows
 
 
@@ -557,6 +558,12 @@ def get_policy(metadata, path):
     else:
         return NOT_AVAILABLE
 
+def get_diskformat(metadata):
+    """ Return the Disk Format of the volume based on its metadata """
+    try:
+        return metadata[kv.VOL_OPTS][kv.DISK_ALLOCATION_FORMAT]
+    except:
+        return NOT_AVAILABLE
 
 def get_fstype(metadata):
     """ Return the Filesystem Type of the volume based on its metadata """
@@ -564,7 +571,6 @@ def get_fstype(metadata):
         return metadata[kv.VOL_OPTS][kv.FILESYSTEM_TYPE]
     except:
         return NOT_AVAILABLE
-
 
 def get_metadata(volPath):
     """ Take the absolute path to volume vmdk and return its metadata as a dict """

--- a/esx_service/cli/vmdkops_admin_sanity_test.py
+++ b/esx_service/cli/vmdkops_admin_sanity_test.py
@@ -20,6 +20,9 @@ import os
 
 ADMIN_CLI = '/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py'
 
+# Number of expected columns in ADMIN_CLI ls
+EXPECTED_COLUMN_COUNT = 12
+
 class TestVmdkopsAdminSanity(unittest.TestCase):
     """ Test output from running vmdkops_admin.py """
 
@@ -38,8 +41,7 @@ class TestVmdkopsAdminSanity(unittest.TestCase):
         output = output.decode('utf-8')
         lines = output.split('\n')
         divider_columns = lines[1].split()
-        expected_column_count = 11
-        self.assertEqual(expected_column_count, len(divider_columns))
+        self.assertEqual(EXPECTED_COLUMN_COUNT, len(divider_columns))
         for string in divider_columns:
             self.assertTrue(all_dashes(string))
 

--- a/esx_service/cli/vmdkops_admin_test.py
+++ b/esx_service/cli/vmdkops_admin_test.py
@@ -24,6 +24,8 @@ import volume_kv as kv
 import vmdkops_admin
 import random
 
+# Number of expected columns in ADMIN_CLI ls
+EXPECTED_COLUMN_COUNT = 12
 
 class TestParsing(unittest.TestCase):
     """ Test command line arg parsing for all commands """
@@ -284,8 +286,7 @@ class TestLs(unittest.TestCase):
         volumes = vmdk_utils.get_volumes(None)
         header = vmdkops_admin.all_ls_headers()
         rows = vmdkops_admin.generate_ls_rows(None)
-        expected_column_count = 11
-        self.assertEqual(expected_column_count, len(header))
+        self.assertEqual(EXPECTED_COLUMN_COUNT, len(header))
         self.assertEqual(len(volumes), len(rows))
         for i in range(len(volumes)):
             self.assertEqual(volumes[i]['filename'], rows[i][0] + '.vmdk')

--- a/esx_service/utils/vmdk_utils.py
+++ b/esx_service/utils/vmdk_utils.py
@@ -162,6 +162,12 @@ def get_datastore_path(vmdk_path):
     datastore, path = match.groups()
     return "[{0}] {1}".format(datastore, path)
 
+def get_datastore_from_vmdk_path(vmdk_path):
+    """Returns a string representing the datastore from a full vmdk path.
+    """
+    match = re.search(DATASTORE_PATH_REGEXP, vmdk_path)
+    datastore, path = match.groups()
+    return datastore
 
 def list_vmdks(path, volname="", show_snapshots=False):
     """ Return a list of VMDKs in a given path. Filters out non-descriptor

--- a/esx_service/utils/vmdk_utils.py
+++ b/esx_service/utils/vmdk_utils.py
@@ -41,7 +41,7 @@ SPECIAL_FILES_REGEXP = r"\A.*-(delta|ctk|digest|flat)\.vmdk$"
 SNAP_SUFFIX_GLOB = "-[0-9][0-9][0-9][0-9][0-9][0-9].vmdk"
 
 # regexp for finding datastore path "[datastore] path/to/file.vmdk" from full vmdk path
-DATASTORE_PATH_REGEXP = r"^/vmfs/volumes/([a-zA-Z0-9_-]+?)/(.*)"
+DATASTORE_PATH_REGEXP = r"^/vmfs/volumes/([^/]+)/(.*\.vmdk)$"
 
 def init_datastoreCache():
     """

--- a/esx_service/utils/vmdk_utils.py
+++ b/esx_service/utils/vmdk_utils.py
@@ -40,6 +40,9 @@ SPECIAL_FILES_REGEXP = r"\A.*-(delta|ctk|digest|flat)\.vmdk$"
 # glob expression to match end of 'delta' (aka snapshots) file names.
 SNAP_SUFFIX_GLOB = "-[0-9][0-9][0-9][0-9][0-9][0-9].vmdk"
 
+# regexp for finding datastore path "[datastore] path/to/file.vmdk" from full vmdk path
+DATASTORE_PATH_REGEXP = r"^/vmfs/volumes/([a-zA-Z0-9_-]+?)/(.*)"
+
 def init_datastoreCache():
     """
     Initializes the datastore cache with the list of datastores accessible from local ESX host.
@@ -149,6 +152,15 @@ def get_vmdk_path(path, vol_name):
     latest = sorted([(vmdk, os.stat(vmdk).st_ctime) for vmdk in delta_disks], key=lambda d: d[1], reverse=True)[0][0]
     logging.debug("The latest delta disk is %s. All delta disks: %s", latest, delta_disks)
     return latest
+
+
+def get_datastore_path(vmdk_path):
+    """Returns a string datastore path "[datastore] path/to/file.vmdk"
+    from a full vmdk path.
+    """
+    match = re.search(DATASTORE_PATH_REGEXP, vmdk_path)
+    datastore, path = match.groups()
+    return "[{0}] {1}".format(datastore, path)
 
 
 def list_vmdks(path, volname="", show_snapshots=False):

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -232,9 +232,10 @@ def cloneVMDK(vm_name, vmdk_path, opts={}, vm_uuid=None, vm_datastore=None):
                     "Known datastores: %s.\n" \
                     "Default datastore: %s" \
                     % (datastore, ", ".join(known_datastores()), vm_datastore))
-    src_path = get_vol_path(src_datastore, tenant_name)
+    src_path, errMsg = get_vol_path(src_datastore, tenant_name)
     if src_path is None:
-        return err("Failed to initialize source volume path {0}".format(src_path))
+        return err("Failed to initialize source volume path {0}: {1}".format(src_path, errMsg))
+
     src_vmdk_path = vmdk_utils.get_vmdk_path(src_path, src_volume)
 
     # Verify if the source volume is in use.

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -334,7 +334,7 @@ def validate_opts(opts, vmdk_path):
     if kv.VSAN_POLICY_NAME in opts:
         validate_vsan_policy_name(opts[kv.VSAN_POLICY_NAME], vmdk_path)
     if kv.DISK_ALLOCATION_FORMAT in opts:
-        validate_disk_allocation_format(opts[kv.DISK_ALLOCATION_FORMAT], clone)
+        validate_disk_allocation_format(opts[kv.DISK_ALLOCATION_FORMAT])
     if kv.ATTACH_AS in opts:
         validate_attach_as(opts[kv.ATTACH_AS])
     if kv.ACCESS in opts:
@@ -369,20 +369,14 @@ def validate_vsan_policy_name(policy_name, vmdk_path):
     if not vsan_policy.policy_exists(policy_name):
         raise ValidationError('Policy {0} does not exist'.format(policy_name))
 
-def validate_disk_allocation_format(alloc_format, clone=False):
+def validate_disk_allocation_format(alloc_format):
     """
     Ensure format is valid.
     """
-    if alloc_format == kv.CLONE_ADD_ALLOCATION_FORMAT and clone:
-        return
-    if alloc_format == kv.CLONE_ADD_ALLOCATION_FORMAT and not clone:
-        raise ValidationError("Disk Allocation Format \'{0}\' is only supported for clones.".format(
-                                alloc_format))
     if not alloc_format in kv.VALID_ALLOCATION_FORMATS :
         raise ValidationError("Disk Allocation Format \'{0}\' is not supported."
-                            " Valid options are: {1}, and optionally '{2}' for clones".format(
-                            alloc_format, kv.VALID_ALLOCATION_FORMATS,
-                            kv.CLONE_ADD_ALLOCATION_FORMAT))
+                            " Valid options are: {1}.".format(
+                            alloc_format, kv.VALID_ALLOCATION_FORMATS))
 
 def validate_attach_as(attach_type):
     """
@@ -401,7 +395,7 @@ def validate_access(access_type):
                              " Valid options are: {1}".format(access_type,
                                                               kv.ACCESS_TYPES))
 
-def validate_fstype(fstype, clone):
+def validate_fstype(fstype, clone=False):
     """
     Ensure that we don't accept fstype for a clone
     """

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -212,6 +212,10 @@ def make_create_cmd(opts, vmdk_path):
 def cloneVMDK(vm_name, vmdk_path, src_vmdk_path, opts={}):
     logging.info("*** cloneVMDK: %s opts = %s", vmdk_path, opts)
 
+    attached, uuid, attach_as = getStatusAttached(src_vmdk_path)
+    if attached:
+        return err("Source volume cannot be in use when cloning")
+
     if not kv.DISK_ALLOCATION_FORMAT in opts:
         disk_format = kv.DEFAULT_ALLOCATION_FORMAT
     else:

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -219,7 +219,7 @@ def cloneVMDK(vm_name, vmdk_path, src_vmdk_path, opts={}, vm_uuid=None, vm_datas
     except ValidationError as e:
         return err(e.msg)
 
-    # We need to authorize again with size info of the volume being cloned
+    # We need to reauthorize with size info of the volume being cloned
     if vm_uuid and vm_datastore:
         src_vol_meta = kv.getAll(src_vmdk_path)
         opts["size"] = src_vol_meta["size"]
@@ -245,6 +245,7 @@ def cloneVMDK(vm_name, vmdk_path, src_vmdk_path, opts={}, vm_uuid=None, vm_datas
     dest_vol = vmdk_utils.get_datastore_path(vmdk_path)
     source_vol = vmdk_utils.get_datastore_path(src_vmdk_path)
 
+    si = get_si()
     task = si.content.virtualDiskManager.CopyVirtualDisk(
         sourceName=source_vol, destName=dest_vol, destSpec=vdisk_spec)
     try:

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -288,7 +288,7 @@ def validate_opts(opts, vmdk_path):
     clone = True if kv.CLONE_FROM in opts else False
 
     if kv.SIZE in opts:
-        validate_size(opts[kv.SIZE])
+        validate_size(opts[kv.SIZE], clone)
     if kv.VSAN_POLICY_NAME in opts:
         validate_vsan_policy_name(opts[kv.VSAN_POLICY_NAME], vmdk_path)
     if kv.DISK_ALLOCATION_FORMAT in opts:
@@ -299,11 +299,14 @@ def validate_opts(opts, vmdk_path):
         validate_access(opts[kv.ACCESS])
 
 
-def validate_size(size):
+def validate_size(size, clone=False):
     """
     Ensure size is given in a human readable format <int><unit> where int is an
     integer and unit is either 'mb', 'gb', or 'tb'. e.g. 22mb
     """
+    if clone:
+        raise ValidationError("Cannot define size for a clone")
+
     if not size.lower().endswith(('kb', 'mb', 'gb', 'tb'
                                   )) or not size[:-2].isdigit():
         msg = ('Invalid format for size. \n'

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -227,11 +227,11 @@ def cloneVMDK(vm_name, vmdk_path, opts={}, vm_uuid=None, vm_datastore=None):
         return err(str(ex))
     if not src_datastore:
         src_datastore = vm_datastore
-    elif src_datastore not in known_datastores():
+    elif not vmdk_utils.validate_datastore(src_datastore):
         return err("Invalid datastore '%s'.\n" \
                     "Known datastores: %s.\n" \
                     "Default datastore: %s" \
-                    % (datastore, ", ".join(known_datastores()), vm_datastore))
+                    % (datastore, ", ".join(get_datastore_names_list), src_datastore))
     src_path, errMsg = get_vol_path(src_datastore, tenant_name)
     if src_path is None:
         return err("Failed to initialize source volume path {0}: {1}".format(src_path, errMsg))

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -85,6 +85,8 @@ class VmdkCreateRemoveTestCase(unittest.TestCase):
     invalid_access_opt = {u'acess': u'read-write'}
     valid_access_opt = {volume_kv.ACCESS: 'read-only'}
     invalid_attach_as_choice = {volume_kv.ATTACH_AS: u'persisten'}
+    invalid_diskformat_choice = {volume_kv.DISK_ALLOCATION_FORMAT: volume_kv.CLONE_ADD_ALLOCATION_FORMAT}
+    valid_diskformat_choice = {volume_kv.DISK_ALLOCATION_FORMAT: volume_kv.VALID_ALLOCATION_FORMATS[2]}
     invalid_attach_as_opt = {u'atach-as': u'persistent'}
     valid_attach_as_opt_1 = {volume_kv.ATTACH_AS: u'persistent'}
     valid_attach_as_opt_2 = {volume_kv.ATTACH_AS: u'independent_persistent'}
@@ -182,6 +184,19 @@ class VmdkCreateRemoveTestCase(unittest.TestCase):
         err = vmdk_ops.removeVMDK(self.name)
         self.assertEqual(err, None, err)
 
+    def testDiskAllocationFormatOpts(self):
+        err = vmdk_ops.createVMDK(vm_name=self.vm_name,
+                                  vmdk_path=self.name,
+                                  vol_name=self.volName,
+                                  opts=self.invalid_diskformat_choice)
+        self.assertNotEqual(err, None, err)
+
+        err = vmdk_ops.createVMDK(vm_name=self.vm_name,
+                                  vmdk_path=self.name,
+                                  vol_name=self.volName,
+                                  opts=self.valid_diskformat_choice)
+        self.assertEqual(err, None, err)
+
 
     @unittest.skipIf(not vsan_info.get_vsan_datastore(),
                     "VSAN is not found - skipping vsan_info tests")
@@ -239,7 +254,99 @@ class VmdkCreateRemoveTestCase(unittest.TestCase):
             err = vmdk_ops.removeVMDK(vmdk_path)
             self.assertEqual(err == None, unit[2], err)
 
+class VmdkCreateCloneRemoveTestCase(unittest.TestCase):
+    vm_name = 'test-vm'
+    vm_uuid = str(uuid.uuid4())
+    volName = "vol_CloneTest"
+    volName1 = "vol_CloneTest_1"
+    volName2 = "vol_CloneTest_2"
+    volName3 = "vol_CloneTest_3"
+    vm_datastore = None
 
+    def setUp(self):
+        if not self.vm_datastore:
+            datastore = vmdk_utils.get_datastores()[0]
+            if not datastore:
+                logging.error("Cannot find a valid datastore")
+                self.assertFalse(True)
+            self.vm_datastore = datastore[0]
+
+        path, err = vmdk_ops.get_vol_path(self.vm_datastore)
+        self.assertEqual(err, None, err)
+
+        self.name = vmdk_utils.get_vmdk_path(path, self.volName)
+        self.name1 = vmdk_utils.get_vmdk_path(path, self.volName1)
+        self.name2 = vmdk_utils.get_vmdk_path(path, self.volName2)
+        self.name3 = vmdk_utils.get_vmdk_path(path, self.volName3)
+        self.badOpts = {volume_kv.CLONE_FROM: self.volName, volume_kv.FILESYSTEM_TYPE: u'ext4',
+                        volume_kv.SIZE: volume_kv.DEFAULT_DISK_SIZE}
+
+    def testBadOpts(self):
+        err = vmdk_ops.createVMDK(vmdk_path=self.name,
+                                  vm_name=self.vm_name,
+                                  vol_name=self.volName)
+        self.assertEqual(err, None, err)
+
+        err = vmdk_ops.createVMDK(vmdk_path=self.name1,
+                                  vm_name=self.vm_name,
+                                  vol_name=self.volName1,
+                                  opts=self.badOpts,
+                                  vm_uuid=self.vm_uuid,
+                                  vm_datastore=self.vm_datastore)
+        self.assertNotEqual(err, None, err)
+
+        err = vmdk_ops.removeVMDK(self.name1)
+        self.assertNotEqual(err, None, err)
+
+        err = vmdk_ops.removeVMDK(self.name)
+        self.assertEqual(err, None, err)
+
+
+    def testCreateCloneDelete(self):
+        err = vmdk_ops.createVMDK(vmdk_path=self.name,
+                                  vm_name=self.vm_name,
+                                  vol_name=self.volName)
+        self.assertEqual(err, None, err)
+
+        err = vmdk_ops.createVMDK(vmdk_path=self.name1,
+                                  vm_name=self.vm_name,
+                                  vol_name=self.volName1,
+                                  opts={volume_kv.CLONE_FROM: self.volName},
+                                  vm_uuid=self.vm_uuid,
+                                  vm_datastore=self.vm_datastore)
+        self.assertEqual(err, None, err)
+
+        err = vmdk_ops.createVMDK(vmdk_path=self.name2,
+                                  vm_name=self.vm_name,
+                                  vol_name=self.volName2,
+                                  opts={volume_kv.CLONE_FROM: self.volName1,
+                                        volume_kv.DISK_ALLOCATION_FORMAT:
+                                        volume_kv.CLONE_ADD_ALLOCATION_FORMAT},
+                                  vm_uuid=self.vm_uuid,
+                                  vm_datastore=self.vm_datastore)
+        self.assertEqual(err, None, err)
+
+        err = vmdk_ops.createVMDK(vmdk_path=self.name3,
+                                  vm_name=self.vm_name,
+                                  vol_name=self.volName3,
+                                  opts={volume_kv.CLONE_FROM: self.volName2,
+                                        volume_kv.DISK_ALLOCATION_FORMAT:
+                                        volume_kv.CLONE_ADD_ALLOCATION_FORMAT},
+                                  vm_uuid=self.vm_uuid,
+                                  vm_datastore=self.vm_datastore)
+        self.assertEqual(err, None, err)
+
+        err = vmdk_ops.removeVMDK(self.name)
+        self.assertEqual(err, None, err)
+
+        err = vmdk_ops.removeVMDK(self.name1)
+        self.assertEqual(err, None, err)
+
+        err = vmdk_ops.removeVMDK(self.name2)
+        self.assertEqual(err, None, err)
+
+        err = vmdk_ops.removeVMDK(self.name3)
+        self.assertEqual(err, None, err)
 
 class ValidationTestCase(unittest.TestCase):
     """ Test validation of -o options on create """

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -85,8 +85,6 @@ class VmdkCreateRemoveTestCase(unittest.TestCase):
     invalid_access_opt = {u'acess': u'read-write'}
     valid_access_opt = {volume_kv.ACCESS: 'read-only'}
     invalid_attach_as_choice = {volume_kv.ATTACH_AS: u'persisten'}
-    invalid_diskformat_choice = {volume_kv.DISK_ALLOCATION_FORMAT: volume_kv.CLONE_ADD_ALLOCATION_FORMAT}
-    valid_diskformat_choice = {volume_kv.DISK_ALLOCATION_FORMAT: volume_kv.VALID_ALLOCATION_FORMATS[2]}
     invalid_attach_as_opt = {u'atach-as': u'persistent'}
     valid_attach_as_opt_1 = {volume_kv.ATTACH_AS: u'persistent'}
     valid_attach_as_opt_2 = {volume_kv.ATTACH_AS: u'independent_persistent'}
@@ -182,19 +180,6 @@ class VmdkCreateRemoveTestCase(unittest.TestCase):
         self.assertEqual(err, None, err)
 
         err = vmdk_ops.removeVMDK(self.name)
-        self.assertEqual(err, None, err)
-
-    def testDiskAllocationFormatOpts(self):
-        err = vmdk_ops.createVMDK(vm_name=self.vm_name,
-                                  vmdk_path=self.name,
-                                  vol_name=self.volName,
-                                  opts=self.invalid_diskformat_choice)
-        self.assertNotEqual(err, None, err)
-
-        err = vmdk_ops.createVMDK(vm_name=self.vm_name,
-                                  vmdk_path=self.name,
-                                  vol_name=self.volName,
-                                  opts=self.valid_diskformat_choice)
         self.assertEqual(err, None, err)
 
 
@@ -319,9 +304,7 @@ class VmdkCreateCloneRemoveTestCase(unittest.TestCase):
         err = vmdk_ops.createVMDK(vmdk_path=self.name2,
                                   vm_name=self.vm_name,
                                   vol_name=self.volName2,
-                                  opts={volume_kv.CLONE_FROM: self.volName1,
-                                        volume_kv.DISK_ALLOCATION_FORMAT:
-                                        volume_kv.CLONE_ADD_ALLOCATION_FORMAT},
+                                  opts={volume_kv.CLONE_FROM: self.volName1},
                                   vm_uuid=self.vm_uuid,
                                   vm_datastore=self.vm_datastore)
         self.assertEqual(err, None, err)
@@ -329,9 +312,7 @@ class VmdkCreateCloneRemoveTestCase(unittest.TestCase):
         err = vmdk_ops.createVMDK(vmdk_path=self.name3,
                                   vm_name=self.vm_name,
                                   vol_name=self.volName3,
-                                  opts={volume_kv.CLONE_FROM: self.volName2,
-                                        volume_kv.DISK_ALLOCATION_FORMAT:
-                                        volume_kv.CLONE_ADD_ALLOCATION_FORMAT},
+                                  opts={volume_kv.CLONE_FROM: self.volName2},
                                   vm_uuid=self.vm_uuid,
                                   vm_datastore=self.vm_datastore)
         self.assertEqual(err, None, err)

--- a/esx_service/volume_kv.py
+++ b/esx_service/volume_kv.py
@@ -56,7 +56,6 @@ DEFAULT_DISK_SIZE = "100mb"
 # The disk allocation format for vmdk
 DISK_ALLOCATION_FORMAT = 'diskformat'
 VALID_ALLOCATION_FORMATS = ["zeroedthick", "thin", "eagerzeroedthick"]
-CLONE_ADD_ALLOCATION_FORMAT = "delta" # Additional allocation format for clones
 DEFAULT_ALLOCATION_FORMAT = 'thin'
 
 # attach type. Default is independent.

--- a/esx_service/volume_kv.py
+++ b/esx_service/volume_kv.py
@@ -56,6 +56,7 @@ DEFAULT_DISK_SIZE = "100mb"
 # The disk allocation format for vmdk
 DISK_ALLOCATION_FORMAT = 'diskformat'
 VALID_ALLOCATION_FORMATS = ["zeroedthick", "thin", "eagerzeroedthick"]
+CLONE_ADD_ALLOCATION_FORMAT = "delta" # Additional allocation format for clones
 DEFAULT_ALLOCATION_FORMAT = 'thin'
 
 # attach type. Default is independent.
@@ -81,6 +82,10 @@ ACCESS_TYPES = [ACCESS_READWRITE, ACCESS_READONLY]
 # This option is handled in the volume-plugin at the docker host, and tracked in volume metadata. 
 FILESYSTEM_TYPE = 'fstype'
 DEFAULT_FILESYSTEM_TYPE = ''
+
+# Clone references
+CLONE_FROM = 'clone-from' # clone volume parent
+DEFAULT_CLONE_FROM = 'None'
 
 # Create a kv store object for this volume identified by vol_path
 # Create the side car or open if it exists.

--- a/vmdk_plugin/plugin.go
+++ b/vmdk_plugin/plugin.go
@@ -209,6 +209,16 @@ func (d *vmdkDriver) unmountVolume(name string) error {
 // Name and driver specific options passed through to the ESX host
 func (d *vmdkDriver) Create(r volume.Request) volume.Response {
 
+	// If cloning a existent volume, create and return
+	if _, result := r.Options["clone-from"]; result == true {
+		errClone := d.ops.Create(r.Name, r.Options)
+		if errClone != nil {
+			log.WithFields(log.Fields{"name": r.Name, "error": errClone}).Error("Clone volume failed ")
+			return volume.Response{Err: errClone.Error()}
+		}
+		return volume.Response{Err: ""}
+	}
+
 	// Use default fstype if not specified
 	if _, result := r.Options["fstype"]; result == false {
 		r.Options["fstype"] = fs.FstypeDefault
@@ -239,11 +249,6 @@ func (d *vmdkDriver) Create(r volume.Request) volume.Response {
 	if errCreate != nil {
 		log.WithFields(log.Fields{"name": r.Name, "error": errCreate}).Error("Create volume failed ")
 		return volume.Response{Err: errCreate.Error()}
-	}
-
-	// If cloning a existent volume return
-	if _, result := r.Options["clone-from"]; result == true {
-		return volume.Response{Err: ""}
 	}
 
 	// Handle filesystem creation

--- a/vmdk_plugin/plugin.go
+++ b/vmdk_plugin/plugin.go
@@ -241,6 +241,11 @@ func (d *vmdkDriver) Create(r volume.Request) volume.Response {
 		return volume.Response{Err: errCreate.Error()}
 	}
 
+	// If cloning a existent volume return
+	if _, result := r.Options["clone-from"]; result == true {
+		return volume.Response{Err: ""}
+	}
+
 	// Handle filesystem creation
 	log.WithFields(log.Fields{"name": r.Name,
 		"fstype": r.Options["fstype"]}).Info("Attaching volume and creating filesystem ")


### PR DESCRIPTION
This PR adds volume cloning support, including delta disks.

The use cases would be:
- app environment/data cloning
- app environment/data checkpointing and rollback
- backups?

This needs #723 to correctly report the size of delta disks.

-----
**EDIT**
The delta allocation format was dropped because the resulting volumes were not deltas from their parents but full sparse clones. More bellow.