### PR TITLE
Include hostd logs on failure only

### DIFF
--- a/misc/drone-scripts/deploy-and-test-wrapper.sh
+++ b/misc/drone-scripts/deploy-and-test-wrapper.sh
@@ -84,12 +84,15 @@ truncate_esx_logs $ESX
 
 log "starting deploy and test"
 
+INCLUDE_HOSTD="false"
+
 if make -s deploy-esx deploy-vm testasroot testremote TEST_VOL_NAME=vol.build$BUILD_NUMBER;
 then
   dump_logs
   stop_build $VM1 $BUILD_NUMBER
 else
   log "Build + Test not successful"
+  INCLUDE_HOSTD="true"
   dump_logs
   stop_build $VM1 $BUILD_NUMBER
   exit 1

--- a/misc/drone-scripts/dump_log.sh
+++ b/misc/drone-scripts/dump_log.sh
@@ -22,8 +22,11 @@ HOSTD_LOGFILE="/var/log/hostd.log"
 dump_log_esx() {
   log $ESX_LOGFILE
   $SSH $USER@$1 cat $ESX_LOGFILE
-  log $HOSTD_LOGFILE
-  $SSH $USER@$1 cat $HOSTD_LOGFILE
+  if [ $INCLUDE_HOSTD == "true" ]
+  then
+    log $HOSTD_LOGFILE
+    $SSH $USER@$1 cat $HOSTD_LOGFILE
+  fi
 }
 
 dump_log_vm(){
@@ -36,5 +39,8 @@ truncate_vm_logs() {
 
 truncate_esx_logs() {
   $SSH $USER@$1 "echo > $ESX_LOGFILE"
-  $SSH $USER@$1 "echo > $HOSTD_LOGFILE"
+  if [ $INCLUDE_HOSTD == "true" ]
+  then
+    $SSH $USER@$1 "echo > $HOSTD_LOGFILE"
+  fi
 }


### PR DESCRIPTION
Due to large log files, the console output gets truncated. I am working with CI folks to bump up the limit but for successful runs, hostd log is a distraction. Thus, only dump hostd logs on failures. 
Testing:
Faked a CI failure https://ci.vmware.run/vmware/docker-volume-vsphere/505

Fixes #769 