### PR TITLE
Rename vmdk driver as vsphere.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Refer to [tenancy
 documentation](http://vmware.github.io/docker-volume-vsphere/documentation/features/tenancy/) for setting up tenants.
 ```
 # To select datastore use --name=MyVolume@<Datastore Name>
-$ docker volume create --driver=vmdk --name=MyVolume -o size=10gb
+$ docker volume create --driver=vsphere --name=MyVolume -o size=10gb
 $ docker volume ls
 $ docker volume inspect MyVolume
 # To select datastore use MyVolume@<Datastore Name>

--- a/docs/features/vsan-policy.md
+++ b/docs/features/vsan-policy.md
@@ -8,5 +8,5 @@ VSAN provides software defined storage and for each storage object it can specif
 Using the Admin CLI an IT admin can create the policies that can be consumed by Docker volumes. The Docker admin can then create a volume using the policies available.
 ```
 vmdkops-admin policy create --name=myPolicy --content="string"
-docker volume create --driver=vmdk --name=MyVol -o vsan-policy-name=myPolicy
+docker volume create --driver=vsphere --name=MyVol -o vsan-policy-name=myPolicy
 ```

--- a/docs/misc/VolumeNames.md
+++ b/docs/misc/VolumeNames.md
@@ -35,10 +35,10 @@ the following:
 ```
 $ docker volume ls
 DRIVER       VOLUME NAME
-vmdk         volume1
-vmdk         volume2
-vmdk         volume1@vsanDatastore
-vmdk         volume2@vsanDatastore
+vsphere         volume1
+vsphere         volume2
+vsphere         volume1@vsanDatastore
+vsphere         volume2@vsanDatastore
 ```
 
 # Volume name usage

--- a/docs/user-guide/admin-cli.md
+++ b/docs/user-guide/admin-cli.md
@@ -531,7 +531,7 @@ some-policy  (("proportionalCapacity" i0)("hostFailuresToTolerate" i0)  Unused
 ```
 
 When creating a virtual disk using `docker volume create`, the policy name should be given with the `-o`
-option such as `docker volume create --driver=vmdk --name=some-vol -o vsan-policy-name=some-policy`.
+option such as `docker volume create --driver=vsphere --name=some-vol -o vsan-policy-name=some-policy`.
 The number of virtual disks using the policy will then show up in the `Active` column.
 
 #### Update

--- a/docs/user-guide/docker-plugin-drivers.md
+++ b/docs/user-guide/docker-plugin-drivers.md
@@ -1,21 +1,24 @@
 [TOC]
-The Docker volume plugin supports the below platforms and the corresponding drivers for those. The plugin supports all volume provisioning and managenment operations, defined by the Docker Volume plugin interface, on both platforms.
+The Docker volume plugin supports the below platforms and the corresponding drivers for those. The plugin supports all volume provisioning and managenment operations, defined by the Docker Volume plugin interface, on both platforms. Both drivers allow users to provision and use VMDK backed volumes for containers in Docker.
 
-1. Vmdk
+1. vSphere
 2. Photon
 
 <script type="text/javascript" src="https://asciinema.org/a/80417.js" id="asciicast-80417" async></script>
 
-## Docker Vmdk volume driver 
-The Docker Vmdk volume driver supports provisioning and managing docker volumes on a standalone or cluster of ESX servers via a service (ESX service) that's installed and runs on each server. Docker volumes are created and managed via publicly available VIM (Virtual Infrastructure Management) APIs on the ESX host.
+## Docker vsphere volume driver
+The Docker vsphere volume driver supports provisioning and managing docker volumes on a standalone or cluster of ESX servers via a service (ESX service) that's installed and runs on each server. Docker volumes are created and managed via publicly available VIM (Virtual Infrastructure Management) APIs on the ESX host.
 
-## Docker Photon volume driver 
-The Docker Photon Volume driver supports provisioning and managing docker volumes on a Photon platform consisting of a cluster of ESX hosts managed via a Photon controller instance. Docker volumes are created and managed entirely via the open Photon platform API via the Photon controller.
+## Docker photon volume driver
+The Docker photon volume driver supports provisioning and managing docker volumes on a Photon platform consisting of a cluster of ESX hosts managed via a Photon controller instance. Docker volumes are created and managed entirely via the open Photon platform API via the Photon controller.
 
 The Docker Volume plugin can support either or both types of volumes, as required, on a given Docker host.
 
 ## Configuring the Docker Volume Plugin
-The docker volume plugin is designed to load run time options and values from a json configuration file (default /etc/docker-volume-vsphere.conf) on the host. The user can also provide a configuration file, via the "--config" option, specifying the full path of the file. The file contains the values for run time options used by the plugin. Options that are currently recognized include the below set. Options provided on the command line will override those in the configuration file.
+The docker volume plugin loads runtime options and values from a json configuration file (default /etc/docker-volume-vsphere.conf) on the host. The user can override the default configuration by providing a different configuration file, via the "--config" option, specifying the full path of the file. Options that are currently recognized include the below set. Options passed on the command line override those in the configuration file.
+
+### Selecting the driver to handle volume operations
+The docker volume plugin supports two drivers, namely, "photon" and "vsphere" for the Photon and vSphere platforms respectively. The "vsphere" driver was earlier named as "vmdk" and the plugin still supports both names. The "vmdk" driver name can be used in place of "vsphere" for now, but will be deprecated in a later release. The choice of driver is specified as below in the sample configuration. The plugin uses "vsphere' as the default driver, which is overriden via the configuration file for the Photon platform.
 
 ### Options for the photon volume driver
 Target    - URL at which to contact the Photon Controller
@@ -28,8 +31,9 @@ LogPath       - location where plugin log fils are created
 MaxLogSizeMb  - max. size of the plugin log file
 MaxLogAgeDays - number of days to retain plugin log files
 
-## Sample plugin configuration, the "Target", "Project" and "Host" options are for photon only.
+## Sample plugin configuration
 {
+	"Driver": "<driver name - vsphere/vmdk/photon>"
 	"MaxLogAgeDays": 28,
 	"MaxLogSizeMb": 100,
 	"LogPath": "/var/log/docker-volume-vsphere.log",

--- a/docs/user-guide/docker-volume-cli.md
+++ b/docs/user-guide/docker-volume-cli.md
@@ -8,33 +8,33 @@ The service works with existing Docker volume commands.
 4. [Docker volume rm](https://docs.docker.com/engine/reference/commandline/volume_rm/)
 
 
-The Docker volume commands are supported for both the Vmdk and Photon platforms with minor differences in capabilities. Features that are specific to either of the platforms are mentioned explicitly below.
+The Docker volume commands are supported for both the vSphere and Photon platforms with minor differences in capabilities. Features that are specific to either of the platforms are mentioned explicitly below.
 <script type="text/javascript" src="https://asciinema.org/a/80417.js" id="asciicast-80417" async></script>
 
 ## Docker volume create options
 ### size
 
 ```
-docker volume create --driver=<vmdk/photon> --name=MyVolume -o size=10gb
+docker volume create --driver=<vsphere/photon> --name=MyVolume -o size=10gb
 ```
 
 The volume units can be ```mb, gb and tb```
 
 The default volume size is 100mb
 
-### vsan-policy-name (Vmdk only)
+### vsan-policy-name (vSphere only)
 
 ```
-docker volume create --driver=vmdk --name=MyVolume -o size=10gb -o vsan-policy-name=allflash
+docker volume create --driver=vsphere --name=MyVolume -o size=10gb -o vsan-policy-name=allflash
 ```
 
 Policy needs to be created via the vmdkops-admin-cli. Once policy is created, it can be addressed during create by passing the ```-o vsan-policy-name``` flag.
 
-### diskformat (Vmdk only)
+### diskformat (vSphere only)
 ```
-docker volume create --driver=vmdk --name=MyVolume -o size=10gb -o diskformat=zeroedthick
-docker volume create --driver=vmdk --name=MyVolume -o size=10gb -o diskformat=thin
-docker volume create --driver=vmdk --name=MyVolume -o size=10gb -o diskformat=eagerzeroedthick
+docker volume create --driver=vsphere --name=MyVolume -o size=10gb -o diskformat=zeroedthick
+docker volume create --driver=vsphere --name=MyVolume -o size=10gb -o diskformat=thin
+docker volume create --driver=vsphere --name=MyVolume -o size=10gb -o diskformat=eagerzeroedthick
 ```
 
 Docker volumes are backed by VMDKs. VMDKs support multiple [types](https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1022242)
@@ -45,10 +45,10 @@ Currently the following are supported
 2. Thin Provision ([thin]((https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1022242)))
 3. Thick Provision Eager Zeroed ([eagerzeroedthick]((https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1022242)))
 
-### attach_as (Vmdk only)
+### attach_as (vSphere only)
 ```
-docker volume create --driver=vmdk --name=MyVolume -o size=10gb -o attach_as=independent_persistent
-docker volume create --driver=vmdk --name=MyVolume -o size=10gb -o attach_as=persistent
+docker volume create --driver=vsphere --name=MyVolume -o size=10gb -o attach_as=independent_persistent
+docker volume create --driver=vsphere --name=MyVolume -o size=10gb -o attach_as=persistent
 ```
 Docker volumes are backed by VMDKs. VMDKs are attached to the VM in which Docker is requesting for a volume during Docker run. VMDKs can be attached in [different modes.](http://cormachogan.com/2013/04/16/what-are-dependent-independent-disks-persistent-and-non-persisent-modes/)
 
@@ -57,33 +57,33 @@ Currently the following are supported
 1. [persistent](http://cormachogan.com/2013/04/16/what-are-dependent-independent-disks-persistent-and-non-persisent-modes/): If the VMDK is attached as persistent it will be part of a VM snapshot. If a VM snapshot has been taken while the Docker volume is attached to a VM, the Docker volume then continues to be attached to the VM that was snapshotted.
 2. [independent_persistent](http://cormachogan.com/2013/04/16/what-are-dependent-independent-disks-persistent-and-non-persisent-modes/): If the VMDK is attached as independent_persistent it will not be part of a VM snapshot. The Docker volume can be attached to any VM that can access the datastore independent of snapshots.
 
-### access (Vmdk only)
+### access (vSphere only)
 ```
-docker volume create --driver=vmdk --name=MyVolume -o access=read-only -o diskformat=thin
-docker volume create --driver=vmdk --name=MyVolume -o access=read-write -o diskformat=thin (default)
+docker volume create --driver=vsphere --name=MyVolume -o access=read-only -o diskformat=thin
+docker volume create --driver=vsphere --name=MyVolume -o access=read-write -o diskformat=thin (default)
 ```
 
 The access mode determines if the volume is modifiable by containers in a VM. The access mode allows to first create a volume with write access and initialize it with binary images, libraries (for exmple), and subsequently change the access to "read-only" (via the admin CLI). Thereby, creating content sharable by all containers in a VM.
 
 ### fstype
 ```
-docker volume create --driver=<vmdk/photon> --name=MyVolume -o size=10gb -o fstype=xfs
-docker volume create --driver=<vmdk/photon> --name=MyVolume -o size=10gb -o fstype=ext4 (default)
+docker volume create --driver=<vsphere/photon> --name=MyVolume -o size=10gb -o fstype=xfs
+docker volume create --driver=<vsphere/photon> --name=MyVolume -o size=10gb -o fstype=ext4 (default)
 ```
 
 Specifies which filesystem will be created on the new volume. vSphere Docker Volume Service will search for a existing /sbin/mkfs.**fstype** on the docker host to create the filesystem, and if not found it will return a list of filesystems for which it has found a corresponding mkfs. The specified filesystem must be supported by the running kernel and support labels (-L flag for mkfs). Defaults to ext4 if not specified. 
 
-### clone-from (Vmdk only)
+### clone-from (vSphere only)
 ```
-docker volume create --driver=vmdk --name=CloneVolume -o clone-from=MyVolume -o access=read-only
-docker volume create --driver=vmdk --name=CloneVolume -o clone-from=MyVolume -o diskformat=thin (default)
+docker volume create --driver=vsphere --name=CloneVolume -o clone-from=MyVolume -o access=read-only
+docker volume create --driver=vsphere --name=CloneVolume -o clone-from=MyVolume -o diskformat=thin (default)
 ```
 
 Specifies a volume to be cloned when creating a new volume. The created clone is completely independent from the original volume and will inherit the same options, which can be changed with the exception of the size and fstype.
  
 ### flavor (Photon only)
 ...
-docker volume create --driver=vmdk --name=CloneVolume -o flavor=<Photon persistent disk flavor name>
+docker volume create --driver=vsphere --name=CloneVolume -o flavor=<Photon persistent disk flavor name>
 ...
 
 The flavor specifies the name of the persistent disk flavor that must have already been created in the Photon Controller. The flavor indicats the resource limits that are applied to the volume being created.

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -136,7 +136,7 @@ DRIVER              VOLUME NAME
 
 Step 5: Run “docker volume create”  to create a new volume “new-tenant1-vol1” and run “docker volume ls”,   should only able to see this volume which was just created
 ``` 
-root@photon-JQQBWNwG6 [ ~ ]# docker volume create --driver=vmdk --name=new-tenant1-vol1 -o size=100MB
+root@photon-JQQBWNwG6 [ ~ ]# docker volume create --driver=vsphere --name=new-tenant1-vol1 -o size=100MB
 new-tenant1-vol1
 root@photon-JQQBWNwG6 [ ~ ]# docker volume ls
 DRIVER              VOLUME NAME

--- a/misc/demos/behind-the-scenes.yaml
+++ b/misc/demos/behind-the-scenes.yaml
@@ -3,7 +3,7 @@ scenes:
   - name: Docker volume commands
     action: echo "Post install, use the plugin for docker volume operations"
   - name: Create a volume
-    action:  docker volume create --driver=vmdk --name=MyVolume -o size=10gb
+    action:  docker volume create --driver=vsphere --name=MyVolume -o size=10gb
     wait: true
   - name: Explain
     action: echo "Let us look at where the volume is on ESX"
@@ -15,7 +15,7 @@ scenes:
     action: echo "Each volume is mapped to a VMDK"
     wait: true
   - name: Create another volume
-    action:  docker volume create --driver=vmdk --name=MyOtherVolume -o size=10gb
+    action:  docker volume create --driver=vsphere --name=MyOtherVolume -o size=10gb
   - name: Check ESX to show VMDK. alias esx='ssh root@$ESX'
     action: esx ls /vmfs/volumes/vsanDatastore/dockvols
     wait: true

--- a/misc/demos/docker-volume-commands.yaml
+++ b/misc/demos/docker-volume-commands.yaml
@@ -3,7 +3,7 @@ scenes:
   - name: Docker volume commands
     action: echo "Post install, use the plugin for docker volume operations"
   - name: Create a volume
-    action:  docker volume create --driver=vmdk --name=MyVolume -o size=10gb
+    action:  docker volume create --driver=vsphere --name=MyVolume -o size=10gb
     wait: true
   - name: List volume
     action: docker volume ls

--- a/misc/demos/multiple-datastore.yaml
+++ b/misc/demos/multiple-datastore.yaml
@@ -3,7 +3,7 @@ scenes:
   - name: Docker volume commands
     action: echo "Post install, use the plugin for docker volume operations"
   - name: Create a volume
-    action:  docker volume create --driver=vmdk --name=MyVolume -o size=10gb
+    action:  docker volume create --driver=vsphere --name=MyVolume -o size=10gb
     wait: true
   - name: Explain
     action: echo "Let us look at where the volume is on ESX"
@@ -18,7 +18,7 @@ scenes:
     action: echo "Plugin can select datastore format:volume@<datastore>"
     wait: true
   - name: Create a volume
-    action:  docker volume create --driver=vmdk --name=MyVolume@datastore1 -o size=10gb
+    action:  docker volume create --driver=vsphere --name=MyVolume@datastore1 -o size=10gb
     wait: true
   - name: Explain
     action: echo "Let's check the datastore1"

--- a/misc/scripts/refcnt_test.sh
+++ b/misc/scripts/refcnt_test.sh
@@ -86,7 +86,7 @@ GREP="$DEBUG grep"
 echo "Testing refcounts..."
 
 echo "Creating volume $vname and $count containers using it"
-$DOCKER volume create --driver=vmdk --name=$vname -o size=1gb
+$DOCKER volume create --driver=vsphere --name=$vname -o size=1gb
 if [ "$?" -ne 0 ] ; then
    echo FAILED TO CREATE $vname
    exit 1

--- a/vmdk_plugin/E2E_Tests/createVolume_test.go
+++ b/vmdk_plugin/E2E_Tests/createVolume_test.go
@@ -38,7 +38,7 @@ The issue was observed on photon so steps are mentioned for photon OS only in fa
 test should be OS agnostic.
 
 1. create docker volume using following command
-	docker volume create --driver=vmdk --name=testVol -o size=10gb
+	docker volume create --driver=vsphere --name=testVol -o size=10gb
 2. verify volume is created correctly or not
 3. delete created volume
 

--- a/vmdk_plugin/E2E_Tests/e2e_verifyVolmProperties_test.go
+++ b/vmdk_plugin/E2E_Tests/e2e_verifyVolmProperties_test.go
@@ -76,7 +76,7 @@ func TestVolumeProperties(t *testing.T) {
 				containerName = "busybox_" + strconv.FormatInt(time.Now().Unix(), 20)
 				log.Println("Creating a volume of Format Type - ", formatTypes[k])
 				volName := TestInputParamsUtil.GetVolumeNameWithTimeStamp("dockerVol")
-				_, err := TestUtil.InvokeCommand(vms[vmIndx], "docker volume create --driver=vmdk --name="+
+				_, err := TestUtil.InvokeCommand(vms[vmIndx], "docker volume create --driver=vsphere --name="+
 					volName+" -o size="+volSizes[i]+" -o diskformat="+formatTypes[k])
 				if err != nil {
 					log.Fatalf("Failed to create a volume named: %s. Error - %v ", volName, err)

--- a/vmdk_plugin/drivers/photon/photon_driver.go
+++ b/vmdk_plugin/drivers/photon/photon_driver.go
@@ -17,7 +17,7 @@ package photon
 //
 // VMWare VMDK Docker Data Volume plugin.
 //
-// Provide support for --driver=vmdk in Docker, when Docker VM is running under ESX.
+// Provide support for --driver=photon in Docker, when Docker VM is running under ESX.
 //
 // Serves requests from Docker Engine related to VMDK volume operations.
 // Depends on vmdk-opsd service to be running on hosting ESX

--- a/vmdk_plugin/drivers/vmdk/vmdk_driver.go
+++ b/vmdk_plugin/drivers/vmdk/vmdk_driver.go
@@ -15,9 +15,9 @@
 package vmdk
 
 //
-// VMWare VMDK Docker Data Volume plugin.
+// VMWare vSphere Docker Data Volume plugin.
 //
-// Provide support for --driver=vmdk in Docker, when Docker VM is running under ESX.
+// Provide support for --driver=vsphere in Docker, when Docker VM is running under ESX.
 //
 // Serves requests from Docker Engine related to VMDK volume operations.
 // Depends on vmdk-opsd service to be running on hosting ESX
@@ -41,8 +41,7 @@ const (
 	devWaitTimeout   = 1 * time.Second
 	sleepBeforeMount = 1 * time.Second
 	watchPath        = "/dev/disk/by-path"
-	version          = "VMDK Volume Driver v0.3"
-	driverName       = "vmdk"
+	version          = "vSphere Volume Driver v0.4"
 )
 
 // VolumeDriver - VMDK driver struct
@@ -55,7 +54,7 @@ type VolumeDriver struct {
 var mountRoot string
 
 // NewVolumeDriver creates Driver which to real ESX (useMockEsx=False) or a mock
-func NewVolumeDriver(port int, useMockEsx bool, mountDir string) *VolumeDriver {
+func NewVolumeDriver(port int, useMockEsx bool, mountDir string, driverName string) *VolumeDriver {
 	var d *VolumeDriver
 
 	vmdkops.EsxPort = port

--- a/vmdk_plugin/main.go
+++ b/vmdk_plugin/main.go
@@ -101,23 +101,9 @@ func main() {
 	// Define command line options
 	logLevel := flag.String("log_level", "info", "Logging Level")
 	configFile := flag.String("config", config.DefaultConfigPath, "Configuration file path")
+	driverName := flag.String("driver", "", "Volume driver")
 
-	// Load the configuration if one was provided.
-	c, err := config.Load(*configFile)
-	if err != nil {
-		log.Warning("Failed to load config file %s: %v", *configFile, err)
-	}
-
-	// Default driver, overridden by the config file
-	name := vsphereDriver
-	if c.Driver != "" {
-		name = c.Driver
-	}
-
-	// Driver specified on the command line overrides option in the config file
-	driverName := flag.String("driver", name, "Volume driver")
-
-	// photon driver options
+	// Photon driver options
 	targetURL := flag.String("target", "", "Photon controller URL")
 	projectID := flag.String("project", "", "Project ID of the docker host")
 	vmID := flag.String("host", "", "ID of docker host")
@@ -129,6 +115,22 @@ func main() {
 	flag.Parse()
 
 	logInit(logLevel, nil, configFile)
+
+	// Load the configuration if one was provided.
+	c, err := config.Load(*configFile)
+	if err != nil {
+		log.Warning("Failed to load config file %s: %v", *configFile, err)
+	}
+
+	// If no driver provided on the command line, use the one in the
+	// config file or the default.
+	if *driverName == "" {
+		if err == nil && c.Driver != "" {
+			*driverName = c.Driver
+		} else {
+			*driverName = vsphereDriver
+		}
+	}
 
 	log.WithFields(log.Fields{
 		"driver":    *driverName,

--- a/vmdk_plugin/sanity_test.go
+++ b/vmdk_plugin/sanity_test.go
@@ -70,7 +70,7 @@ func init() {
 	configFile := flag.String("config", config.DefaultConfigPath, "Configuration file path")
 
 	flag.BoolVar(&removeContainers, "rm", true, "rm container after run")
-	flag.StringVar(&driverName, "d", "vmdk", "Driver name. We refcount volumes on this driver")
+	flag.StringVar(&driverName, "d", "vsphere", "Driver name. We refcount volumes on this driver")
 	flag.IntVar(&parallelVolumes, "parallel_volumes", 5, "Volumes per docker daemon for create/delete concurrent tests")
 	flag.IntVar(&parallelClones, "parallel_clones", 3, "Volumes per docker daemon for clone concurrent tests")
 	flag.Parse()

--- a/vmdk_plugin/utils/config/config.go
+++ b/vmdk_plugin/utils/config/config.go
@@ -37,6 +37,7 @@ const (
 
 // Config stores the configuration for the plugin
 type Config struct {
+	Driver        string `json:",omitempty"`
 	LogPath       string `json:",omitempty"`
 	MaxLogSizeMb  int    `json:",omitempty"`
 	MaxLogAgeDays int    `json:",omitempty"`

--- a/vmdk_plugin/utils/test_util/VolumeCreationTestUtil.go
+++ b/vmdk_plugin/utils/test_util/VolumeCreationTestUtil.go
@@ -30,7 +30,7 @@ var SSH_OPTS []string = []string{strings.Split(os.Getenv("SSH_KEY_OPT"), " ")[0]
 // defaults.
 func CreateDefaultVolume(ip string, name string) ([]byte, error) {
 	fmt.Printf("\ncreating volume [%s] on VM[%s]", name, ip)
-	return InvokeCommand(ip, "docker volume create --driver=vmdk --name="+name)
+	return InvokeCommand(ip, "docker volume create --driver=vsphere --name="+name)
 }
 
 // This helper deletes the created volume as per passed volume name.


### PR DESCRIPTION
Updated docs and the plugin init code to expose a "vsphere" driver.

plugin logs

2017-02-16 01:42:49.690079924 -0800 PST [INFO] No config file found. Using defaults.
2017-02-16 01:42:49.690279065 -0800 PST [INFO] Starting plugin log_level=debug config="/etc/docker-volume-vsphere.conf" driver=vsphere
2017-02-16 01:42:49.690325892 -0800 PST [WARNING] Failed to load config file %s: %v/etc/docker-volume-vsphere.confopen /etc/docker-volume-vsphere.conf: no such file or directory
2017-02-16 01:42:49.690346301 -0800 PST [INFO] Plugin options - port=1019
2017-02-16 01:42:49.690389849 -0800 PST [INFO] Getting volume data from unix:///var/run/docker.sock
2017-02-16 01:42:49.763661689 -0800 PST [DEBUG] Docker info: version=1.13.0-rc1, root=/var/lib/docker, OS=Ubuntu 14.04.5 LTS
2017-02-16 01:42:49.764895552 -0800 PST [DEBUG] Found 0 running or paused containers
2017-02-16 01:42:49.765255637 -0800 PST [INFO] Discovered 0 volumes in use.
2017-02-16 01:42:49.765306372 -0800 PST [INFO] Docker Vsphere plugin started version="VSphere Volume Driver v0.3" port=1019 mock_esx=false
2017-02-16 01:42:49.765423389 -0800 PST [INFO] Going into ServeUnix - Listening on Unix socket address="/run/docker/plugins/vsphere.sock"
2017-02-16 01:42:49.765706329 -0800 PST [DEBUG] root group found. gid: 0

Docker reports the new driver.

$ docker volume ls
DRIVER              VOLUME NAME
vsphere             newvol1@bigone
vsphere             newvol2@bigone
vsphere             newvol3@bigone
vsphere             newvol@bigone
