### PR TITLE
Add some parameter checks for multi-tenancy CLI commands

### DIFF
--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -998,6 +998,10 @@ def generate_privileges(args):
 
 def tenant_access_add(args):
     """ Handle tenant access command """
+    error_info = check_args(args)
+    if error_info:
+        return operation_fail(error_info)
+
     error_info, tenant = get_tenant_from_db(args.name)
     if error_info:
         return operation_fail(error_info)
@@ -1014,6 +1018,16 @@ def tenant_access_add(args):
         return operation_fail(error_info)
     else:
         print "tenant access add succeeded"
+
+def check_args(args):
+    """ Check validity of CLI arguments """
+    if (args.volume_maxsize > args.volume_totalsize):
+        error_info = "Volume max size should not exceed the total size"
+    
+    if error_info:
+        return error_info
+    else
+        return None;
 
 def modify_privileges(privileges, args):
     """ Modify privileges based on CLI argument """
@@ -1050,6 +1064,10 @@ def generate_privileges_dict(privileges):
 
 def tenant_access_set(args):
     """ Handle tenant access set command """
+    error_info = check_args(args)
+    if error_info:
+        return operation_fail(error_info)
+
     error_info, tenant = get_tenant_from_db(args.name)
     if error_info:
         return operation_fail(error_info)

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -1125,7 +1125,7 @@ def check_tenant_access_set_args(args, privileges):
         return error_info
 
     # If volume max size is set, but volume total size is NOT set,
-    # volume max size should not exceed existing volume total size (if available), i.e. usage quota
+    # volume max size should not exceed existing volume total size (i.e. usage quota), if already set.
     existing_total_size = privileges[auth_data_const.COL_USAGE_QUOTA]
     if (args.volume_maxsize and not args.volume_totalsize and existing_total_size):
         new_max_size_in_MB = convert.convert_to_MB(args.volume_maxsize)
@@ -1135,8 +1135,8 @@ def check_tenant_access_set_args(args, privileges):
             return error_info
 
     # If volume total size is set, but volume max size is NOT set,
-    # 1) if existing volume max size is set, volume total size should not be smaller than that
-    # 2) if existing volume max size is not set, it should be set to the same as volume total size
+    # 1) if existing volume max size was already set, volume total size should not be smaller than that
+    # 2) if existing volume max size was not set, it should be set to the same as volume total size
     if (args.volume_totalsize and not args.volume_maxsize):
         new_total_size_in_MB = convert.convert_to_MB(args.volume_totalsize)
         existing_max_size = privileges[auth_data_const.COL_MAX_VOLUME_SIZE]


### PR DESCRIPTION
Add parameter checks for multi-tenancy CLI commands (Fixes #673 & Fixes #684)

1. Fail the operation if "tenant access add" is called on the same tenant & datastore again
2. For "tenant access add" command:
    1) If setting both max_size and total_size, max_size should not be bigger than total_size
    2) If setting total_size only, max_size should be set to the same
3. For "tenant access set" command:
    1) If setting both max_size and total_size, max_size should not be bigger than total_size
    2) If setting max_size only, max_size should not exceed existing usage quota (if already set)
    3) If setting total_size only, and existing max_size was already set, total_size should not be smaller than that; otherwise max_size should be set to the same as total_size

Please note that the current change does not address all parameter validation scenarios - for example, volume total size should not exceed datastore capacity itself. Those scenarios will be tracked in separate issues.