### PR TITLE
Handle datastores that are not added to the datastore cache of the service

### DIFF
--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -839,6 +839,9 @@ def generate_tenant_ls_rows(tenant_list):
         else:
             default_datastore = vmdk_utils.get_datastore_name(tenant.default_datastore_url)
 
+        if default_datastore is None:
+            return rows
+
         vm_list = generate_vm_list(tenant.vms)
         rows.append([uuid, name, description, default_datastore, vm_list])
 
@@ -1019,6 +1022,10 @@ def generate_tenant_access_ls_rows(privileges):
             datastore = ""
         else:
             datastore = vmdk_utils.get_datastore_name(p.datastore_url)
+
+        if datastore is None:
+            return rows
+
         allow_create = ("False", "True")[p.allow_create]
         # p[auth_data_const.COL_MAX_VOLUME_SIZE] is max_volume_size in MB
         max_vol_size = UNSET if p.max_volume_size == 0 else human_readable(p.max_volume_size * MB)

--- a/esx_service/utils/vmdk_utils.py
+++ b/esx_service/utils/vmdk_utils.py
@@ -394,6 +394,8 @@ def get_datastore_name(datastore_url):
     # get_datastores() return a list of tuple
     # each tuple has format like (datastore_name, datastore_url, dockvol_path)
     res = [d[0] for d in get_datastores() if d[1] == datastore_url]
+    if not res:
+        return None
     return res[0]
 
 def get_datastore_url_from_config_path(config_path):

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -776,11 +776,11 @@ def datastore_path_exist(datastore_name):
 def get_datastore_name(datastore_url):
     """ Get datastore_name with given datastore_url """
     datastore_name = vmdk_utils.get_datastore_name(datastore_url)
-    if not datastore_path_exist(datastore_name):
+    if datastore_name is None or not datastore_path_exist(datastore_name):
         # path /vmfs/volumes/datastore_name does not exist
         # the possible reason is datastore_name which got from
-        # datastore cache is invalid(old name)
-        # need to refresh cache, and try again
+        # datastore cache is invalid(old name) need to refresh
+	# cache, and try again, may still return None
         vmdk_utils.init_datastoreCache()
         datastore_name = vmdk_utils.get_datastore_name(datastore_url)
 
@@ -802,6 +802,8 @@ def executeRequest(vm_uuid, vm_name, config_path, cmd, full_vol_name, opts):
     logging.debug("config_path=%s", config_path)
     vm_datastore_url = vmdk_utils.get_datastore_url_from_config_path(config_path)
     vm_datastore = get_datastore_name(vm_datastore_url)
+    logging.debug("executeRequest: vm_datastore = %s, vm_datastore_url = %s",
+                  vm_datastore, vm_datastore_url)
 
     error_info, tenant_uuid, tenant_name = auth.get_tenant(vm_uuid)
     if error_info:
@@ -813,16 +815,40 @@ def executeRequest(vm_uuid, vm_name, config_path, cmd, full_vol_name, opts):
         else:
             return err(error_info)
 
-    # if default_datastore is not set for tenant,
-    # default_datastore_url will be set to None
+    # if default_datastore is not set for tenant, default_datastore_url will be set to None
     error_info, default_datastore_url = auth_api.get_default_datastore_url(tenant_name)
+
     # if get_default_datastore fails or default_datastore_url is not specified,
-    # use vm_datastore_url
+    # use vm_datastore. The datastore URL is retreived after the chosen datastore
+    # is validated.
     if error_info or not default_datastore_url:
-        default_datastore_url = vm_datastore_url
         default_datastore = vm_datastore
+        default_datastore_url = vm_datastore_url
     else:
         default_datastore = get_datastore_name(default_datastore_url)
