### PR TITLE
Fix the issue that client without protocol version set cannot talk to server with protocol version check.

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -1491,8 +1491,9 @@ def execRequestThread(client_socket, cartel, request):
             send_vmci_reply(client_socket, reply_string)
         else:
             logging.debug("execRequestThread: req=%s", req)
-            # If req from client does not include version number, set the version to "2" by default
-            client_protocol_version = int(req["version"]) if "version" in req else 2
+            # If req from client does not include version number, set the version to
+            # SERVER_PROTOCOL_VERSION by default
+            client_protocol_version = int(req["version"]) if "version" in req else SERVER_PROTOCOL_VERSION
             logging.debug("execRequestThread: version=%d", client_protocol_version)
             if client_protocol_version != SERVER_PROTOCOL_VERSION:
                 if client_protocol_version < SERVER_PROTOCOL_VERSION:

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -1492,7 +1492,7 @@ def execRequestThread(client_socket, cartel, request):
         else:
             logging.debug("execRequestThread: req=%s", req)
             # If req from client does not include version number, set the version to
-            # SERVER_PROTOCOL_VERSION by default
+            # SERVER_PROTOCOL_VERSION by default to make backward compatible
             client_protocol_version = int(req["version"]) if "version" in req else SERVER_PROTOCOL_VERSION
             logging.debug("execRequestThread: version=%d", client_protocol_version)
             if client_protocol_version != SERVER_PROTOCOL_VERSION:

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -1491,8 +1491,8 @@ def execRequestThread(client_socket, cartel, request):
             send_vmci_reply(client_socket, reply_string)
         else:
             logging.debug("execRequestThread: req=%s", req)
-            # If req from client does not include version number, set the version to "1" by default
-            client_protocol_version = int(req["version"]) if "version" in req else 1
+            # If req from client does not include version number, set the version to "2" by default
+            client_protocol_version = int(req["version"]) if "version" in req else 2
             logging.debug("execRequestThread: version=%d", client_protocol_version)
             if client_protocol_version != SERVER_PROTOCOL_VERSION:
                 if client_protocol_version < SERVER_PROTOCOL_VERSION:


### PR DESCRIPTION
This PR is to make sure client without protocol version set can talk to server with protocol check 
to make sure the backward compatibility.
Fixed #1102.