### PR TITLE
Serialize attach/detach ops for the same vm 

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -728,7 +728,7 @@ def executeRequest(vm_uuid, vm_name, config_path, cmd, full_vol_name, opts):
     # Set thread name to vm_name-lockname
     threadutils.set_thread_name("{0}-{1}".format(vm_name, lockname))
 
-    # Get a resource lock
+    # Get a lock for the volume
     logging.debug("Trying to acquire lock: %s", lockname)
     with lockManager.get_lock(lockname):
         logging.debug("Acquired lock: %s", lockname)
@@ -748,10 +748,14 @@ def executeRequest(vm_uuid, vm_name, config_path, cmd, full_vol_name, opts):
                                   vm_name=vm_name,
                                   tenant_uuid=tenant_uuid,
                                   datastore=datastore)
+
+        # For attach/detach reconfigure tasks, hold a per vm lock.
         elif cmd == "attach":
-            response = attachVMDK(vmdk_path, vm_uuid)
+            with lockManager.get_lock(vm_uuid):
+                response = attachVMDK(vmdk_path, vm_uuid)
         elif cmd == "detach":
-            response = detachVMDK(vmdk_path, vm_uuid)
+            with lockManager.get_lock(vm_uuid):
+                response = detachVMDK(vmdk_path, vm_uuid)
         else:
             return err("Unknown command:" + cmd)
 


### PR DESCRIPTION
This is a simple change that fixes concurrency on the same docker host. It adds a per vm lock on attach/detach ops.

Fixes #809 

//CC @msterin 

before:
```
=== RUN   TestSanity
Running tests on  tcp://vsc02:2375 (may take a while)...
Running create/delete parallel tests on tcp://vsc02:2375 and tcp://vsc02:2375 (may take a while)...
--- FAIL: TestSanity (3.66s)
	sanity_test.go:190: Successfully connected to tcp://vsc02:2375
	sanity_test.go:190: Successfully connected to tcp://vsc02:2375
	sanity_test.go:196: Creating vol=DefaultTestVol on client tcp://vsc02:2375.
	sanity_test.go:90: Running cmd=&[touch /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://vsc02:2375
	sanity_test.go:90: Running cmd=&[stat /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://vsc02:2375
	sanity_test.go:262: Parallel test failed, err: Error response from daemon: create volTestP10: VolumeDriver.Create: Another task is already in progress.
FAIL
Makefile:319: recipe for target 'test-vm' failed
make[1]: *** [test-vm] Error 1
```

after:
```
=== RUN   TestSanity
Running tests on  tcp://vsc02:2375 (may take a while)...
Running create/delete parallel tests on tcp://vsc02:2375 and tcp://vsc02:2375 (may take a while)...
Running clone parallel tests (may take a while)...
--- PASS: TestSanity (17.83s)
	sanity_test.go:190: Successfully connected to tcp://vsc02:2375
	sanity_test.go:190: Successfully connected to tcp://vsc02:2375
	sanity_test.go:196: Creating vol=DefaultTestVol on client tcp://vsc02:2375.
	sanity_test.go:90: Running cmd=&[touch /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://vsc02:2375
	sanity_test.go:90: Running cmd=&[stat /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://vsc02:2375
PASS
make[1]: Leaving directory '/usr/share/go-1.6/src/github.com/vmware/docker-volume-vsphere/vmdk_plugin'
```