### PR TITLE
Enable all concurrent tests.

### DIFF
--- a/vmdk_plugin/sanity_test.go
+++ b/vmdk_plugin/sanity_test.go
@@ -311,28 +311,27 @@ func TestConcurrency(t *testing.T) {
 	fmt.Printf("%s END: Running create/delete multi-host concurrent test ...\n",
 		time.Now().Format(time.RFC3339))
 
-	// TODO: Temporarily disable test until #1062 is root caused & fixed.
-	// fmt.Printf("Running same docker host concurrent create/delete test on %s...\n", clients[0].endPoint)
-	// parallelVolumes1 := parallelVolumes / 2
-	// for idx := 0; idx < 3; idx++ {
-	// 	go func(idx int, c *client.Client) {
-	// 		for i := 0; i < parallelVolumes1; i++ {
-	// 			volName := fmt.Sprintf("%s-same%d%d", volumeName, idx, i)
-	// 			createRequest.Name = volName
-	// 			_, err := c.VolumeCreate(context.Background(), createRequest)
-	// 			results <- err
-	// 			err = c.VolumeRemove(context.Background(), volName)
-	// 			results <- err
-	// 		}
-	// 	}(idx, clients[0].client)
-	// }
+	fmt.Printf("Running same docker host concurrent create/delete test on %s...\n", clients[0].endPoint)
+	parallelVolumes1 := parallelVolumes / 2
+	for idx := 0; idx < 3; idx++ {
+		go func(idx int, c *client.Client) {
+			for i := 0; i < parallelVolumes1; i++ {
+				volName := fmt.Sprintf("%s-same%d%d", volumeName, idx, i)
+				createRequest.Name = volName
+				_, err := c.VolumeCreate(context.Background(), createRequest)
+				results <- err
+				err = c.VolumeRemove(context.Background(), volName)
+				results <- err
+			}
+		}(idx, clients[0].client)
+	}
 	// Read the results from the channel
-	// for i := 0; i < 3*parallelVolumes1*2; i++ {
-	// 	err := <-results
-	// 	if err != nil {
-	// 		t.Errorf("Same docker host concurrent create/delete test failed, err: %v", err)
-	// 	}
-	// }
+	for i := 0; i < 3*parallelVolumes1*2; i++ {
+		err := <-results
+		if err != nil {
+			t.Errorf("Same docker host concurrent create/delete test failed, err: %v", err)
+		}
+	}
 
 	fmt.Printf("%s START: Running clone concurrent test...\n",
 		time.Now().Format(time.RFC3339))


### PR DESCRIPTION
Retain calloc of response buffer, verify original issue is reproduced. Minor fix in vmci_client.c code where the request sent is kept within MAXBUF size limit.

The build is successful and original panic isn't reproduced. Most likely it may be a GO/C run time issue that was addressed with the recent upgrade of Go run time.