### PR TITLE
Disallow renaming the default tenant.

### DIFF
--- a/esx_service/utils/auth_api.py
+++ b/esx_service/utils/auth_api.py
@@ -29,6 +29,7 @@ import re
 # regex for valid tenant name
 VALID_TENANT_NAME_REGEXP = "[a-zA-Z0-9_][a-zA-Z0-9_.-]*"
 VALID_TENANT_NAMES = 'rename of vm-groups other than _DEFAULT'
+
 global valid_tenant_name_reg
 valid_tenant_name_reg = re.compile("^" + VALID_TENANT_NAME_REGEXP + "$")
 
@@ -348,10 +349,6 @@ def _tenant_create(name, description="", vm_list=None, privileges=None):
 
 def _tenant_update(name, new_name=None, description=None, default_datastore=None):
     """ API to update a tenant """
-    if name == auth_data_const.DEFAULT_TENANT:
-        error_info = error_code.generate_error_info(ErrorCode.TENANT_NAME_INVALID, name, VALID_TENANT_NAMES)
-        return error_info
-
     error_info, tenant = get_tenant_from_db(name)
     if error_info:
         return error_info
@@ -366,6 +363,10 @@ def _tenant_update(name, new_name=None, description=None, default_datastore=None
         return error_info
 
     if new_name:
+        if name == auth_data_const.DEFAULT_TENANT:
+            error_info = error_code.generate_error_info(ErrorCode.TENANT_NAME_INVALID, name, VALID_TENANT_NAMES)
+            return error_info
+
         # check whether tenant with new_name already exist or not
         error_info = check_tenant_exist(new_name)
         if error_info:

--- a/esx_service/utils/auth_api.py
+++ b/esx_service/utils/auth_api.py
@@ -28,6 +28,7 @@ import re
 
 # regex for valid tenant name
 VALID_TENANT_NAME_REGEXP = "[a-zA-Z0-9_][a-zA-Z0-9_.-]*"
+VALID_TENANT_NAMES = 'rename of vm-groups other than _DEFAULT'
 global valid_tenant_name_reg
 valid_tenant_name_reg = re.compile("^" + VALID_TENANT_NAME_REGEXP + "$")
 
@@ -347,6 +348,10 @@ def _tenant_create(name, description="", vm_list=None, privileges=None):
 
 def _tenant_update(name, new_name=None, description=None, default_datastore=None):
     """ API to update a tenant """
+    if name == auth_data_const.DEFAULT_TENANT:
+        error_info = error_code.generate_error_info(ErrorCode.TENANT_NAME_INVALID, name, VALID_TENANT_NAMES)
+        return error_info
+
     error_info, tenant = get_tenant_from_db(name)
     if error_info:
         return error_info


### PR DESCRIPTION
Verified as below,
/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vm-group update --name=_DEFAULT --descr
iption="Renaming default tenant to vm-group1" --new-name=new-vm-group1
Vm-group name _DEFAULT is invalid, only rename of vm-groups other than _DEFAULT is allowed
