### PR TITLE
Handle datastores missing in the datatore cache and special chars in datastore names.

### DIFF
--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -920,6 +920,8 @@ def generate_tenant_ls_rows(tenant_list):
             default_datastore = ""
         else:
             default_datastore = vmdk_utils.get_datastore_name(tenant.default_datastore_url)
+            if default_datastore is None:
+                default_datastore = ""
 
         vm_list = generate_vm_list(tenant.vms)
         rows.append([uuid, name, description, default_datastore, vm_list])
@@ -1101,6 +1103,9 @@ def generate_tenant_access_ls_rows(privileges):
             datastore = ""
         else:
             datastore = vmdk_utils.get_datastore_name(p.datastore_url)
+            if datastore is None:
+                datastore = ""
+
         allow_create = ("False", "True")[p.allow_create]
         # p[auth_data_const.COL_MAX_VOLUME_SIZE] is max_volume_size in MB
         max_vol_size = UNSET if p.max_volume_size == 0 else human_readable(p.max_volume_size * MB)

--- a/esx_service/utils/vmdk_utils.py
+++ b/esx_service/utils/vmdk_utils.py
@@ -394,7 +394,7 @@ def get_datastore_name(datastore_url):
     # get_datastores() return a list of tuple
     # each tuple has format like (datastore_name, datastore_url, dockvol_path)
     res = [d[0] for d in get_datastores() if d[1] == datastore_url]
-    return res[0]
+    return res[0] if res else None
 
 def get_datastore_url_from_config_path(config_path):
     """Returns datastore url in config_path """

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -704,7 +704,7 @@ def get_vol_path(datastore, tenant_name=None):
         return path, None
 
     if not os.path.isdir(dock_vol_path):
-        # The osfs tools are usable for DOCK_VOLS_DIR on all datastores
+        # The osfs tools are usable for DOCK_VOLS_DIR on all datastores.
         cmd = "{} '{}'".format(OSFS_MKDIR_CMD, dock_vol_path)
         logging.info("Creating %s, running '%s'", dock_vol_path, cmd)
         rc, out = RunCommand(cmd)

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -688,15 +688,15 @@ def get_vol_path(datastore, tenant_name=None):
     # is created on <datastore>/DOCK_VOLS_DIR/tenant_uuid
     # a symlink <datastore>/DOCK_VOLS_DIR/tenant_name will be created to point to
     # path <datastore>/DOCK_VOLS_DIR/tenant_uuid
-    dock_vol_path = os.path.join("/vmfs/volumes", datastore, DOCK_VOLS_DIR)
+
+    path = dock_vol_path = os.path.join("/vmfs/volumes", datastore, DOCK_VOLS_DIR)
+
     if tenant_name:
         error_info, tenant = auth_api.get_tenant_from_db(tenant_name)
         if error_info:
             logging.error("get_vol_path: failed to find tenant info for tenant %s", tenant_name)
             path = dock_vol_path
         path = os.path.join(dock_vol_path, tenant.id)
-    else:
-        path = dock_vol_path
 
     if os.path.isdir(path):
         # If the path exists then return it as is.
@@ -705,7 +705,7 @@ def get_vol_path(datastore, tenant_name=None):
 
     if not os.path.isdir(dock_vol_path):
         # The osfs tools are usable for DOCK_VOLS_DIR on all datastores
-        cmd = "{0} {1}".format(OSFS_MKDIR_CMD, dock_vol_path)
+        cmd = "{} '{}'".format(OSFS_MKDIR_CMD, dock_vol_path)
         logging.info("Creating %s, running '%s'", dock_vol_path, cmd)
         rc, out = RunCommand(cmd)
         if rc != 0:
@@ -777,11 +777,11 @@ def datastore_path_exist(datastore_name):
 def get_datastore_name(datastore_url):
     """ Get datastore_name with given datastore_url """
     datastore_name = vmdk_utils.get_datastore_name(datastore_url)
