### PR TITLE
Use VM uuid if the VM name can't be got locally.

### DIFF
--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -563,7 +563,7 @@ def get_creation_info(metadata):
 
 
 def get_attached_to(metadata):
-    """ Return which VM a volume is attached to based on its metadata """
+    """ Return which VM a volume is attached to based on its metadata. """
     try:
         vm_name = vmdk_ops.vm_uuid2name(metadata[kv.ATTACHED_VM_UUID])
         if not vm_name:

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -528,7 +528,7 @@ def ls_dash_c(columns, tenant_reg):
 def all_ls_headers():
     """ Return a list of all header for ls -l """
     return ['Volume', 'Datastore', 'Created By VM', 'Created',
-            'Attached To VM', 'Policy', 'Capacity', 'Used',
+            'Attached To VM (name/uuid)', 'Policy', 'Capacity', 'Used',
             'Disk Format', 'Filesystem Type', 'Access', 'Attach As']
 
 def generate_ls_rows(tenant_reg):

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -567,7 +567,10 @@ def get_attached_to(metadata):
     try:
         vm_name = vmdk_ops.vm_uuid2name(metadata[kv.ATTACHED_VM_UUID])
         if not vm_name:
+            if metadata[kv.ATTACHED_VM_UUID]:
+                return metadata[kv.ATTACHED_VM_UUID]
             return kv.DETACHED
+
         return vm_name
     except:
         return kv.DETACHED


### PR DESCRIPTION
Use the VM uuid if the VM name can't be got on the local ESX host. The VM could be on a different ESX host in that case. Its possible that the VM doesn't exist even, but the volume KV may still record the fact. In which case a subsequent attach of the volume on the other ESX host will clear the stale attached-to entry in the volume KV. From a remote node there's nothing much that can be done in this case except use the data thats in the KV.