### PR TITLE
Adding support to use current build number while running tests

### DIFF
--- a/vmdk_plugin/Makefile
+++ b/vmdk_plugin/Makefile
@@ -88,7 +88,7 @@ VMDKOPS_MODULE_SRC = $(VMDKOPS_MODULE)/*.go $(VMCI_SRC)
 
 # All sources. We rebuild if anything changes here
 SRC = plugin.go main.go log_formatter.go refcnt.go \
-	utils/fs/fs.go utils/config/config.go
+	utils/fs/fs.go utils/config/config.go utils/TestInputParamsUtil.go
 
 # Canned recipe
 define log_target
@@ -302,7 +302,7 @@ testasroot:
 	$(GO) test $(PLUGIN)/utils/config
 
 # does sanity check of create/remove docker volume on the guest
-TEST_VOL_NAME ?= TestVolume
+TEST_VOL_NAME ?= DefaultTestVol
 TEST_VERBOSE   = -test.v
 
 CONN_MSG := "Please make sure Docker is running and is configured to accept TCP connections"

--- a/vmdk_plugin/sanity_test.go
+++ b/vmdk_plugin/sanity_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/filters"
 	"github.com/docker/engine-api/types/strslice"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils"
 	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/config"
 	"golang.org/x/net/context"
 )
@@ -190,8 +191,8 @@ func TestSanity(t *testing.T) {
 	}
 
 	c := clients[0].client // this is the endpoint we use as master
-	volName := TestInputParamsUtil.GetVolumeName()
-	t.Logf("Creating vol=%s on client %s.", volName, clients[0].endPoint)
+	volumeName := TestInputParamsUtil.GetVolumeName()
+	t.Logf("Creating vol=%s on client %s.", volumeName, clients[0].endPoint)
 	_, err := c.VolumeCreate(context.Background(),
 		types.VolumeCreateRequest{
 			Name:   volumeName,

--- a/vmdk_plugin/utils/TestInputParamsUtil.go
+++ b/vmdk_plugin/utils/TestInputParamsUtil.go
@@ -1,0 +1,53 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package TestInputParamsUtil
+
+// This file holds basic utility/helper methods for object creation used
+// at test methods
+
+import (
+	"flag"
+	"strconv"
+	"time"
+)
+
+var (
+	endPoint1  string
+	endPoint2  string
+	volumeName string
+)
+
+func init() {
+	flag.StringVar(&volumeName, "v", "DockerTestVol", "Volume name to use in tests")
+	flag.StringVar(&endPoint1, "H1", "unix:///var/run/docker.sock", "Endpoint (Host1) to connect to")
+	flag.StringVar(&endPoint2, "H2", "unix:///var/run/docker.sock", "Endpoint (Host2) to connect to")
+	flag.Parse()
+}
+
+func GetVolumeName() string {
+	return volumeName
+}
+
+func GetVolumeNameWithTimeStamp(volName string) string {
+	return volumeName + "_" + strconv.FormatInt(time.Now().Unix(), 10)
+}
+
+func GetEndPoint1() string {
+	return endPoint1
+}
+
+func GetEndPoint2() string {
+	return endPoint2
+}

--- a/vmdk_plugin/vmdkops/cmd_test.go
+++ b/vmdk_plugin/vmdkops/cmd_test.go
@@ -18,16 +18,16 @@ package vmdkops_test
 // Does not communicate over VMCI
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils"
 	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/vmdkops"
+	"testing"
 )
 
 func TestCommands(t *testing.T) {
 	ops := vmdkops.VmdkOps{Cmd: vmdkops.MockVmdkCmd{}}
-	volumeName := TestInputParamsUtil.GetVolumeName()
-	t.Logf("\nCreating Test Volume with name = [%s]...\n", volumeName)
+	name := TestInputParamsUtil.GetVolumeName()
+	t.Logf("\nCreating Test Volume with name = [%s]...\n", name)
 	opts := map[string]string{"size": "2gb"}
 	if assert.Nil(t, ops.Create(name, opts)) {
 

--- a/vmdk_plugin/vmdkops/cmd_test.go
+++ b/vmdk_plugin/vmdkops/cmd_test.go
@@ -26,7 +26,8 @@ import (
 
 func TestCommands(t *testing.T) {
 	ops := vmdkops.VmdkOps{Cmd: vmdkops.MockVmdkCmd{}}
-	name := "myVolume"
+	volumeName := TestInputParamsUtil.GetVolumeName()
+	t.Logf("\nCreating Test Volume with name = [%s]...\n", volumeName)
 	opts := map[string]string{"size": "2gb"}
 	if assert.Nil(t, ops.Create(name, opts)) {
 


### PR DESCRIPTION
Supplying a fix for #509 "Test runs should be isolated in namespace"

1) added a new util file named 'TestInputParamsUtil.go' which keeps track of all test variables passed through command line and later used by tests
2) make necessary changes at sanity_test.go & cmd_test.go
3) renaming default volume name passed from vmdk_plugin/Makefile 

-----local test run logs -------
Parameter passed from Makefile
```
# does sanity check of create/remove docker volume on the guest
TEST_VOL_NAME ?= DefaultTestVol
```
```
ssh  -kTax -o StrictHostKeyChecking=no root@10.20.105.77 /tmp/docker-volume-vsphere/docker-volume-vsphere.test -test.v \
	-v DefaultTestVol \
	-H1 tcp://10.20.105.77:2375 -H2 tcp://10.20.105.89:2375
```
```
=== RUN   TestSanity
Running tests on  tcp://10.20.105.77:2375 (may take a while)...
Running parallel tests on tcp://10.20.105.77:2375 and tcp://10.20.105.89:2375 (may take a while)...
--- PASS: TestSanity (162.56s)
	sanity_test.go:189: Successfully connected to tcp://10.20.105.77:2375
	sanity_test.go:189: Successfully connected to tcp://10.20.105.89:2375
	sanity_test.go:195: Creating vol=DefaultTestVol on client tcp://10.20.105.77:2375.
	sanity_test.go:89: Running cmd=&[touch /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.20.105.77:2375
	sanity_test.go:89: Running cmd=&[stat /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.20.105.77:2375

```