-    if not datastore_path_exist(datastore_name):
+    if datastore_name is None or not datastore_path_exist(datastore_name):
         # path /vmfs/volumes/datastore_name does not exist
         # the possible reason is datastore_name which got from
-        # datastore cache is invalid(old name)
-        # need to refresh cache, and try again
+        # datastore cache is invalid(old name) need to refresh
+	# cache, and try again, may still return None
         vmdk_utils.init_datastoreCache()
         datastore_name = vmdk_utils.get_datastore_name(datastore_url)
 
@@ -803,6 +803,8 @@ def executeRequest(vm_uuid, vm_name, config_path, cmd, full_vol_name, opts):
     logging.debug("config_path=%s", config_path)
     vm_datastore_url = vmdk_utils.get_datastore_url_from_config_path(config_path)
     vm_datastore = get_datastore_name(vm_datastore_url)
+    logging.debug("executeRequest: vm_datastore = %s, vm_datastore_url = %s",
+                  vm_datastore, vm_datastore_url)
 
     error_info, tenant_uuid, tenant_name = auth.get_tenant(vm_uuid)
     if error_info:
@@ -814,14 +816,15 @@ def executeRequest(vm_uuid, vm_name, config_path, cmd, full_vol_name, opts):
         else:
             return err(error_info)
 
-    # if default_datastore is not set for tenant,
-    # default_datastore_url will be set to None
+    # if default_datastore is not set for tenant, default_datastore_url will be set to None
     error_info, default_datastore_url = auth_api.get_default_datastore_url(tenant_name)
+
     # if get_default_datastore fails or default_datastore_url is not specified,
-    # use vm_datastore_url
+    # use vm_datastore. The datastore URL is retreived after the chosen datastore
+    # is validated.
     if error_info or not default_datastore_url:
-        default_datastore_url = vm_datastore_url
         default_datastore = vm_datastore
+        default_datastore_url = vm_datastore_url
     else:
         default_datastore = get_datastore_name(default_datastore_url)
 
@@ -838,24 +841,24 @@ def executeRequest(vm_uuid, vm_name, config_path, cmd, full_vol_name, opts):
     except ValidationError as ex:
         return err(str(ex))
 
+    if not datastore:
+        datastore = default_datastore 
+
     if datastore and not vmdk_utils.validate_datastore(datastore):
         return err("Invalid datastore '%s'.\n" \
                    "Known datastores: %s.\n" \
                    "Default datastore: %s" \
                    % (datastore, ", ".join(get_datastore_names_list()), default_datastore))
 
-    if not datastore:
-        datastore_url = default_datastore_url
-        datastore = default_datastore
-    else:
-        datastore_url = vmdk_utils.get_datastore_url(datastore)
+    # datastore is present and validated.
+    datastore_url = vmdk_utils.get_datastore_url(datastore)
+
+    logging.debug("executeRequest: vm_uuid=%s, vm_name=%s, tenant_name=%s, tenant_uuid=%s, default_datastore_url=%s",
+                  vm_uuid, vm_name, tenant_uuid, tenant_name, default_datastore_url)
 
     error_info, tenant_uuid, tenant_name = auth.authorize(vm_uuid, datastore_url, cmd, opts)
     if error_info:
         return err(error_info)
-
-    # get /vmfs/volumes/<volid>/dockvols path on ESX:
-    datastore = get_datastore_name(datastore_url)
 
     path, errMsg = get_vol_path(datastore, tenant_name)
     logging.debug("executeRequest for tenant %s with path %s", tenant_name, path)

--- a/esx_service/vmodl/VsphereContainerServiceImpl.py
+++ b/esx_service/vmodl/VsphereContainerServiceImpl.py
@@ -252,6 +252,8 @@ class TenantManagerImpl(vim.vcs.TenantManager):
         # Populate default datastore
         if tenant.default_datastore_url:
             result.default_datastore = vmdk_utils.get_datastore_name(tenant.default_datastore_url)
+            if result.default_datastore is None:
+                return None
 
         # Populate associated VMs
         if tenant.vms:
