### PR TITLE
Use VirtualDiskManager API in vmdk_ops.

### DIFF
--- a/esx_service/utils/auth_data.py
+++ b/esx_service/utils/auth_data.py
@@ -663,7 +663,7 @@ class AuthorizationDataManager:
                                           datastore=vmdk['datastore'])
                 if err:
                     logging.error("remove vmdk %s failed with error %s", vmdk_path, err)
-                    error_info += err
+                    error_info += str(err)
             
             # Delete path /vmfs/volumes/datastore_name/tenant_name
             logging.debug("Deleting dir paths %s", dir_paths)
@@ -673,12 +673,12 @@ class AuthorizationDataManager:
                 except os.error as e:
                     msg = "remove dir {0} failed with error {1}".format(path, e)
                     logging.error(msg)
-                    error_info += msg
+                    error_info += str(err)
 
         err = self.remove_volumes_from_volumes_table(tenant_id)
         if err:
             logging.error("Failed to remove volumes from database %s", err)
-            error_info += err
+            error_info += str(err)
        
         if error_info:
             return error_info

--- a/esx_service/utils/convert.py
+++ b/esx_service/utils/convert.py
@@ -20,7 +20,7 @@ def convert_to_MB(vol_size_str):
         Example:
         '100MB': return 100
         '100GB': return 100*1024
-        
+
     """
 
     unit = vol_size_str[-2:].upper()
@@ -30,10 +30,17 @@ def convert_to_MB(vol_size_str):
                    'TB' : 1024*1024,
                    'PB' : 1024*1024*1024,
     }
-    
+
     if unit in conversions.keys():
         value = value*conversions[unit]
     else:
         logging.error("Invalid volume size")
     return value
-  
+
+
+def convert_to_KB(vol_size_str):
+    """ For a given size string, return values in KB.
+    """
+    size_mb = convert_to_MB(vol_size_str)
+    if size_mb:
+        return size_mb * 1024

--- a/esx_service/utils/vmdk_utils.py
+++ b/esx_service/utils/vmdk_utils.py
@@ -62,10 +62,15 @@ def init_datastoreCache():
     #  We are connected to ESX so childEntity[0] is current DC/Host
     ds_objects = \
       si.content.rootFolder.childEntity[0].datastoreFolder.childEntity
-    datastores = [(d.info.name,
-                   os.path.split(d.info.url)[1],
-                   os.path.join(d.info.url, 'dockvols'))
-                  for d in ds_objects]
+    datastores = []
+
+    for datastore in ds_objects:
+        dockvols_path, err = vmdk_ops.get_vol_path(datastore.info.name)
+        if err:
+            continue
+        datastores.append((datastore.info.name,
+                           os.path.split(datastore.info.url)[1],
+                           dockvols_path))
 
 def validate_datastore(datastore):
     """

