### PR TITLE
Fix for #942 - set uuid correctly

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -632,7 +632,7 @@ def get_vol_path(datastore, tenant_name=None):
             errMsg = "Failed to initialize volume path {0} - {1}".format(path, out)
             logging.warning(errMsg)
             return None, err(errMsg)
-        
+
         # create the symbol link /vmfs/volumes/datastore_name/dockvol/tenant_name
         symlink_path = os.path.join(dock_vol_path, tenant_name)
         if not os.path.isdir(symlink_path):
@@ -718,13 +718,13 @@ def executeRequest(vm_uuid, vm_name, config_path, cmd, full_vol_name, opts):
         # if default_datastore is not set for tenant,
         # default_datastore will be set to None
         error_info, default_datastore = auth_api.get_default_datastore(tenant_name)
-        # if get default_datastore fails or default_datastore is not specified, 
+        # if get default_datastore fails or default_datastore is not specified,
         # use vm_datastore
         if error_info or not default_datastore:
             default_datastore = vm_datastore
-    
+
     logging.debug("executeRequest: vm_uuid=%s, vm_name=%s, tenant_name=%s, tenant_uuid=%s, default_datastore=%s",
-                  vm_uuid, vm_name, tenant_uuid, tenant_name, default_datastore)    
+                  vm_uuid, vm_name, tenant_uuid, tenant_name, default_datastore)
 
     if cmd == "list":
         threadutils.set_thread_name("{0}-nolock-{1}".format(vm_name, cmd))
@@ -999,8 +999,8 @@ def handle_stale_attach(vmdk_path, kv_uuid):
                                                                 cur_vm.config.name)
              return err(msg)
        else:
-          logging.warning("Failed to find VM %s that attached the disk %s, resetting volume metadata",
-                          cur_vm.config.name, vmdk_path)
+          logging.warning("Failed to find VM (id %s) attaching the disk %s, resetting volume metadata",
+                          kv_uuid, vmdk_path)
           ret = reset_vol_meta(vmdk_path)
           if ret:
              return ret


### PR DESCRIPTION
Fixes #942 (mount rejected).

This was caused by the bug in `handle_stale_attach` where the code first check that 'cur_vm == None` and if it is, still tries to use curr.config in the log message.

Tested manually: 
* Step 1:  prepare a corrupted KV file 
  * created a docker volume `docker volume create -d vmdk --name=uv1`
  * attached a volume to a VM `docker run --name ng -d -p 80:80 -v uv1:/uv1 nginx `
  * on ESX, copied the .vmfd file to a backup
  * killed the container to detach the volume `docker rm -f ng`
  * on ESX, copied a backup version back to .vmfd file and replaced attach_uuid with all 1 so VM with uuid would be not found
* Step 2: test without a change `docker run -d -p 80:80 -v uv1:/uv1 nginx`
  * result `docker: Error response from daemon: error while mounting volume '/mnt/vmdk/uv1': VolumeDriver.Mount: Server returned an error: AttributeError("'NoneType' object has no attribute 'config'",).`
   * also the log shows traceback reported in the bug
* Step 3: update the code with the fix ,  redeployed the VIB and rerun the command. 
   * result: success and the following log 
```
0/24/16 13:30:39 2560127 [photon-1-[datastore1] dockvols/4a3fccea-a878-40ec-b07c-24f58f1c0de2/uv1.vmdk] [WARNING] Failed to find VM (id 11111111-7496-cbf0-ce67-792f6bf76619) attaching the disk /vmfs/volumes/datastore1/dockvols/4a3fccea-a878-40ec-b07c-24f58f1c0de2/uv1.vmdk, resetting volume metadata
10/24/16 13:30:40 2560127 [photon-1-[datastore1] dockvols/4a3fccea-a878-40ec-b07c-24f58f1c0de2/uv1.vmdk] [INFO   ] Disk /vmfs/volumes/datastore1/dockvols/4a3fccea-a878-40ec-b07c-24f58f1c0de2/uv1.vmdk successfully attached. controller pci_slot_number=192, disk_slot=0
```

  