@@ -276,6 +278,9 @@ class TenantManagerImpl(vim.vcs.TenantManager):
 
         result = vim.vcs.storage.DatastoreAccessPrivilege()
         result.datastore =  vmdk_utils.get_datastore_name(privilege.datastore_url)
+        if result.datastore is None:
+            return None
+
         result.allow_create = privilege.allow_create
         result.volume_max_size = privilege.max_volume_size
         result.volume_total_size = privilege.usage_quota


### PR DESCRIPTION
See issue #1116 for the root cause, there are two issues, one triggering the   ##other,

1. Issue #1 - The VM used in the test was located on a datastore "local-0 (11)", the mkdir command in vmdk_ops.py:get_vol_path() fails with the space and the '(' and ')' chars in the datastore name. This is fixed in get_vol_path().

2. Issue #2 - (1) opens up another issue. In vmdk_utils.py:get_datastore_name() the given datastore isn't found but the empty list is accessed and causes the exception.

3. The change handles (1) and (2) by allowing vmdk_utils.py:get_datastore_name() to return None if a datastore isn't found. The same scenario may happen where a datastore is temprarily inaccessible and hence not included in the in-memory datastore list. A subsequent request for the datastore name can cause the exception.

4. To handle the None return from vmdk_utils.py:get_datastore_name() changes are done in places where this function is called to handle the None return value.

Tests:
1. WIth these fixes, tested with a datastore named "bigone (1)" and no issues.

04/03/17 12:13:37 1177180 [Thread-1] [DEBUG  ] Running cmd /usr/lib/vmware/osfs/bin/osfs-mkdir -n  '/vmfs/volumes/bigone (1)/dockvols' <---------
04/03/17 12:13:37 1177180 [Thread-1] [INFO   ] Created /vmfs/volumes/bigone (1)/dockvols

04/03/17 12:13:37 1177180 [Thread-1] [DEBUG  ] Running cmd /bin/mkdir '/vmfs/volumes/bigone (1)/dockvols/11111111-1111-1111-1111-111111111111' <----------
04/03/17 12:13:37 1177180 [Thread-1] [INFO   ] Symlink /vmfs/volumes/bigone (1)/dockvols/_DEFAULT is created to point to path /vmfs/volumes/bigone (1)/dockvols/11111111-1111-1111-1111-111111111111
04/03/17 12:13:37 1177180 [Thread-1] [INFO   ] Created /vmfs/volumes/bigone (1)/dockvols/11111111-1111-1111-1111-111111111111

2. Tested a scenario where a datastore isn't on the datastore list, but get_datastore_name is called with the same datastore name.

Without fix:

04/03/17 06:58:09 1162246 [Thread-1] [ERROR  ] Unhandled Exception:
Traceback (most recent call last):
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 1513, in execRequestThread
    opts=opts)
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 804, in executeRequest
    vm_datastore = get_datastore_name(vm_datastore_url)
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 778, in get_datastore_name
    datastore_name = vmdk_utils.get_datastore_name(datastore_url)
  File "/usr/lib/vmware/vmdkops/Python/vmdk_utils.py", line 359, in get_datastore_name
    return res[0]
IndexError: list index out of range
04/03/17 06:58:09 1162246 [Thread-2] [ERROR  ] Unhandled Exception:
Traceback (most recent call last):
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 1513, in execRequestThread
    opts=opts)
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 804, in executeRequest
    vm_datastore = get_datastore_name(vm_datastore_url)
  File "/usr/lib/vmware/vmdkops/bin/vmdk_ops.py", line 778, in get_datastore_name
    datastore_name = vmdk_utils.get_datastore_name(datastore_url)
  File "/usr/lib/vmware/vmdkops/Python/vmdk_utils.py", line 359, in get_datastore_name
    return res[0]
IndexError: list index out of range

With fix:

administrator@hte-1s-eng-dhcp98:~/vpl-ut/docker-volume-vsphere$ docker volume create --driver=vsphere --name=TestVol1 -o size=400mb
Error response from daemon: create TestVol1: VolumeDriver.Create: Invalid datastore 'None'.
Known datastores: datastore1.