+
+    try:
+        vol_name, datastore = parse_vol_name(full_vol_name)
+    except ValidationError as ex:
+        return err(str(ex))
+
+    if not datastore:
+        datastore = default_datastore
+
+    # Its possible the datastore is None, which can happen if datastores on the
+    # host could not be identified or initialized with the dockvols path.
+    if not datastore:
+        return err("Invalid datastore '%s'.\n" \
+                "Known datastores: %s.\n" \
+                % (datastore, ", ".join(get_datastore_names_list())))
+    elif not vmdk_utils.validate_datastore(datastore):
+        return err("Invalid datastore '%s'.\n" \
+                "Known datastores: %s.\n" \
+                "Default datastore: %s" \
+                % (datastore, ", ".join(get_datastore_names_list()), default_datastore))
+
+    # datastore is present and validated.
+    datastore_url = vmdk_utils.get_datastore_url(datastore)
 
     logging.debug("executeRequest: vm_uuid=%s, vm_name=%s, tenant_name=%s, tenant_uuid=%s, default_datastore_url=%s",
                   vm_uuid, vm_name, tenant_uuid, tenant_name, default_datastore_url)
@@ -832,29 +858,9 @@ def executeRequest(vm_uuid, vm_name, config_path, cmd, full_vol_name, opts):
         # if default_datastore is not set, should return error
         return listVMDK(tenant_name)
 
-    try:
-        vol_name, datastore = parse_vol_name(full_vol_name)
-    except ValidationError as ex:
-        return err(str(ex))
-
-    if datastore and not vmdk_utils.validate_datastore(datastore):
-        return err("Invalid datastore '%s'.\n" \
-                "Known datastores: %s.\n" \
-                "Default datastore: %s" \
-                % (datastore, ", ".join(get_datastore_names_list()), default_datastore))
-
-    if not datastore:
-        datastore_url = default_datastore_url
-        datastore = default_datastore
-    else:
-        datastore_url = vmdk_utils.get_datastore_url(datastore)
-
     error_info, tenant_uuid, tenant_name = auth.authorize(vm_uuid, datastore_url, cmd, opts)
     if error_info:
         return err(error_info)
-
-    # get /vmfs/volumes/<volid>/dockvols path on ESX:
-    datastore = get_datastore_name(datastore_url)
 
     path, errMsg = get_vol_path(datastore, tenant_name)
     logging.debug("executeRequest for tenant %s with path %s", tenant_name, path)

--- a/esx_service/vmodl/VsphereContainerServiceImpl.py
+++ b/esx_service/vmodl/VsphereContainerServiceImpl.py
@@ -252,6 +252,8 @@ class TenantManagerImpl(vim.vcs.TenantManager):
         # Populate default datastore
         if tenant.default_datastore_url:
             result.default_datastore = vmdk_utils.get_datastore_name(tenant.default_datastore_url)
+            if result.default_datastore is None:
+                return None
 
         # Populate associated VMs
         if tenant.vms:
@@ -276,6 +278,9 @@ class TenantManagerImpl(vim.vcs.TenantManager):
 
         result = vim.vcs.storage.DatastoreAccessPrivilege()
         result.datastore =  vmdk_utils.get_datastore_name(privilege.datastore_url)
+        if result.datastore is None:
+            return None
+
         result.allow_create = privilege.allow_create
         result.volume_max_size = privilege.max_volume_size
         result.volume_total_size = privilege.usage_quota


### PR DESCRIPTION
See issue #1116 for root cause. The issue is the service is unable to initialize Fix includes the following changes,

1. Fix utils/vmdk_utils.py:get_datastore_name() to handle a possible empty list when searching the "datastore" list for a given datastore name. Return None if the datastore isn't found.

2. Handle all callers of vmdk_utils.py:get_datastore_name().

3. Fixed vmdk_ops.py:executeRequest() to reorder the code a bit to keep all the datastore determination logic together. The sequence is like this,
a. Get the vm datastore name and datastore URL.
b. Get the datastore name and URL from the tenant.
c. Check if the user has specified a datastore and use that if specified.
d. If (c) is false then use the datastore name and URL from (b) or (a) if (b) is not valid.
e. New check - verify that the datastore isn't None. Which can happen as in #1116 (service is unable to access the VM datastore).
f. If datastore is valid then validate its in the datastore cache.