### PR TITLE
Update docker-volume-cli.md

### DIFF
--- a/docs/user-guide/docker-volume-cli.md
+++ b/docs/user-guide/docker-volume-cli.md
@@ -20,13 +20,13 @@ The volume units can be ```kb, mb, gb and tb```
 
 The default volume size is 100mb
 
-### policy
+### policy (vsan-policy-name)
 
 ```
-docker volume create --driver=vmdk --name=MyVolume -o size=10gb -o policy=allflash
+docker volume create --driver=vmdk --name=MyVolume -o size=10gb -o vsan-policy-name=allflash
 ```
 
-Policy needs to be created via the vmdkops-admin-cli. Once policy is created, it can be addressed during create by passing the ```-o policy``` flag.
+Policy needs to be created via the vmdkops-admin-cli. Once policy is created, it can be addressed during create by passing the ```-o vsan-policy-name``` flag.
 
 ### diskformat
 ```

--- a/docs/user-guide/docker-volume-cli.md
+++ b/docs/user-guide/docker-volume-cli.md
@@ -20,7 +20,7 @@ The volume units can be ```kb, mb, gb and tb```
 
 The default volume size is 100mb
 
-### policy (vsan-policy-name)
+### vsan-policy-name
 
 ```
 docker volume create --driver=vmdk --name=MyVolume -o size=10gb -o vsan-policy-name=allflash


### PR DESCRIPTION
using 'vsan-policy-name' instead of 'policy' to keep the documentation in sync with the code and consistent with https://github.com/vmware/docker-volume-vsphere/blob/8717d753b606fad41597d074e5ee07a6893ee2f2/docs/user-guide/admin-cli.md#list-4

/CC @kerneltime 