### PR TITLE
Fix displaying default opts for clone and fstype.

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -329,7 +329,7 @@ def validate_opts(opts, vmdk_path):
                   kv.ATTACH_AS, kv.ACCESS, kv.FILESYSTEM_TYPE, kv.CLONE_FROM]
     defaults = [kv.DEFAULT_DISK_SIZE, kv.DEFAULT_VSAN_POLICY,\
                 kv.DEFAULT_ALLOCATION_FORMAT, kv.DEFAULT_ATTACH_AS,\
-                kv.DEFAULT_ACCESS, kv.DEFAULT_FILESYSTEM_TYPE, kv.CLONE_FROM]
+                kv.DEFAULT_ACCESS, kv.DEFAULT_FILESYSTEM_TYPE, kv.DEFAULT_CLONE_FROM]
     invalid = frozenset(opts.keys()).difference(valid_opts)
     if len(invalid) != 0:
         msg = 'Invalid options: {0} \n'.format(list(invalid)) \

--- a/esx_service/volume_kv.py
+++ b/esx_service/volume_kv.py
@@ -80,7 +80,7 @@ ACCESS_TYPES = [ACCESS_READWRITE, ACCESS_READONLY]
 # Filesystem type
 # This option is handled in the volume-plugin at the docker host, and tracked in volume metadata. 
 FILESYSTEM_TYPE = 'fstype'
-DEFAULT_FILESYSTEM_TYPE = ''
+DEFAULT_FILESYSTEM_TYPE = 'ext4'
 
 # Clone references
 CLONE_FROM = 'clone-from' # clone volume parent


### PR DESCRIPTION
vmdk_ops: Fix a typo in validate opts.
Set kv.DEFAULT_FILESYSTEM_TYPE for output the default fstype. (hinting mounts when not present in kv is done at the plugin, so there's no issue here.)

Before the fix:
```
root@dev01:~# docker volume create -d vmdk --name vol$$ -o invalid=opt
Error response from daemon: create vol10746: VolumeDriver.Create: Invalid options: [u'invalid']
Valid options and defaults: [('size', '100mb'), ('vsan-policy-name', '[VSAN default]'), ('diskformat', 'thin'), ('attach-as', 'independent_persistent'), ('access', 'read-write'), ('fstype', ''), ('clone-from', 'clone-from')]

```

With the fix:
```
root@dev01:~# docker volume create -d vmdk --name vol$$ -o invalid=opt
Error response from daemon: create vol10746: VolumeDriver.Create: Invalid options: [u'invalid']
Valid options and defaults: [('size', '100mb'), ('vsan-policy-name', '[VSAN default]'), ('diskformat', 'thin'), ('attach-as', 'independent_persistent'), ('access', 'read-write'), ('fstype', 'ext4'), ('clone-from', 'None')]
```