### PR TITLE
Reduce CI run time. Add gofmt updates.

### DIFF
--- a/misc/drone-scripts/deploy-and-test-wrapper.sh
+++ b/misc/drone-scripts/deploy-and-test-wrapper.sh
@@ -86,7 +86,16 @@ log "starting deploy and test"
 
 INCLUDE_HOSTD="false"
 
-if make -s deploy-esx deploy-vm testasroot testremote e2e-dkrVolDriver-test TEST_VOL_NAME=vol.build$BUILD_NUMBER;
+TESTS=""
+if [ -e /tmp/$ESX ]
+then
+   TESTS="test-vm e2e-dkrVolDriver-test"
+else
+   touch /tmp/$ESX
+   TESTS="testasroot test-esx test-vm e2e-dkrVolDriver-test"
+fi
+
+if make -s deploy-esx deploy-vm $TESTS TEST_VOL_NAME=vol.build$BUILD_NUMBER;
 then
   echo "=> Build Complete" `date`
   #stop_build $VM1 $BUILD_NUMBER

--- a/vmdk_plugin/E2E_Tests/createVolume_test.go
+++ b/vmdk_plugin/E2E_Tests/createVolume_test.go
@@ -23,10 +23,10 @@
 package e2e_test
 
 import (
-	"testing"
-	"os"
-	TestUtil "github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/test_util"
 	volumeNameUtil "github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils"
+	TestUtil "github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/test_util"
+	"os"
+	"testing"
 )
 
 // Test objective: create volume on fresh setup very first time and verifies the volume
@@ -34,7 +34,7 @@ import (
 
 /*
 
-The issue was observed on photon so steps are mentioned for photon OS only in fact 
+The issue was observed on photon so steps are mentioned for photon OS only in fact
 test should be OS agnostic.
 
 1. create docker volume using following command
@@ -50,12 +50,12 @@ func TestVolumeCreationFristTime(t *testing.T) {
 	var err error
 	var out []byte
 	volumeName := volumeNameUtil.GetVolumeNameWithTimeStamp("abc")
-	
+
 	// create volume
 	out, err = TestUtil.CreateDefaultVolume(os.Getenv("VM1"), volumeName)
-	
-	if (err != nil) {
-		t.Fatalf("\nError has occurred [%s] \n\twhile creating volume [%s] very first time: err -> %v", out, volumeName, err)		
+
+	if err != nil {
+		t.Fatalf("\nError has occurred [%s] \n\twhile creating volume [%s] very first time: err -> %v", out, volumeName, err)
 	} else {
 		t.Logf("\nTestcase passed: successfully able to create volume [%s]\n", out)
 		// delete volume


### PR DESCRIPTION
This reduces CI time down by close to half.
We currently run the same target test-esx 2 times against each ESX since we blindly repeat the entire test suite against each target. This change will only run test-esx once per ESX.

Also, picked up some gofmt complaints.