--- a/esx_service/utils/vsan_info.py
+++ b/esx_service/utils/vsan_info.py
@@ -47,7 +47,9 @@ def get_vsan_dockvols_path():
     """
     datastore = get_vsan_datastore()
     if datastore:
-        return os.path.join(datastore.info.url, 'dockvols')
+        path, err = vmdk_ops.get_vol_path(datastore.info.name)
+        if not err:
+            return path
     else:
         return None
 

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -92,13 +92,12 @@ PYTHON64_VERSION = 50659824
 OBJ_TOOL_CMD = "/usr/lib/vmware/osfs/bin/objtool open -u "
 OSFS_MKDIR_CMD = "/usr/lib/vmware/osfs/bin/osfs-mkdir -n "
 MKDIR_CMD = "/bin/mkdir"
-VMDK_CREATE_CMD = "/sbin/vmkfstools"
-VMDK_DELETE_CMD = "/sbin/vmkfstools -U "
 
 # Defaults
 DOCK_VOLS_DIR = "dockvols"  # place in the same (with Docker VM) datastore
 MAX_JSON_SIZE = 1024 * 4  # max buf size for query json strings. Queries are limited in size
 MAX_SKIP_COUNT = 16       # max retries on VMCI Get Ops failures
+VMDK_ADAPTER_TYPE = 'busLogic'  # default adapter type
 
 # Error codes
 VMCI_ERROR = -1 # VMCI C code uses '-1' to indicate failures
@@ -170,54 +169,60 @@ def createVMDK(vmdk_path, vm_name, vol_name, opts={}, vm_uuid=None, tenant_uuid=
         return cloneVMDK(vm_name, vmdk_path, opts,
                          vm_uuid, datastore)
 
-    cmd = make_create_cmd(opts, vmdk_path)
-    rc, out = RunCommand(cmd)
-    if rc != 0:
-        return err("Failed to create %s. %s" % (vmdk_path, out))
+    if not kv.DISK_ALLOCATION_FORMAT in opts:
+        disk_format = kv.DEFAULT_ALLOCATION_FORMAT
+        # Update opts with DISK_ALLOCATION_FORMAT for volume metadata
+        opts[kv.DISK_ALLOCATION_FORMAT] = kv.DEFAULT_ALLOCATION_FORMAT
+    else:
+        disk_format = kv.VALID_ALLOCATION_FORMATS[opts[kv.DISK_ALLOCATION_FORMAT]]
+
+    # VirtualDiskSpec
+    vdisk_spec = vim.VirtualDiskManager.FileBackedVirtualDiskSpec()
+    vdisk_spec.adapterType = VMDK_ADAPTER_TYPE
+    vdisk_spec.diskType = disk_format
+
+    if  kv.SIZE in opts:
+        vdisk_spec.capacityKb = convert.convert_to_KB(opts[kv.SIZE])
+    else:
+        vdisk_spec.capacityKb = convert.convert_to_KB(kv.DEFAULT_DISK_SIZE)
+
+    # Form datastore path from vmdk_path
+    volume_datastore_path = vmdk_utils.get_datastore_path(vmdk_path)
+
+    si = get_si()
+    task = si.content.virtualDiskManager.CreateVirtualDisk(
+        name=volume_datastore_path, spec=vdisk_spec)
+    try:
+        wait_for_tasks(si, [task])
+    except vim.fault.VimFault as ex:
+        return err("Failed to create volume: {0}".format(ex.msg))
+
+    # Handle vsan policy
+    if kv.VSAN_POLICY_NAME in opts:
+        if not vsan_policy.set_policy_by_name(vmdk_path, opts[kv.VSAN_POLICY_NAME]):
+            logging.error("Could not set policy: %s to volume %s",
+                          opts[kv.VSAN_POLICY_NAME], vmdk_path)
+            del opts[kv.VSAN_POLICY_NAME]
 
     if not create_kv_store(vm_name, vmdk_path, opts):
         msg = "Failed to create metadata kv store for {0}".format(vmdk_path)
         logging.warning(msg)
         error_info = err(msg)
-        remove_err = removeVMDK(vmdk_path=vmdk_path, 
-                                vol_name=vol_name, 
+        remove_err = removeVMDK(vmdk_path=vmdk_path,
+                                vol_name=vol_name,
                                 vm_name=vm_name,
                                 tenant_uuid=tenant_uuid,
                                 datastore=datastore)
         if remove_err:
             error_info = error_info + remove_err
         return error_info
-   
+
     # create succeed, insert the volume information into "volumes" table
     if tenant_uuid:
         vol_size_in_MB = convert.convert_to_MB(auth.get_vol_size(opts))
         auth.add_volume_to_volumes_table(tenant_uuid, datastore, vol_name, vol_size_in_MB)
     else:
         logging.debug(error_code.VM_NOT_BELONG_TO_TENANT.format(vm_name))
-
-def make_create_cmd(opts, vmdk_path):
-    """ Return the command used to create a VMDK """
-    if not "size" in opts:
-        size = kv.DEFAULT_DISK_SIZE
-    else:
-        size = str(opts["size"])
-    logging.debug("Setting vmdk size to %s for %s", size, vmdk_path)
-
-    if not kv.DISK_ALLOCATION_FORMAT in opts:
-        disk_format = kv.DEFAULT_ALLOCATION_FORMAT
-    else:
-        disk_format = str(opts[kv.DISK_ALLOCATION_FORMAT])
-    logging.debug("Setting vmdk disk allocation format to %s for %s",
-                  disk_format, vmdk_path)
-
-    if kv.VSAN_POLICY_NAME in opts:
-        # Note that the --policyFile option gets ignored if the
-        # datastore is not VSAN
-        policy_file = vsan_policy.policy_path(opts[kv.VSAN_POLICY_NAME])
-        return "{0} -d {1} -c {2} --policyFile {3} {4}".format(VMDK_CREATE_CMD, disk_format, size,
-                                                               policy_file, vmdk_path)
-    else:
-        return "{0} -d {1} -c {2} {3}".format(VMDK_CREATE_CMD, disk_format, size, vmdk_path)
 
 
 def cloneVMDK(vm_name, vmdk_path, opts={}, vm_uuid=None, vm_datastore=None):
@@ -278,12 +283,14 @@ def cloneVMDK(vm_name, vmdk_path, opts={}, vm_uuid=None, vm_datastore=None):
         # Handle the allocation format
         if not kv.DISK_ALLOCATION_FORMAT in opts:
             disk_format = kv.DEFAULT_ALLOCATION_FORMAT
+            # Update opts with DISK_ALLOCATION_FORMAT for volume metadata
+            opts[kv.DISK_ALLOCATION_FORMAT] = kv.DEFAULT_ALLOCATION_FORMAT
         else:
-            disk_format = str(opts[kv.DISK_ALLOCATION_FORMAT])
+            disk_format = kv.VALID_ALLOCATION_FORMATS[opts[kv.DISK_ALLOCATION_FORMAT]]
 
         # VirtualDiskSpec
         vdisk_spec = vim.VirtualDiskManager.VirtualDiskSpec()
-        vdisk_spec.adapterType = 'busLogic'
+        vdisk_spec.adapterType = VMDK_ADAPTER_TYPE
         vdisk_spec.diskType = disk_format
 
         # Clone volume
@@ -295,13 +302,21 @@ def cloneVMDK(vm_name, vmdk_path, opts={}, vm_uuid=None, vm_datastore=None):
         except vim.fault.VimFault as ex:
             return err("Failed to clone volume: {0}".format(ex.msg))
 
+
+    # Handle vsan policy
+    if kv.VSAN_POLICY_NAME in opts:
+        if not vsan_policy.set_policy_by_name(vmdk_path, opts[kv.VSAN_POLICY_NAME]):
+            logging.error("Could not set policy: %s to volume %s",
+                          opts[kv.VSAN_POLICY_NAME], vmdk_path)
+            del opts[kv.VSAN_POLICY_NAME]
+
     # Update volume meta
     vol_name = vmdk_utils.strip_vmdk_extension(src_vmdk_path.split("/")[-1])
     vol_meta = kv.getAll(vmdk_path)
     vol_meta[kv.CREATED_BY] = vm_name
     vol_meta[kv.CREATED] = time.asctime(time.gmtime())
     vol_meta[kv.VOL_OPTS][kv.CLONE_FROM] = src_volume
-    vol_meta[kv.VOL_OPTS][kv.DISK_ALLOCATION_FORMAT] = disk_format
+    vol_meta[kv.VOL_OPTS][kv.DISK_ALLOCATION_FORMAT] = opts[kv.DISK_ALLOCATION_FORMAT]
     if kv.ACCESS in opts:
         vol_meta[kv.VOL_OPTS][kv.ACCESS] = opts[kv.ACCESS]
     if kv.ATTACH_AS in opts:
@@ -391,7 +406,7 @@ def validate_disk_allocation_format(alloc_format):
     if not alloc_format in kv.VALID_ALLOCATION_FORMATS :
         raise ValidationError("Disk Allocation Format \'{0}\' is not supported."
                             " Valid options are: {1}.".format(
-                            alloc_format, kv.VALID_ALLOCATION_FORMATS))
+                            alloc_format, list(kv.VALID_ALLOCATION_FORMATS)))
 
 def validate_attach_as(attach_type):
     """
