### PR TITLE
[Part 1 - test coverage report] showing individual coverage for go tests

### DIFF
--- a/vmdk_plugin/Makefile
+++ b/vmdk_plugin/Makefile
@@ -131,10 +131,10 @@ $(PLUGIN_BIN): $(SRC) $(VMDKOPS_MODULE_SRC)
 	$(GO) build --ldflags '-extldflags "-static"' -o $(PLUGIN_BIN) $(PLUGIN)
 
 $(BIN)/$(VMDKOPS_MODULE).test: $(VMDKOPS_MODULE_SRC) $(VMDKOPS_MODULE)/*_test.go
-	$(GO) test -c -o $@ $(PLUGIN)/$(VMDKOPS_MODULE)
+	$(GO) test -c -o $@ $(PLUGIN)/$(VMDKOPS_MODULE) -cover
 
 $(BIN)/$(PLUGNAME).test: $(SRC) *_test.go
-	$(GO) test -c -o $@ $(PLUGIN)
+	$(GO) test -c -o $@ $(PLUGIN) -cover
 
 .PHONY: clean
 clean:
@@ -297,8 +297,8 @@ test:
 .PHONY: testasroot
 testasroot:
 	$(log_target)
-	$(GO) test $(PLUGIN)/vmdkops
-	$(GO) test $(PLUGIN)/utils/config
+	$(GO) test $(PLUGIN)/vmdkops -cover
+	$(GO) test $(PLUGIN)/utils/config -cover
 
 # does sanity check of create/remove docker volume on the guest
 TEST_VOL_NAME ?= DefaultTestVol


### PR DESCRIPTION
Adding go coverage for go tests. WIP for #404 and this PR is to share an idea how coverage data looks like for go tests while using go coverage tool.

some interesting log snip from the local run.

```
=> Running target testasroot Wed Dec 14 22:04:25 UTC 2016

GO15VENDOREXPERIMENT=1 go test github.com/vmware/docker-volume-vsphere/vmdk_plugin/vmdkops -cover
ok  	github.com/vmware/docker-volume-vsphere/vmdk_plugin/vmdkops	1.538s	coverage: 47.3% of statements
GO15VENDOREXPERIMENT=1 go test github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/config -cover
ok  	github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/config	0.009s	coverage: 64.3% of statements
make: Leaving directory `/go/src/github.com/vmware/docker-volume-vsphere/vmdk_plugin'
```

individual tests data
```
--- PASS: TestCommands (0.84s)
	cmd_test.go:30: 
		Creating Test Volume with name = [DockerTestVol]...
PASS
coverage: 46.7% of statements
:::::::::::::::
:::::::::::::::
--- PASS: TestSanity (158.79s)
	sanity_test.go:189: Successfully connected to tcp://10.20.105.77:2375
	sanity_test.go:189: Successfully connected to tcp://10.20.105.89:2375
	sanity_test.go:195: Creating vol=DefaultTestVol on client tcp://10.20.105.77:2375.
	sanity_test.go:89: Running cmd=&[touch /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.20.105.77:2375
	sanity_test.go:89: Running cmd=&[stat /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.20.105.77:2375
PASS
coverage: 12.5% of statements
```