@@ -483,32 +498,35 @@ def removeVMDK(vmdk_path, vol_name=None, vm_name=None, tenant_uuid=None, datasto
             return err("Failed to remove volume {0}, in use by VM uuid = {1}.".format(
                 vmdk_path, kv_uuid))
 
-    cmd = "{0} {1}".format(VMDK_DELETE_CMD, vmdk_path)
-    # Workaround timing/locking issues.
+    # Form datastore path from vmdk_path
+    volume_datastore_path = vmdk_utils.get_datastore_path(vmdk_path)
+
     retry_count = 0
     while True:
-        rc, out = RunCommand(cmd)
-        if rc != 0 and "lock" in out:
-            if retry_count == vmdk_utils.VMDK_RETRY_COUNT:
-                return err("Failed to remove %s. %s" % (vmdk_path, out))
-            logging.warning("*** removeVMDK: %s, coudn't lock volume for removal. Retrying...",
-                            vmdk_path)
-            vmdk_utils.log_volume_lsof(vol_name)
-            retry_count += 1
-            time.sleep(vmdk_utils.VMDK_RETRY_SLEEP)
-            continue
-        elif rc != 0:
-            return err("Failed to remove %s. %s" % (vmdk_path, out))
-        else:
-            # remove succeed, remove infomation of this volume from volumes table
-            if tenant_uuid:
-                error_info = auth.remove_volume_from_volumes_table(tenant_uuid, datastore, vol_name)
-                return error_info
+        si = get_si()
+        task = si.content.virtualDiskManager.DeleteVirtualDisk(name=volume_datastore_path)
+        try:
+            # Wait for delete, exit loop on success
+            wait_for_tasks(si, [task])
+            break
+        except vim.fault.VimFault as ex:
+            if retry_count == vmdk_utils.VMDK_RETRY_COUNT or "Error caused by file" not in ex.msg:
+                return err("Failed to remove volume: {0}".format(ex.msg))
             else:
-                if not vm_name:
-                    logging.debug(error_code.VM_NOT_BELONG_TO_TENANT.format(vm_name))
+                logging.warning("*** removeVMDK: Retrying removal on error: %s", ex.msg)
+                vmdk_utils.log_volume_lsof(vol_name)
+                retry_count += 1
+                time.sleep(vmdk_utils.VMDK_RETRY_SLEEP)
 
-            return None
+    # remove succeed, remove infomation of this volume from volumes table
+    if tenant_uuid:
+        error_info = auth.remove_volume_from_volumes_table(tenant_uuid, datastore, vol_name)
+        return error_info
+    elif not vm_name:
+        logging.debug(error_code.VM_NOT_BELONG_TO_TENANT.format(vm_name))
+
+    return None
+
 
 def getVMDK(vmdk_path, vol_name, datastore):
     """Checks if the volume exists, and returns error if it does not"""

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -200,8 +200,8 @@ def createVMDK(vmdk_path, vm_name, vol_name, opts={}, vm_uuid=None, tenant_uuid=
     # Handle vsan policy
     if kv.VSAN_POLICY_NAME in opts:
         if not vsan_policy.set_policy_by_name(vmdk_path, opts[kv.VSAN_POLICY_NAME]):
-            logging.error("Could not set policy: %s to volume %s",
-                          opts[kv.VSAN_POLICY_NAME], vmdk_path)
+            # Drop the failed option
+            # A warning is being logged in the called functions
             del opts[kv.VSAN_POLICY_NAME]
 
     if not create_kv_store(vm_name, vmdk_path, opts):
@@ -306,8 +306,8 @@ def cloneVMDK(vm_name, vmdk_path, opts={}, vm_uuid=None, vm_datastore=None):
     # Handle vsan policy
     if kv.VSAN_POLICY_NAME in opts:
         if not vsan_policy.set_policy_by_name(vmdk_path, opts[kv.VSAN_POLICY_NAME]):
-            logging.error("Could not set policy: %s to volume %s",
-                          opts[kv.VSAN_POLICY_NAME], vmdk_path)
+            # Drop the failed option
+            # A warning is being logged in the called functions
             del opts[kv.VSAN_POLICY_NAME]
 
     # Update volume meta

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -968,17 +968,9 @@ if __name__ == '__main__':
     log_config.configure()
     volume_kv.init()
 
-    # Calculate the path
-    paths = glob.glob("/vmfs/volumes/[a-zA-Z]*/dockvols")
-    logging.info("Found datastores: %s", paths)
-    if paths:
-        # WARNING: for many datastores with dockvols, this picks up the first
-        path = paths[0]
-    else:
-        # create dir in a datastore (just pick first datastore if needed)
-        path = glob.glob("/vmfs/volumes/[a-zA-Z]*")[0] + "/dockvols"
-        logging.debug("Directory does not exist - creating %s", path)
-        os.makedirs(path)
+    # Calculate the path, use the first datastore in datastores
+    datastores = vmdk_utils.get_datastores()
+    path = datastores[0][2]
 
     def clean_path(path):
         if not path:

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -219,6 +219,8 @@ class VmdkCreateRemoveTestCase(unittest.TestCase):
         self.assertNotEqual(None, vsan_policy.update('good', 'blah'))
         self.assertFalse(os.path.isfile(backup_policy_file))
 
+        err = vmdk_ops.removeVMDK(vmdk_path)
+        self.assertEqual(err, None, err)
 
     @unittest.skipIf(not vsan_info.get_vsan_datastore(),
                     "VSAN is not found - skipping vsan_info tests")

--- a/esx_service/volume_kv.py
+++ b/esx_service/volume_kv.py
@@ -55,7 +55,9 @@ DEFAULT_DISK_SIZE = "100mb"
 
 # The disk allocation format for vmdk
 DISK_ALLOCATION_FORMAT = 'diskformat'
-VALID_ALLOCATION_FORMATS = ["zeroedthick", "thin", "eagerzeroedthick"]
+VALID_ALLOCATION_FORMATS = {"zeroedthick": "preallocated",
+                            "thin": "thin",
+                            "eagerzeroedthick": "eagerZeroedThick"}
 DEFAULT_ALLOCATION_FORMAT = 'thin'
 
 # attach type. Default is independent.

--- a/esx_service/vsan_policy.py
+++ b/esx_service/vsan_policy.py
@@ -228,6 +228,20 @@ def get_policies():
         policies[name] = content
     return policies
 
+def get_policy_content(policy_name):
+    """ Return the content for a given policy. """
+    if not policy_exists(policy_name):
+        logging.warning("Policy %s does not exist", policy_name)
+        return None
+    with open(policy_path(policy_name)) as f:
+        return f.read()
+
+def set_policy_by_name(vmdk_path, policy_name):
+    """ Set policy for a given volume. """
+    content = get_policy_content(policy_name)
+    if not content:
+        return False
+    return vsan_info.set_policy(vmdk_path, content)
 
 def list_volumes_and_policies():
     """ Return a list of vmdks and the policies in use"""


### PR DESCRIPTION
This PR remove the usage of vmkfstools in vmdk_ops, and provide other small fixes.

With this change i was unable to reproduce the timing/locking (open descriptors after vmkfstools completed execution) issues observed in the parallel tests.

Probably fixes #768 #695 and part of #39 

//CC @msterin @kerneltime @govint 