### PR TITLE
Handle default_datastore for vmgroup

### DIFF
--- a/docs/user-guide/admin-cli.md
+++ b/docs/user-guide/admin-cli.md
@@ -87,45 +87,107 @@ optional arguments:
 
 ### Create
 A vmgroup named "_DEFAULT" will be created automatically post install.
+```
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+Uuid                                  Name      Description                Default_datastore  VM_list
+------------------------------------  --------  -------------------------  -----------------  -------
+11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS
+```
+
+The "Default_datastore" field is set to "_VM_DS" for "_DEFAULT" vmgroup. Any volume create from VM which belongs to "_DEFAULT" vmgroup will be created on the datastore where VM resides.
+
+When configuration is initialized with 'config init', the access to _ALL_DS and _VM_DS for all VMs is automatically enabled.
+```
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=_DEFAULT
+Datastore  Allow_create  Max_volume_size  Total_size
+---------  ------------  ---------------  ----------
+_ALL_DS   True          Unset            Unset
+_VM_DS    True          Unset            Unset
+```
 
 Creates a new named vmgroup and optionally assigns VMs. Valid vmgroup name is only allowed to be "[a-zA-Z0-9_][a-zA-Z0-9_.-]*"
 
+"Default_datastore" is a required parameter. The value is either a valid datastore name, or special string "_VM_DS.
+After setting the "default_datastore" of a named vmgroup, a full access privilege to the "default_datastore" will be added automatically
+and the volume will be created on the "default_datastore" if using short name.
+After default_datastore is set, all VMs in the group have full access to it. Also, all volumes created with [short names](/features/tenancy/#Default datastore)
+will be placed on this datastore.
+Users can modify this privilege using `vmgroup access` subcommands.
+
 Sample:
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=vmgroup1
-vmgroup 'vmgroup1' is created.  Do not forget to run 'vmgroup vm add' and 'vmgroup access add' commands to enable access control.
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=vmgroup1 --default-datastore=datastore1
+vmgroup 'vmgroup1' is created. Do not forget to run 'vmgroup vm add' to add vm to vmgroup.
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
-Uuid                                  Name       Description                 Default_datastore  VM_list
-------------------------------------  ---------  --------------------------  -----------------  -------
-11111111-1111-1111-1111-111111111111  _DEFAULT   This is a default vmgroup
-1ddb5b46-6a9f-4649-8e48-c47039905752  vmgroup1
+Uuid                                  Name      Description                Default_datastore  VM_list
+------------------------------------  --------  -------------------------  -----------------  -------
+11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS
+9de84179-6894-44ad-b444-470e8619a5ed  vmgroup1                             datastore1
+
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
+Datastore   Allow_create  Max_volume_size  Total_size
+----------  ------------  ---------------  ----------
+datastore1  True          Unset            Unset
+```
+
+The "default_datastore" can be also set to a special value "_VM_DS" during vmgroup create.
+```
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+Uuid                                  Name      Description                  Default_datastore  VM_list
+------------------------------------  --------  ---------------------------  -----------------  -------
+11111111-1111-1111-1111-111111111111  _DEFAULT  This is the default vmgroup  _VM_DS
+
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=vmgroup1 --default-datastore="_VM_DS"
+vmgroup 'vmgroup1' is created. Do not forget to run 'vmgroup vm add' to add vm to vmgroup.
+[root@localhost:~]
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+Uuid                                  Name      Description                  Default_datastore  VM_list
+------------------------------------  --------  ---------------------------  -----------------  -------
+11111111-1111-1111-1111-111111111111  _DEFAULT  This is the default vmgroup  _VM_DS
+30545fdc-20e0-409a-8330-6ebe027fcc34  vmgroup1                               _VM_DS
+
+[root@localhost:~]
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
+Datastore  Allow_create  Max_volume_size  Total_size
+---------  ------------  ---------------  ----------
+_VM_DS    True          Unset            Unset
+
+```
+
+"Default_datastore" cannot be set to "_ALL_DS". An attempt to do so will generate an error"
+```
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=vmgroup2 --default-datastore="_ALL_DS"
+Cannot use _ALL_DS as default datastore. Please use specific datastore name or _VM_DS special datastore
 ```
 
 The vmgroup to VM association can be done at create time.
 
 Sample:
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=vmgroup1 --vm-list=photon6
-vmgroup 'vmgroup1' is created.  Do not forget to run 'vmgroup vm add' and 'vmgroup access add' commands to enable access control.
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
-Uuid                                  Name       Description                 Default_datastore  VM_list
-------------------------------------  ---------  --------------------------  -----------------  --------
-11111111-1111-1111-1111-111111111111  _DEFAULT   This is a default vmgroup
-035ddfb7-349b-4ba1-8abf-e77a430d5098  vmgroup1                                                 photon6
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=vmgroup1 --default-datastore=datastore1 --vm-list=photon7
+vmgroup 'vmgroup1' is created. Do not forget to run 'vmgroup vm add' to add vm to vmgroup.
 
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+Uuid                                  Name      Description                Default_datastore  VM_list
+------------------------------------  --------  -------------------------  -----------------  -------
+11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS
+04423382-efa4-4525-b0a6-16b98ce38f0f  vmgroup1                             datastore1         photon7
 
 ```
 
 #### Help
 ```
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create -h
-usage: vmdkops_admin.py vmgroup create [-h] --name NAME
-                                        [--description DESCRIPTION]
-                                        [--vm-list vm1, vm2, ...]
+usage: vmdkops_admin.py vmgroup create [-h] --name NAME --default-datastore
+                                       DEFAULT_DATASTORE
+                                       [--description DESCRIPTION]
+                                       [--vm-list vm1, vm2, ...]
 
 optional arguments:
   -h, --help            show this help message and exit
   --name NAME           The name of the vmgroup
+  --default-datastore DEFAULT_DATASTORE
+                        Datastore to be used by default for volumes placement
   --description DESCRIPTION
                         The description of the vmgroup
   --vm-list vm1, vm2, ...
@@ -135,11 +197,11 @@ optional arguments:
 ### List
 List existing vmgroups, the datastores vmgroups have access to and the VMs assigned.
 ```
-[root@localhost:~] usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
-Uuid                                  Name       Description                 Default_datastore  VM_list
-------------------------------------  ---------  --------------------------  -----------------  --------
-11111111-1111-1111-1111-111111111111  _DEFAULT   This is a default vmgroup
-035ddfb7-349b-4ba1-8abf-e77a430d5098  vmgroup1                                                 photon6
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+Uuid                                  Name      Description                Default_datastore  VM_list
+------------------------------------  --------  -------------------------  -----------------  -------
+11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS
+04423382-efa4-4525-b0a6-16b98ce38f0f  vmgroup1                             datastore1         photon7
 
 ```
 
@@ -154,23 +216,37 @@ optional arguments:
 
 ### Update
 Update existing vmgroup. This command allows to update "Description" and "Default_datastore" fields, or rename an existing vmgroup.
+"Default_datastore" is either a valid datastore name or a special value "_VM_DS".
+After changing the "default_datastore" for a vmgroup, a full access privilege to the new "default_datastore" will be created automatically, and the existing access privilege to old "default_datastore" will remain. User can remove the access privilege to old "default_datastore" if not needed using `vmgroup access rm` subcommands.
 Sample:
 ```
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
-Uuid                                  Name       Description                 Default_datastore  VM_list
-------------------------------------  ---------  --------------------------  -----------------  --------
-11111111-1111-1111-1111-111111111111  _DEFAULT   This is a default vmgroup
-035ddfb7-349b-4ba1-8abf-e77a430d5098  vmgroup1                                                 photon6
+Uuid                                  Name      Description                Default_datastore  VM_list
+------------------------------------  --------  -------------------------  -----------------  -------
+11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS
+0767f5f8-73de-4382-8c38-1935bb636ef4  vmgroup1                             datastore1         photon7
 
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup update --name=vmgroup1 --description="New description of vmgroup1" --new-name=new-vmgroup1 --default-datastore=datastore1
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
+Datastore   Allow_create  Max_volume_size  Total_size
+----------  ------------  ---------------  ----------
+datastore1  True          Unset            Unset
+
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup update --name=vmgroup1 --description="New description of vmgroup1" --new-name=new-vmgroup1 --default-datastore=datastore2
 vmgroup modify succeeded
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
-Uuid                                  Name           Description                   Default_datastore  VM_list
-------------------------------------  -------------  ----------------------------  -----------------  --------
-11111111-1111-1111-1111-111111111111  _DEFAULT       This is a default vmgroup
-035ddfb7-349b-4ba1-8abf-e77a430d5098  new-vmgroup1  New description of vmgroup1  datastore1         photon6
 
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+Uuid                                  Name          Description                  Default_datastore  VM_list
+------------------------------------  ------------  ---------------------------  -----------------  -------
+11111111-1111-1111-1111-111111111111  _DEFAULT      This is a default vmgroup    _VM_DS
+0767f5f8-73de-4382-8c38-1935bb636ef4  new-vmgroup1  New description of vmgroup1  datastore2         photon7
+
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=new-vmgroup1
+Datastore   Allow_create  Max_volume_size  Total_size
+----------  ------------  ---------------  ----------
+datastore1  True          Unset            Unset
+datastore2  True          Unset            Unset
 ```
+Please use the test suggested above, for "create".
 
 #### Help
 ```
@@ -315,90 +391,94 @@ optional arguments:
 
 #### Add
 Grants datastore access to a vmgroup.
-
-The datastore will be automatically set as "default_datastore" for the vmgroup
-when you grant first datastore access for a vmgroup.
-
+Valid value for "datastore" includes the name of valid datastores in the ESX host , special value "_VM_DS" or "_ALL_DS".
+When DS is set to _VM_DS, access to vm_datastore where vm lives is allowed for vms in vmgroup.
+When DS is set to _ALL_DS, access to all DS is allowed for vms in vmgroup.
 Sample:
 
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=datastore1  --volume-maxsize=500MB --volume-totalsize=1GB
-vmgroup access add succeeded
-
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
-Uuid                                  Name       Description                 Default_datastore  VM_list
-------------------------------------  ---------  --------------------------  -----------------  -------
-11111111-1111-1111-1111-111111111111  _DEFAULT   This is a default vmgroup
-6d810c66-ffc7-47c8-8870-72114f86c2cf  vmgroup1                              datastore1         photon7
-```
-
-The datastore will be set as "default_datastore" for the vmgroup when you grant datastore access for a vmgroup with "--default-datastore" flag.
-
-Sample:
-
-```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=datastore2  --allow-create --default-datastore --volume-maxsize=500MB --volume-totalsize=1GB
-vmgroup access add succeeded
-
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
 Datastore   Allow_create  Max_volume_size  Total_size
 ----------  ------------  ---------------  ----------
-datastore1  False         500.00MB         1.00GB
-datastore2  True          500.00MB         1.00GB
+datastore1  True          Unset            Unset
 
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
-Uuid                                  Name       Description                 Default_datastore  VM_list
-------------------------------------  ---------  --------------------------  -----------------  -------
-11111111-1111-1111-1111-111111111111  _DEFAULT   This is a default vmgroup
-6d810c66-ffc7-47c8-8870-72114f86c2cf  vmgroup1                              datastore2         photon7
+[root@localhost:~]
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=datastore2  --volume-maxsize=500MB --volume-totalsize=1GB
+vmgroup access add succeeded
+[root@localhost:~]
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
+Datastore   Allow_create  Max_volume_size  Total_size
+----------  ------------  ---------------  ----------
+datastore1  True          Unset            Unset
+datastore2  False         500.00MB         1.00GB
 
 ```
 
 By default no "allow_create" right is given
 
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=datastore1  --volume-maxsize=500MB --volume-totalsize=1GB
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=datastore2  --volume-maxsize=500MB --volume-totalsize=1GB
 vmgroup access add succeeded
-
+[root@localhost:~]
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
 Datastore   Allow_create  Max_volume_size  Total_size
 ----------  ------------  ---------------  ----------
-datastore1  False         500.00MB         1.00GB
+datastore1  True          Unset            Unset
+datastore2  False         500.00MB         1.00GB
 ```
 
 "allow_create" right is given when you run the command with "--allow-create" flag.
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=datastore2  --allow-create --default-datastore --volume-maxsize=500MB --volume-totalsize=1GB
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=datastore2  --volume-maxsize=500MB --volume-totalsize=1GB --allow-create
 vmgroup access add succeeded
-
+[root@localhost:~]
+[root@localhost:~]
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
 Datastore   Allow_create  Max_volume_size  Total_size
 ----------  ------------  ---------------  ----------
-datastore1  False         500.00MB         1.00GB
+datastore1  True          Unset            Unset
 datastore2  True          500.00MB         1.00GB
 ```
+For _VM_DS and _ALL_DS special DS names, --volume-totalzie has to be "Unset".
+```
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=_VM_DS  --volume-maxsize=500MB --volume-totalsize=1GB --allow-create
+Canont set volume-totalsize for _VM_DS
+[root@localhost:~]
+[root@localhost:~]
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=_ALL_DS  --volume-maxsize=500MB --volume-totalsize=1GB --allow-create
+Canont set volume-totalsize for _VM_DS
+[root@localhost:~]
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=_ALL_DS  --volume-maxsize=500MB  --allow-create
+vmgroup access add succeeded
+[root@localhost:~]
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
+Datastore   Allow_create  Max_volume_size  Total_size
+----------  ------------  ---------------  ----------
+datastore1  True          Unset            Unset
+_ALL_DS    True          500.00MB         Unset
+
+```
+
 
 ##### Help
 ```bash
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add -h
 usage: vmdkops_admin.py vmgroup access add [-h]
-                                            [--volume-totalsize Num{MB,GB,TB} - e.g. 2TB]
-                                            [--volume-maxsize Num{MB,GB,TB} - e.g. 2TB]
-                                            [--allow-create] --name NAME
-                                            [--default-datastore] --datastore
-                                            DATASTORE
+                                           [--volume-totalsize Num{MB,GB,TB} - e.g. 2TB]
+                                           --name NAME
+                                           [--volume-maxsize Num{MB,GB,TB} - e.g. 2TB]
+                                           [--allow-create] --datastore
+                                           DATASTORE
 
 optional arguments:
   -h, --help            show this help message and exit
   --volume-totalsize Num{MB,GB,TB} - e.g. 2TB
                         Maximum total size of all volume that can be created
                         on the datastore for this vmgroup
+  --name NAME           The name of the vmgroup
   --volume-maxsize Num{MB,GB,TB} - e.g. 2TB
                         Maximum size of the volume that can be created
   --allow-create        Allow create and delete on datastore if set
-  --name NAME           The name of the vmgroup
-  --default-datastore   Mark datastore as a default datastore for this vm-
-                        group
   --datastore DATASTORE
                         Datastore which access is controlled
 
@@ -416,7 +496,7 @@ When displaying the result keep in mind:
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
 Datastore   Allow_create  Max_volume_size  Total_size
 ----------  ------------  ---------------  ----------
-datastore1  False         500.00MB         1.00GB
+datastore1  True          Unset            Unset
 datastore2  True          500.00MB         1.00GB
 ```
 
@@ -433,20 +513,32 @@ optional arguments:
 
 #### Remove
 Remove access to a datastore for a vmgroup.
+Removing of access privilege to "default_datastore" is not suported
 ```bash
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+Uuid                                  Name      Description                Default_datastore  VM_list
+------------------------------------  --------  -------------------------  -----------------  -------
+11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS
+2a97fef4-30cd-4a50-bf31-3dbc7d130be2  vmgroup1                             datastore1         photon7
+
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
 Datastore   Allow_create  Max_volume_size  Total_size
 ----------  ------------  ---------------  ----------
-datastore1  False         500.00MB         1.00GB
+datastore1  True          Unset            Unset
 datastore2  True          500.00MB         1.00GB
 
-[root@localhost:~]  /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup  access rm --name=vmgroup1 --datastore=datastore1
+[root@localhost:~]
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access rm --name=vmgroup1 --datastore=datastore1
+Removing of access privilege to "default_datastore" is not supported
+[root@localhost:~]
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access rm --name=vmgroup1 --datastore=datastore2
 vmgroup access rm succeeded
-
+[root@localhost:~]
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
 Datastore   Allow_create  Max_volume_size  Total_size
 ----------  ------------  ---------------  ----------
-datastore2  True          500.00MB         1.00GB
+datastore1  True          Unset            Unset
+
 ```
 
 ##### Help
@@ -472,21 +564,35 @@ Sample:
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
 Datastore   Allow_create  Max_volume_size  Total_size
 ----------  ------------  ---------------  ----------
-datastore1  False         500.00MB         1.00GB
+datastore1  False         Unset            Unset
+_ALL_DS    True          500.00MB         Unset
 
+[root@localhost:~]
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access set --name=vmgroup1 --datastore=datastore1 --allow-create=True  --volume-maxsize=1000MB --volume-totalsize=2GB
 vmgroup access set succeeded
-
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls
-usage: vmdkops_admin.py vmgroup access ls [-h] --name NAME
-vmdkops_admin.py vmgroup access ls: error: argument --name is required
+[root@localhost:~]
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
 Datastore   Allow_create  Max_volume_size  Total_size
 ----------  ------------  ---------------  ----------
 datastore1  True          1000.00MB        2.00GB
+_ALL_DS    True          500.00MB         Unset
+```
 
+"-volume-totalsize" cannot be set to the value other than unlimit when add privilege for special value "_VM_DS" and "_ALL_DS".
+```
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
+Datastore   Allow_create  Max_volume_size  Total_size
+----------  ------------  ---------------  ----------
+datastore1  True          1000.00MB        2.00GB
+_ALL_DS    True          500.00MB         Unset
+_VM_DS     True          Unset            Unset
 
+[root@localhost:~]
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access set --name=vmgroup1 --datastore=_VM_DS --volume-totalsize=1GB
+Canont set volume-totalsize for _VM_DS
 
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access set --name=vmgroup1 --datastore=_ALL_DS --volume-totalsize=1GB
+Canont set volume-totalsize for _ALL_DS
 ```
 
 ##### Help

--- a/docs/user-guide/admin-cli.md
+++ b/docs/user-guide/admin-cli.md
@@ -460,7 +460,7 @@ _ALL_DS    True          500.00MB         Unset
 ```
 
 
-##### Help
+##### Help 
 ```bash
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add -h
 usage: vmdkops_admin.py vmgroup access add [-h]

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -133,11 +133,8 @@ Step 4: Recreate the vmgroup configuration with new name “new-vmgroup1” (ass
 ***Note: Please DO NOT create the vmgroup with the old name “vmgroup1”!!!***
 
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=new-vmgroup1  --vm-list=photon-6
-vmgroup 'new-vmgroup1' is created.  Do not forget to run 'vmgroup vm add' and 'vmgroup access add' commands to enable access control.
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=new-vmgroup1 --datastore=datastore1  --volume-maxsize=500MB --volume-totalsize=1GB --allow-create
-vmgroup access add succeeded
-
+[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=new-vmgroup1  --vm-list=photon-6 --default-datastore=datastore1
+vmgroup 'new-vmgroup1' is created.  Do not forget to run 'vmgroup vm add' to add vm to vmgroup.
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
 Uuid                                  Name           Description                 Default_datastore  VM_list
 ------------------------------------  -------------  --------------------------  -----------------  --------

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -40,6 +40,9 @@ import convert
 import auth_api
 import auth_data
 from auth_data import DB_REF
+from error_code import ErrorCode
+from error_code import error_code_to_message
+from error_code import generate_error_info
 
 NOT_AVAILABLE = 'N/A'
 UNSET = "Unset"
@@ -244,6 +247,10 @@ def commands():
                             'help': 'A list of VM names to place in this vmgroup',
                             'metavar': 'vm1, vm2, ...',
                             'type': comma_separated_string
+                        },
+                        '--default-datastore': {
+                            'help': 'Datastore to be used by default for volumes placement',
+                            'required': True
                         }
                     }
                 },
@@ -361,10 +368,6 @@ def commands():
                                 '--datastore': {
                                     'help': "Datastore which access is controlled",
                                     'required': True
-                                },
-                                '--default-datastore': {
-                                    'help': "Mark datastore as a default datastore for this vmgroup",
-                                    'action': 'store_true'
                                 },
                                 '--allow-create': {
                                     'help': 'Allow create and delete on datastore if set',
@@ -914,8 +917,12 @@ def generate_tenant_ls_rows(tenant_list):
         uuid = tenant.id
         name = tenant.name
         description = tenant.description
-        if not tenant.default_datastore_url or tenant.default_datastore_url == auth_data_const.DEFAULT_DS_URL:
+        # "default_datastore_url" should always be set, and cannot be empty
+        # it can only happen when DB has some corruption
+        if not tenant.default_datastore_url:
             default_datastore = ""
+            error_info = generate_error_info(ErrorCode.DS_DEFAULT_NOT_SET, name)
+            return error_info, None
         else:
             default_datastore = vmdk_utils.get_datastore_name(tenant.default_datastore_url)
             if default_datastore is None:
@@ -924,20 +931,20 @@ def generate_tenant_ls_rows(tenant_list):
         vm_list = generate_vm_list(tenant.vms)
         rows.append([uuid, name, description, default_datastore, vm_list])
 
-    return rows
+    return None, rows
 
 def tenant_create(args):
     """ Handle tenant create command """
-    error_info, _ = auth_api._tenant_create(
-        name=args.name,
-        description="",
-        vm_list=args.vm_list,
-        privileges=[])
+    error_info, tenant = auth_api._tenant_create(name=args.name,
+                                                 default_datastore=args.default_datastore,
+                                                 description="",
+                                                 vm_list=args.vm_list,
+                                                 privileges=[])
+
     if error_info:
         return operation_fail(error_info.msg)
     else:
-        print("vmgroup '{}' is created. Do not forget to run 'vmgroup vm add' and "
-              "'vmgroup access add' to enable access control.".format(args.name))
+        print("vmgroup '{}' is created. Do not forget to run 'vmgroup vm add' to add vm to vmgroup.".format(args.name))
 
 def tenant_update(args):
     """ Handle tenant update command """
@@ -974,8 +981,11 @@ def tenant_ls(args):
         return operation_fail(error_info.msg)
 
     header = tenant_ls_headers()
-    rows = generate_tenant_ls_rows(tenant_list)
-    print(cli_table.create(header, rows))
+    error_info, rows = generate_tenant_ls_rows(tenant_list)
+    if error_info:
+        print error_info.msg
+    else:
+        print(cli_table.create(header, rows))
 
 def tenant_vm_add(args):
     """ Handle tenant vm add command """
@@ -1051,7 +1061,6 @@ def tenant_access_add(args):
 
     error_info = auth_api._tenant_access_add(name=args.name,
                                              datastore=args.datastore,
-                                             default_datastore=args.default_datastore,
                                              allow_create=args.allow_create,
                                              volume_maxsize_in_MB=volume_maxsize_in_MB,
                                              volume_totalsize_in_MB=volume_totalsize_in_MB
@@ -1095,12 +1104,14 @@ def tenant_access_ls_headers():
     headers = ['Datastore', 'Allow_create', 'Max_volume_size', 'Total_size']
     return headers
 
-def generate_tenant_access_ls_rows(privileges):
+def generate_tenant_access_ls_rows(privileges, name):
     """ Generate output for tenant access ls command """
     rows = []
     for p in privileges:
-        if not p.datastore_url or p.datastore_url == auth_data_const.DEFAULT_DS_URL:
+        if not p.datastore_url:
             datastore = ""
+            error_info = generate_error_info(ErrorCode.DS_DEFAULT_NOT_SET, name)
+            return error_info, None
         else:
             datastore = vmdk_utils.get_datastore_name(p.datastore_url)
             if datastore is None:
@@ -1113,7 +1124,7 @@ def generate_tenant_access_ls_rows(privileges):
         total_size = UNSET if p.usage_quota == 0 else human_readable(p.usage_quota * MB)
         rows.append([datastore, allow_create, max_vol_size, total_size])
 
-    return rows
+    return None, rows
 
 def tenant_access_ls(args):
     """ Handle tenant access ls command """
@@ -1123,8 +1134,11 @@ def tenant_access_ls(args):
         return operation_fail(error_info.msg)
 
     header = tenant_access_ls_headers()
-    rows = generate_tenant_access_ls_rows(privileges)
-    print(cli_table.create(header, rows))
+    error_info, rows = generate_tenant_access_ls_rows(privileges, name)
+    if error_info:
+        print error_info.msg
+    else:
+        print(cli_table.create(header, rows))
 
 # ==== CONFIG DB manipulation functions ====
 

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -983,7 +983,7 @@ def tenant_ls(args):
     header = tenant_ls_headers()
     error_info, rows = generate_tenant_ls_rows(tenant_list)
     if error_info:
-        print error_info.msg
+        print(error_info.msg)
     else:
         print(cli_table.create(header, rows))
 

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -1136,7 +1136,7 @@ def tenant_access_ls(args):
     header = tenant_access_ls_headers()
     error_info, rows = generate_tenant_access_ls_rows(privileges, name)
     if error_info:
-        print error_info.msg
+        print(error_info.msg)
     else:
         print(cli_table.create(header, rows))
 

--- a/esx_service/cli/vmdkops_admin_test.py
+++ b/esx_service/cli/vmdkops_admin_test.py
@@ -126,13 +126,34 @@ class TestParsing(unittest.TestCase):
     # all the function name remain unchanged
 
     def test_tenant_create(self):
-        args = self.parser.parse_args((VMGROUP + ' create --name=vmgroup1 --vm-list vm1,vm2').split())
+        args = self.parser.parse_args((VMGROUP + ' create --name=vmgroup1 --default-datastore=datastore1 --vm-list vm1,vm2').split())
         self.assertEqual(args.func, vmdkops_admin.tenant_create)
+        self.assertEqual(args.default_datastore, 'datastore1')
+        self.assertEqual(args.name, 'vmgroup1')
+        self.assertEqual(args.vm_list, ['vm1', 'vm2'])
+
+    def test_tenant_create_vm_ds(self):
+        args = self.parser.parse_args((VMGROUP + ' create --name=vmgroup1 --default-datastore=_VM_DS --vm-list vm1,vm2').split())
+        self.assertEqual(args.func, vmdkops_admin.tenant_create)
+        self.assertEqual(args.default_datastore, '_VM_DS')
         self.assertEqual(args.name, 'vmgroup1')
         self.assertEqual(args.vm_list, ['vm1', 'vm2'])
 
     def test_tenant_create_missing_option_fails(self):
         self.assert_parse_error(VMGROUP + ' create')
+        # does not set default_datastore
+        self.assert_parse_error(VMGROUP + ' create --name=vmgroup1')
+
+    def test_tenant_update(self):
+        args = self.parser.parse_args((VMGROUP + ' update --name=vmgroup1 --default-datastore=datastore1 --new-name=new-vmgroup1 --description=new_desc').split())
+        self.assertEqual(args.func, vmdkops_admin.tenant_update)
+        self.assertEqual(args.default_datastore, 'datastore1')
+        self.assertEqual(args.name, 'vmgroup1')
+        self.assertEqual(args.new_name, 'new-vmgroup1')
+        self.assertEqual(args.description, 'new_desc')
+
+    def test_tenant_update_missing_name(self):
+        self.assert_parse_error(VMGROUP + ' update')
 
     def test_tenant_rm(self):
         args = self.parser.parse_args((VMGROUP + ' rm --name=vmgroup1 --remove-volumes').split())
@@ -185,18 +206,18 @@ class TestParsing(unittest.TestCase):
         self.assert_parse_error(VMGROUP + ' vm ls')
 
     def test_tenant_access_add(self):
-        args = self.parser.parse_args((VMGROUP + ' access add --name=vmgroup1 --datastore=datastore1 --default-datastore --allow-create --volume-maxsize=500MB --volume-totalsize=1GB').split())
+        args = self.parser.parse_args((VMGROUP + ' access add --name=vmgroup1 --datastore=datastore1 --allow-create --volume-maxsize=500MB --volume-totalsize=1GB').split())
         self.assertEqual(args.func, vmdkops_admin.tenant_access_add)
         self.assertEqual(args.name, 'vmgroup1')
         self.assertEqual(args.datastore, 'datastore1')
         self.assertEqual(args.allow_create, True)
-        self.assertEqual(args.default_datastore, True)
         self.assertEqual(args.volume_maxsize, '500MB')
         self.assertEqual(args.volume_totalsize, '1GB')
 
     def test_tenant_access_add_missing_option_fails(self):
         self.assert_parse_error(VMGROUP + ' access add')
         self.assert_parse_error(VMGROUP + ' access add --name=vmgroup1')
+        self.assert_parse_error(VMGROUP + ' access add --name=vmgroup1 --default-datastore')
 
     def test_tenant_access_add_invalid_option_fails(self):
         self.assert_parse_error(VMGROUP + ' access add --name=vmgroup1 --datastore=datastore1 --rights=create mount')
@@ -477,6 +498,7 @@ class TestTenant(unittest.TestCase):
     # The following tests are covered:
     # 1. tenant command
     # Test tenant create, tenant ls and tenant rm
+    # test tenant create with "default_datastore" set to an invalid datastore name, "_VM_DS" and "_ALL_DS"
     # tenant update to update tenant description and default_datastore
     # tenant update to rename a tenant
     # 2. tenant vm command
@@ -484,7 +506,7 @@ class TestTenant(unittest.TestCase):
     # 3. tenant access command
     # tenant access create, tenant access ls and tenant access rm
     # tenant access set command to update allow_create, volume_maxsize and volume_totalsize
-    # tenant access set command to update default_datastore
+    # tenant access rm command to remove a privilege to default_datastore failed as expect
     # Test are positive, no negative testing is done here.
 
     # tenant1 info
@@ -498,6 +520,7 @@ class TestTenant(unittest.TestCase):
     tenant1_new_name = "new_test_tenant1"
     datastore_name = None
     datastore1_name = None
+    bad_datastore_name = "__BAD_DS"
 
     def setUp(self):
         """ Setup run before each test """
@@ -563,9 +586,33 @@ class TestTenant(unittest.TestCase):
         """ Test AdminCLI command for tenant management """
         # create tenant1
         vm_list = [self.vm1_name]
+
+        # create tenant and set "default_datastore" to an invalide datastore_name
+        # should fail since the "default_datastore" is not valid
         error_info, tenant = auth_api._tenant_create(
                                                     name=self.tenant1_name,
-                                                    description="Test tenant1" ,
+                                                    default_datastore=self.bad_datastore_name,
+                                                    description="Test tenant1",
+                                                    vm_list=vm_list,
+                                                    privileges=[])
+        self.assertNotEqual(None, error_info)
+
+        # try to create the tenant and set "default_datastore" to "_ALL_DS"
+        # should fail since "_ALL_DS" cannot be set as "default_datastore"
+        error_info, tenant = auth_api._tenant_create(
+                                                    name=self.tenant1_name,
+                                                    default_datastore=self.bad_datastore_name,
+                                                    description="Test tenant1",
+                                                    vm_list=vm_list,
+                                                    privileges=[])
+        self.assertNotEqual(None, error_info)
+
+        # try to create the tenant and set "default_datastore" to "_VM_DS"
+        # should succeed
+        error_info, tenant = auth_api._tenant_create(
+                                                    name=self.tenant1_name,
+                                                    default_datastore=auth_data_const.VM_DS,
+                                                    description="Test tenant1",
                                                     vm_list=vm_list,
                                                     privileges=[])
         self.assertEqual(None, error_info)
@@ -574,7 +621,7 @@ class TestTenant(unittest.TestCase):
         self.assertEqual(None, error_info)
 
         header = vmdkops_admin.tenant_ls_headers()
-        rows = vmdkops_admin.generate_tenant_ls_rows(tenant_list)
+        _, rows = vmdkops_admin.generate_tenant_ls_rows(tenant_list)
         self.assertEqual(len(header), TENANT_LS_EXPECTED_COLUMN_COUNT)
 
         # Two tenants in the list, "_DEFAULT" and "test_tenant1"
@@ -587,7 +634,7 @@ class TestTenant(unittest.TestCase):
         # [u'9e1be0ce-3d58-40f6-a335-d6e267e34baa', u'test_tenant1', u'Test tenant1', '', 'test_vm1']
         expected_output = [self.tenant1_name,
                            "Test tenant1",
-                           "",
+                           auth_data_const.VM_DS,
                            generate_vm_name_str(vm_list)]
         actual_output = [convert_to_str(rows[1][1]),
                          convert_to_str(rows[1][2]),
@@ -598,23 +645,72 @@ class TestTenant(unittest.TestCase):
         self.assertEqual(expected_output, actual_output)
 
         # tenant update to update description and default_datastore
+        # update default_datastore to self.datastore_name, which should succeed
         error_info = auth_api._tenant_update(
                                              name=self.tenant1_name,
                                              description="This is test tenant1",
                                              default_datastore=self.datastore_name)
         self.assertEqual(None, error_info)
 
+
+        # update default_datastore to "_ALL_DS", which should fail
+        error_info = auth_api._tenant_update(
+                                             name=self.tenant1_name,
+                                             default_datastore=auth_data_const.ALL_DS)
+        self.assertNotEqual(None, error_info)
+
+        # list the access privilege for tenant1
+        # now should have two access privileges
+        # to datastore "_VM_DS" and self.datastore
+        error_info, privileges = auth_api._tenant_access_ls(self.tenant1_name)
+        self.assertEqual(None, error_info)
+        _, rows = vmdkops_admin.generate_tenant_access_ls_rows(privileges, self.tenant1_name)
+
+        self.assertEqual(len(rows), 2)
+        if rows[0][0] == self.datastore_name:
+            expected_output = [
+                               [self.datastore_name, 'True', 'Unset', 'Unset'],
+                               [auth_data_const.VM_DS, 'True', 'Unset', 'Unset']
+                              ]
+        else:
+            expected_output = [
+                               [auth_data_const.VM_DS, 'True', 'Unset', 'Unset'],
+                               [self.datastore_name, 'True', 'Unset', 'Unset']
+                              ]
+
+        actual_output = [
+                         [rows[0][0], rows[0][1], rows[0][2], rows[0][3]],
+                         [rows[1][0], rows[1][1], rows[1][2], rows[1][3]]
+                        ]
+
+        self.assertEqual(expected_output, actual_output)
+
+        # remove access privileg to "_VM_DS"
+        error_info = auth_api._tenant_access_rm(name=self.tenant1_name,
+                                                datastore=auth_data_const.VM_DS)
+        self.assertEqual(None, error_info)
+
+        # now, should only have one access privilege
+        error_info, privileges = auth_api._tenant_access_ls(self.tenant1_name)
+        self.assertEqual(None, error_info)
+        _, rows = vmdkops_admin.generate_tenant_access_ls_rows(privileges, self.tenant1_name)
+        self.assertEqual(len(rows), 1)
+
+        expected_output = [self.datastore_name, 'True', 'Unset', 'Unset']
+        actual_output = [rows[0][0], rows[0][1], rows[0][2], rows[0][3]]
+        self.assertEqual(expected_output, actual_output)
+
         # update default vmgroup description
         error_info = auth_api._tenant_update(name=auth_data_const.DEFAULT_TENANT,
-                                             description="This is the default vmgroup",
-                                             default_datastore=self.datastore_name)
+                                             description="This is the default vmgroup")
+
         self.assertEqual(None, error_info)
 
         error_info, tenant_list = auth_api._tenant_ls()
         self.assertEqual(None, error_info)
 
         header = vmdkops_admin.tenant_ls_headers()
-        rows = vmdkops_admin.generate_tenant_ls_rows(tenant_list)
+        _, rows = vmdkops_admin.generate_tenant_ls_rows(tenant_list)
 
         expected_output = [self.tenant1_name,
                            "This is test tenant1",
@@ -643,7 +739,7 @@ class TestTenant(unittest.TestCase):
         self.assertEqual(None, error_info)
 
         header = vmdkops_admin.tenant_ls_headers()
-        rows = vmdkops_admin.generate_tenant_ls_rows(tenant_list)
+        _, rows = vmdkops_admin.generate_tenant_ls_rows(tenant_list)
 
         expected_output = [self.tenant1_new_name,
                            "This is test tenant1",
@@ -666,7 +762,7 @@ class TestTenant(unittest.TestCase):
         self.assertEqual(None, error_info)
 
         header = vmdkops_admin.tenant_ls_headers()
-        rows = vmdkops_admin.generate_tenant_ls_rows(tenant_list)
+        _, rows = vmdkops_admin.generate_tenant_ls_rows(tenant_list)
 
         # right now, should only have 1 tenant, which is "_DEFAULT" tenant
         self.assertEqual(len(rows), 1)
@@ -677,6 +773,7 @@ class TestTenant(unittest.TestCase):
         # create tenant1 without adding any vms and privilege
         error_info, tenant = auth_api._tenant_create(
                                                     name=self.tenant1_name,
+                                                    default_datastore=auth_data_const.VM_DS,
                                                     description="Test tenant1",
                                                     vm_list=[],
                                                     privileges=[])
@@ -696,6 +793,7 @@ class TestTenant(unittest.TestCase):
         # Trying to create tenant with duplicate vm names
         error_info, tenant_dup = auth_api._tenant_create(
                                                     name="tenant_add_dup_vms",
+                                                    default_datastore=auth_data_const.VM_DS,
                                                     description="Tenant with duplicate VMs",
                                                     vm_list=[self.vm1_name, self.vm1_name],
                                                     privileges=[])
@@ -715,6 +813,7 @@ class TestTenant(unittest.TestCase):
         # of just one tenant
         error_info, tenant2 = auth_api._tenant_create(
                                                     name="Test_tenant2",
+                                                    default_datastore=auth_data_const.VM_DS,
                                                     description="Test_tenant2",
                                                     vm_list=[self.vm1_name],
                                                     privileges=[])
@@ -724,6 +823,7 @@ class TestTenant(unittest.TestCase):
         # another tenant. Should fail as VM can be a part of just one tenant
         error_info, tenant3 = auth_api._tenant_create(
                                                     name="Test_tenant3",
+                                                    default_datastore=auth_data_const.VM_DS,
                                                     description="Test_tenant3",
                                                     vm_list=[],
                                                     privileges=[])
@@ -780,14 +880,38 @@ class TestTenant(unittest.TestCase):
         """ Test AdminCLI command for tenant access management """
 
         # create tenant1 without adding any vms and privileges
+        # the "default_datastore" will be set to "_VM_DS"
+        # a full access privilege will be created for tenant1
         error_info, tenant = auth_api._tenant_create(
                                                     name=self.tenant1_name,
+                                                    default_datastore=auth_data_const.VM_DS,
                                                     description="Test tenant1",
                                                     vm_list=[self.vm1_name],
                                                     privileges=[])
         self.assertEqual(None, error_info)
 
-        # add first access privilege for tenant
+        # now, should only have privilege to ""_VM_DS
+        error_info, privileges = auth_api._tenant_access_ls(self.tenant1_name)
+        _, rows = vmdkops_admin.generate_tenant_access_ls_rows(privileges, self.tenant1_name)
+        self.assertEqual(1, len(rows))
+        expected_output = [auth_data_const.VM_DS,
+                            "True",
+                            "Unset",
+                            "Unset"]
+        actual_output = [rows[0][0],
+                         rows[0][1],
+                         rows[0][2],
+                         rows[0][3]]
+        self.assertEqual(expected_output, actual_output)
+
+        # remove the privilege to "_VM_DS", which should fail
+        # since "_VM_DS still the "default_datastore" for tenant1
+        error_info = auth_api._tenant_access_rm(name=self.tenant1_name,
+                                                datastore=auth_data_const.VM_DS
+                                                )
+        self.assertNotEqual(None, error_info)
+
+        # add a access privilege for tenant to self.datastore_name
         # allow_create = False
         # max_volume size = 600MB
         # total_volume size = 1GB
@@ -795,11 +919,22 @@ class TestTenant(unittest.TestCase):
         volume_totalsize_in_MB = convert.convert_to_MB("1GB")
         error_info = auth_api._tenant_access_add(name=self.tenant1_name,
                                                  datastore=self.datastore_name,
-                                                 default_datastore=False,
                                                  allow_create=False,
                                                  volume_maxsize_in_MB=volume_maxsize_in_MB,
                                                  volume_totalsize_in_MB=volume_totalsize_in_MB
                                              )
+        self.assertEqual(None, error_info)
+
+        # update the "default_datastore" to self.datastore_name
+        error_info = auth_api._tenant_update(name=self.tenant1_name,
+                                             default_datastore=self.datastore_name)
+        self.assertEqual(None, error_info)
+
+        # try to remove the privilege to "_VM_DS" again, which should not fail
+        # since the "default_datastore" for tenant1 is set to self.datastore_name
+        error_info = auth_api._tenant_access_rm(name=self.tenant1_name,
+                                                datastore=auth_data_const.VM_DS
+                                                )
         self.assertEqual(None, error_info)
 
         error_info, privileges = auth_api._tenant_access_ls(self.tenant1_name)
@@ -810,7 +945,7 @@ class TestTenant(unittest.TestCase):
         # "Datastore", "Allow_create", "Max_volume_size", "Total_size"
         # Sample output of a row:
         # ['datastore1', 'False', '600.00MB', '1.00GB']
-        rows = vmdkops_admin.generate_tenant_access_ls_rows(privileges)
+        _, rows = vmdkops_admin.generate_tenant_access_ls_rows(privileges, self.tenant1_name)
         self.assertEqual(len(header), TENANT_ACCESS_LS_EXPECTED_COLUMN_COUNT)
 
         # tenant aceess privilege should only have a row now
@@ -857,7 +992,7 @@ class TestTenant(unittest.TestCase):
             error_info, privileges = auth_api._tenant_access_ls(self.tenant1_name)
             self.assertEqual(None, error_info)
 
-            rows = vmdkops_admin.generate_tenant_access_ls_rows(privileges)
+            _, rows = vmdkops_admin.generate_tenant_access_ls_rows(privileges, self.tenant1_name)
             self.assertEqual(len(rows), 1)
 
             expected_output = [self.datastore_name,
@@ -883,7 +1018,7 @@ class TestTenant(unittest.TestCase):
             self.assertEqual(expected_message, error_info)
 
         if self.datastore1_name:
-            # second datastore is available, can test tenant access add with --default_datastore
+            # second datastore is available, can test tenant update with  --default_datastore
             error_info, tenant_list = auth_api._tenant_ls()
             self.assertEqual(None, error_info)
 
@@ -894,55 +1029,69 @@ class TestTenant(unittest.TestCase):
             # "Uuid", "Name", "Description", "Default_datastore", "VM_list"
             # Sample output of one row:
             # [u'9e1be0ce-3d58-40f6-a335-d6e267e34baa', u'test_tenant1', u'Test tenant1', '', 'test_vm1']
-            rows = vmdkops_admin.generate_tenant_ls_rows(tenant_list)
+            _, rows = vmdkops_admin.generate_tenant_ls_rows(tenant_list)
 
             # get "default_datastore" from the output
             actual_output = rows[1][3]
             expected_output = self.datastore_name
             self.assertEqual(expected_output, actual_output)
 
-            # add second access privilege for tenant
-            # allow_create = False
-            # max_volume size = 600MB
-            # total_volume size = 1GB
+            # add access privilege to self.datastore1_name
             volume_maxsize_in_MB = convert.convert_to_MB("600MB")
             volume_totalsize_in_MB = convert.convert_to_MB("1GB")
             error_info = auth_api._tenant_access_add(name=self.tenant1_name,
-                                                    datastore=self.datastore1_name,
-                                                    default_datastore=True,
-                                                    allow_create=False,
-                                                    volume_maxsize_in_MB=volume_maxsize_in_MB,
-                                                    volume_totalsize_in_MB=volume_totalsize_in_MB
-                                                )
+                                                     datastore=self.datastore1_name,
+                                                     allow_create=False,
+                                                     volume_maxsize_in_MB=volume_maxsize_in_MB,
+                                                     volume_totalsize_in_MB=volume_totalsize_in_MB)
+            self.assertEqual(None, error_info)
+
+            # update the "default_datastore"
+            error_info = auth_api._tenant_update(name=self.tenant1_name,
+                                                 default_datastore=self.datastore1_name)
             self.assertEqual(None, error_info)
 
             error_info, tenant_list = auth_api._tenant_ls()
             self.assertEqual(None, error_info)
 
-
-            rows = vmdkops_admin.generate_tenant_ls_rows(tenant_list)
+            _, rows = vmdkops_admin.generate_tenant_ls_rows(tenant_list)
             # get "default_datastore" from the output
             actual_output = rows[1][3]
             expected_output = self.datastore1_name
             self.assertEqual(expected_output, actual_output)
 
+            # switch the "default_datastore" to self.datastore_name
+            error_info = auth_api._tenant_update(name=self.tenant1_name,
+                                                 default_datastore=self.datastore_name)
+            self.assertEqual(error_info, None)
+            # remove the privilege to self.datastore1_name
             error_info = auth_api._tenant_access_rm(name=self.tenant1_name,
                                                     datastore=self.datastore1_name)
             self.assertEqual(error_info, None)
 
-        # remove access privileges
+        # remove access privileges, which should fail
+        # since the "default_datastore" is set to self.datastore_name
+        # cannot remove the privilege
         error_info = auth_api._tenant_access_rm(name=self.tenant1_name,
         datastore=self.datastore_name)
 
-        self.assertEqual(None, error_info)
+        self.assertNotEqual(None, error_info)
 
         error_info, privileges = auth_api._tenant_access_ls(self.tenant1_name)
         self.assertEqual(None, error_info)
 
-        rows = vmdkops_admin.generate_tenant_access_ls_rows(privileges)
-
-        # no tenant access privilege available for this tenant
-        self.assertEqual(rows, [])
+        # now, only have a privilege to self.datastore_name
+        _, rows = vmdkops_admin.generate_tenant_access_ls_rows(privileges, self.tenant1_name)
+        self.assertEqual(1, len(rows))
+        expected_output = [self.datastore_name,
+                            "True",
+                            "500.00MB",
+                            "1.00GB"]
+        actual_output = [rows[0][0],
+                         rows[0][1],
+                         rows[0][2],
+                         rows[0][3]]
+        self.assertEqual(expected_output, actual_output)
 
     def test_tenant_vm_for_default_tenant(self):
         """ Test AdminCLI vmgroup vm management for _DEFAULT vmgroup """

--- a/esx_service/utils/auth_api.py
+++ b/esx_service/utils/auth_api.py
@@ -26,6 +26,8 @@ import log_config
 import logging
 from error_code import ErrorCode
 from error_code import ErrorInfo
+from error_code import generate_error_info
+from error_code import error_code_to_message
 import re
 
 # regex for valid tenant name
@@ -60,12 +62,12 @@ def only_when_configured(ret_obj=False):
 
         def not_inited():
             'Returns err code for not initialized'
-            return error_code.generate_error_info(ErrorCode.INIT_NEEDED)
+            return generate_error_info(ErrorCode.INIT_NEEDED)
 
         def internal_error():
             'Returns error code for internal errors'
-            return error_code.generate_error_info(ErrorCode.INTERNAL_ERROR,
-                                                  "@only_when_configured: %s" % func.__name__)
+            return generate_error_info(ErrorCode.INTERNAL_ERROR,
+                                       "@only_when_configured: %s" % func.__name__)
 
         def check_config(*args, **kwargs):
             'call func() if DB is configured and issue an error if not.'
@@ -106,8 +108,10 @@ def get_tenant_from_db(name):
     logging.debug("auth_api.get_tenant_from_db name=%s", name)
     error_msg, tenant = auth_mgr.get_tenant(name)
     if error_msg:
-        error_info = error_code.generate_error_info(error_msg)
-    return error_info, tenant
+        error_info = generate_error_info(error_msg)
+        return error_info, None
+
+    return None, tenant
 
 def get_tenant_name(tenant_uuid):
     """
@@ -122,7 +126,7 @@ def get_tenant_name(tenant_uuid):
 
     error_msg, tenant_name = auth_mgr.get_tenant_name(tenant_uuid)
     if error_msg:
-        error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+        error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
     return error_info, tenant_name
 
 
@@ -138,11 +142,11 @@ def check_tenant_exist(name):
 
     error_msg, exist_tenant = auth_mgr.get_tenant(name)
     if error_msg:
-        error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+        error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
         return error_info
 
     if exist_tenant:
-        error_info = error_code.generate_error_info(ErrorCode.TENANT_ALREADY_EXIST, name)
+        error_info = generate_error_info(ErrorCode.TENANT_ALREADY_EXIST, name)
         return error_info
 
 
@@ -166,7 +170,7 @@ def create_tenant_in_db(name, description, vms, privileges):
                                                vms=vms,
                                                privileges=privileges)
     if error_msg:
-        error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+        error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
 
     return error_info, tenant
 
@@ -187,11 +191,11 @@ def get_tenant_list_from_db(name=None):
     if not name:
         error_msg, tenant_list = auth_mgr.list_tenants()
         if error_msg:
-            error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+            error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
     else:
         error_msg, tenant = auth_mgr.get_tenant(name)
         if error_msg:
-            error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+            error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
         if error_msg or not tenant:
             tenant_list = []
         else:
@@ -327,22 +331,22 @@ def get_default_datastore_url(name):
 
     if auth_mgr.allow_all_access():
         if name == auth_data_const.DEFAULT_TENANT:
-            return None, None  # "None" means default_url for now
+            return None, auth_data_const.VM_DS_URL
         else:
-            return error_code.generate_error_info(ErrorCode.INIT_NEEDED), None
+            return generate_error_info(ErrorCode.INIT_NEEDED), None
 
     error_info, tenant = get_tenant_from_db(name)
     if error_info:
         return error_info, None
 
     if not tenant:
-        error_info = error_code.generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
+        error_info = generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
         return error_info, None
 
     # if default_datastore is not set for this tenant, default_datastore will be None
     error_msg, default_datastore_url = tenant.get_default_datastore(auth_mgr.conn)
     if error_msg:
-        error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+        error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
     logging.debug("returning url %s", default_datastore_url)
     return error_info, default_datastore_url
 
@@ -365,14 +369,86 @@ def is_vm_duplicate(vm_list):
 
     return None
 
+def check_default_datastore(datastore_name):
+    """
+        Check datastore with given name is a valid value for default_datastore
+        Returns None for success and err message for errors
+    """
+    # The valid default_datastore name are:
+    # named datastore existing on the host
+    # hard coded datastore name "_VM_DS"
+    # "_ALL_DS" is not a valid value to set as "default_datastore"
+    if datastore_name == auth_data_const.VM_DS:
+        return None
+    if datastore_name == auth_data_const.ALL_DS:
+        return generate_error_info(ErrorCode.DS_DEFAULT_CANNOT_USE_ALL_DS)
+
+    if not vmdk_utils.validate_datastore(datastore_name):
+        error_info = generate_error_info(ErrorCode.DS_NOT_EXIST, datastore_name)
+        return error_info
+
+    return None
+
+def set_default_ds(tenant, default_datastore, check_existing):
+    """
+        Set "default_datastore" for given tenant and create a full access privilege
+        to "default_datastore" if entry does not exist
+        Need to check whether the default_datastore to be set is the same as exiting
+        default_datastore when @Param check_existing is set to True
+    """
+    # @Param tenant is a DockerVolumeTenant object
+    logging.debug("set_default_ds: tenant_name=%s default_datastore=%s check_existing=%d",
+                  tenant.name, default_datastore, check_existing)
+
+    error_info, auth_mgr = get_auth_mgr_object()
+    if error_info:
+        return error_info
+
+    datastore_url = vmdk_utils.get_datastore_url(default_datastore)
+    # datastore_url will be set to "None" by "vmdk_utils.get_datastore_url" is "default_datastore"
+    # is not a valid datastore
+    if datastore_url is None:
+        error_info = generate_error_info(ErrorCode.DS_DEFAULT_NAME_INVALID, default_datastore)
+        return error_info
+
+    existing_default_ds_url = None
+    if check_existing:
+        error_msg, existing_default_ds_url = tenant.get_default_datastore(auth_mgr.conn)
+        if error_msg:
+            error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+            return error_info
+
+        # the "default_datastore" to be set is the same as existing "default_datastore" for this tenant
+        if datastore_url == existing_default_ds_url:
+            return None
+
+    error_msg = tenant.set_default_datastore(auth_mgr.conn, datastore_url)
+    if error_msg:
+        error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+        return error_info
+    existing_default_ds = vmdk_utils.get_datastore_name(existing_default_ds_url) if existing_default_ds_url is not None else None
+    logging.info("Existing default_datastore %s is being changed to %s for tenant %s", existing_default_ds,
+                 default_datastore, tenant)
+
+    # create full access privilege to default_datastore
+    error_info = _tenant_access_add(name=tenant.name,
+                                    datastore=default_datastore,
+                                    allow_create=True)
+    # privilege to default_datastore already exist, no need to create
+    if error_info and error_info.code == ErrorCode.PRIVILEGE_ALREADY_EXIST:
+        logging.info(error_info.msg + " not overwriting the existing access privilege")
+        error_info = None
+
+    return error_info
+
 @only_when_configured(ret_obj=True)
-def _tenant_create(name, description="", vm_list=None, privileges=None):
+def _tenant_create(name, default_datastore, description="", vm_list=None, privileges=None):
     """ API to create a tenant . Returns (ErrInfo, Tenant) """
-    logging.debug("_tenant_create: name=%s description=%s vm_list=%s privileges=%s",
-                  name, description, vm_list, privileges)
+    logging.debug("_tenant_create: name=%s description=%s vm_list=%s privileges=%s default_ds=%s",
+                  name, description, vm_list, privileges, default_datastore)
+
     if not is_tenant_name_valid(name):
-        error_info = error_code.generate_error_info(ErrorCode.TENANT_NAME_INVALID,
-                                                    name, VALID_TENANT_NAME_REGEXP)
+        error_info = generate_error_info(ErrorCode.TENANT_NAME_INVALID, name, VALID_TENANT_NAME_REGEXP)
         return error_info, None
 
     # if param "description" is not set by caller, the default value is empty string
@@ -389,7 +465,7 @@ def _tenant_create(name, description="", vm_list=None, privileges=None):
         error_msg, vms, not_found_vms = generate_tuple_from_vm_list(vm_list)
         if error_msg:
             not_found_vm_list = ",".join(not_found_vms)
-            error_info = error_code.generate_error_info(ErrorCode.VM_NOT_FOUND, not_found_vm_list)
+            error_info = generate_error_info(ErrorCode.VM_NOT_FOUND, not_found_vm_list)
             return error_info, None
 
         error_info = vm_in_any_tenant(vms)
@@ -397,6 +473,10 @@ def _tenant_create(name, description="", vm_list=None, privileges=None):
             return error_info, None
 
         logging.debug("_tenant_create: vms=%s", vms)
+
+    error_info = check_default_datastore(default_datastore)
+    if error_info:
+        return error_info, None
 
     error_info, tenant = create_tenant_in_db(
         name=name,
@@ -406,60 +486,66 @@ def _tenant_create(name, description="", vm_list=None, privileges=None):
     if error_info:
         return error_info, None
 
+    error_info = set_default_ds(tenant=tenant,
+                                default_datastore=default_datastore,
+                                check_existing=False)
+    if error_info:
+        return error_info, None
     return None, tenant
 
 
 @only_when_configured()
 def _tenant_update(name, new_name=None, description=None, default_datastore=None):
     """ API to update a tenant """
+    logging.debug("_tenant_update: name=%s, new_name=%s, descrption=%s, default_datastore=%s",
+                  name, new_name, description, default_datastore)
     error_info, tenant = get_tenant_from_db(name)
     if error_info:
         return error_info
 
     if not tenant:
-        error_info = error_code.generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
+        error_info = generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
         return error_info
 
     error_info, auth_mgr = get_auth_mgr_object()
     if error_info:
         return error_info
 
+    if default_datastore:
+        error_info = check_default_datastore(default_datastore)
+        if error_info:
+            return error_info
+        error_info = set_default_ds(tenant=tenant,
+                                    default_datastore=default_datastore,
+                                    check_existing=True)
+        if error_info:
+            return error_info
+
     if new_name:
         if name == auth_data_const.DEFAULT_TENANT:
-            error_info = error_code.generate_error_info(ErrorCode.TENANT_NAME_INVALID, name, VALID_TENANT_NAMES)
+            error_info = generate_error_info(ErrorCode.TENANT_NAME_INVALID, name, VALID_TENANT_NAMES)
             return error_info
 
         # check whether tenant with new_name already exist or not
         error_info = check_tenant_exist(new_name)
         if error_info:
-            return error_info, None
+            return error_info
 
         if not is_tenant_name_valid(name):
-            error_info = error_code.generate_error_info(ErrorCode.TENANT_NAME_INVALID, name, VALID_TENANT_NAME_REGEXP)
-            return error_info, None
+            error_info = generate_error_info(ErrorCode.TENANT_NAME_INVALID, name, VALID_TENANT_NAME_REGEXP)
+            return error_info
 
         error_msg = tenant.set_name(auth_mgr.conn, name, new_name)
         if error_msg:
-            error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+            error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
             return error_info
     if description:
         error_msg = tenant.set_description(auth_mgr.conn, description)
         if error_msg:
-            error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
-            return error_info
-    if default_datastore:
-        error_info = check_datastore(default_datastore)
-        if error_info:
-            return error_info
-
-        datastore_url = vmdk_utils.get_datastore_url(default_datastore)
-        error_msg = tenant.set_default_datastore(auth_mgr.conn, datastore_url)
-        if error_msg:
-            error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+            error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
             return error_info
 
     return None
-
 
 @only_when_configured()
 def _tenant_rm(name, remove_volumes=False):
@@ -470,7 +556,7 @@ def _tenant_rm(name, remove_volumes=False):
         return error_info
 
     if not tenant:
-        error_info = error_code.generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
+        error_info = generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
         return error_info
 
     # check if vms that are a part of this tenant have any volumes mounted.
@@ -491,7 +577,7 @@ def _tenant_rm(name, remove_volumes=False):
 
     error_msg = auth_mgr.remove_tenant(tenant.id, remove_volumes)
     if error_msg:
-        error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+        error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
     return error_info
 
 def _tenant_ls(name=None):
@@ -510,7 +596,7 @@ def vm_already_in_tenant(name, vms):
 
     for vm_id, vm_name in vms:
         if vm_id in existing_vms:
-            error_info = error_code.generate_error_info(ErrorCode.VM_ALREADY_IN_TENANT,
+            error_info = generate_error_info(ErrorCode.VM_ALREADY_IN_TENANT,
                                                         vm_name, name)
             logging.error(error_info.msg)
             return error_info
@@ -561,8 +647,7 @@ def named_tenant(func):
     Return error 'feature is not supported' if called by _DEFAULT tenant
     """
     def not_supported():
-        return error_code.generate_error_info(ErrorCode.FEATURE_NOT_SUPPORTED,
-                                              auth_data_const.DEFAULT_TENANT)
+        return generate_error_info(ErrorCode.FEATURE_NOT_SUPPORTED, auth_data_const.DEFAULT_TENANT)
 
     def check_name(name, vm_list):
         if name == auth_data_const.DEFAULT_TENANT:
@@ -582,11 +667,11 @@ def _tenant_vm_add(name, vm_list):
         return error_info
 
     if not tenant:
-        error_info = error_code.generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
+        error_info = generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
         return error_info
 
     if not vm_list:
-        error_info = error_code.generate_error_info(ErrorCode.VM_LIST_EMPTY)
+        error_info = generate_error_info(ErrorCode.VM_LIST_EMPTY)
         return error_info
 
     error_info = is_vm_duplicate(vm_list)
@@ -596,7 +681,7 @@ def _tenant_vm_add(name, vm_list):
     error_msg, vms, not_found_vms = generate_tuple_from_vm_list(vm_list)
     if error_msg:
         not_found_vm_list = ",".join(not_found_vms)
-        error_info = error_code.generate_error_info(ErrorCode.VM_NOT_FOUND, not_found_vm_list)
+        error_info = generate_error_info(ErrorCode.VM_NOT_FOUND, not_found_vm_list)
         return error_info
 
     error_info = vm_already_in_tenant(name, vms)
@@ -615,7 +700,7 @@ def _tenant_vm_add(name, vm_list):
     logging.debug("_tenant_vm_add: vms=%s", vms)
     error_msg = tenant.add_vms(auth_mgr.conn, vms)
     if error_msg:
-        error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+        error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
     return error_info
 
 
@@ -630,11 +715,11 @@ def _tenant_vm_rm(name, vm_list):
         return error_info
 
     if not tenant:
-        error_info = error_code.generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
+        error_info = generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
         return error_info
 
     if not vm_list:
-        error_info = error_code.generate_error_info(ErrorCode.VM_LIST_EMPTY)
+        error_info = generate_error_info(ErrorCode.VM_LIST_EMPTY)
         return error_info
 
     error_info = is_vm_duplicate(vm_list)
@@ -644,7 +729,7 @@ def _tenant_vm_rm(name, vm_list):
     error_msg, vms, not_found_vms = generate_tuple_from_vm_list(vm_list)
     if error_msg:
         not_found_vm_list = ",".join(not_found_vms)
-        error_info = error_code.generate_error_info(ErrorCode.VM_NOT_FOUND, not_found_vm_list)
+        error_info = generate_error_info(ErrorCode.VM_NOT_FOUND, not_found_vm_list)
         return error_info
 
     # check if vms to be removed have any volumes mounted.
@@ -667,7 +752,7 @@ def _tenant_vm_rm(name, vm_list):
 
     error_msg = tenant.remove_vms(auth_mgr.conn, vms)
     if error_msg:
-        error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+        error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
     return error_info
 
 
@@ -679,7 +764,7 @@ def _tenant_vm_ls(name):
         return error_info, None
 
     if not tenant:
-        error_info = error_code.generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
+        error_info = generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
         return error_info, None
     # tenant.vms is a list of vm_uuid of vms which belong to this tenant
     return None, tenant.vms
@@ -696,11 +781,11 @@ def _tenant_vm_replace(name, vm_list):
         return error_info
 
     if not tenant:
-        error_info = error_code.generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
+        error_info = generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
         return error_info
 
     if not vm_list:
-        error_info = error_code.generate_error_info(ErrorCode.REPLACE_VM_EMPTY)
+        error_info = generate_error_info(ErrorCode.REPLACE_VM_EMPTY)
         return error_info
 
     error_info = is_vm_duplicate(vm_list)
@@ -711,7 +796,7 @@ def _tenant_vm_replace(name, vm_list):
 
     if error_msg:
         not_found_vm_list = ",".join(not_found_vms)
-        error_info = error_code.generate_error_info(ErrorCode.VM_NOT_FOUND, not_found_vm_list)
+        error_info = generate_error_info(ErrorCode.VM_NOT_FOUND, not_found_vm_list)
         return error_info
 
     error_info = vm_already_in_tenant(name, vms)
@@ -741,16 +826,19 @@ def _tenant_vm_replace(name, vm_list):
 
     error_msg = tenant.replace_vms(auth_mgr.conn, vms)
     if error_msg:
-        error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+        error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
     return error_info
 
 def check_datastore(datastore_name):
     """ Check datastore with given name is a valid datastore or not """
-    if datastore_name == auth_data_const.DEFAULT_DS:
+    if datastore_name == auth_data_const.VM_DS:
+        return None
+
+    if datastore_name == auth_data_const.ALL_DS:
         return None
 
     if not vmdk_utils.validate_datastore(datastore_name):
-        error_info = error_code.generate_error_info(ErrorCode.DS_NOT_EXIST, datastore_name)
+        error_info = generate_error_info(ErrorCode.DS_NOT_EXIST, datastore_name)
         return error_info
 
     return None
@@ -777,14 +865,26 @@ def check_privilege_parameters(privilege):
     # If both volume max size and volume total size are set,
     # volume max size should not exceed volume total size
     if (volume_maxsize and volume_totalsize and (volume_maxsize > volume_totalsize)):
-        error_info = error_code.generate_error_info(ErrorCode.PRIVILEGE_INVALID_VOLUME_SIZE, volume_maxsize, volume_totalsize)
+        error_info = generate_error_info(ErrorCode.PRIVILEGE_INVALID_VOLUME_SIZE, volume_maxsize, volume_totalsize)
         return error_info
 
     return None
 
+def check_usage_quota(datastore, volume_totalsize_in_MB):
+    """
+        Check if the requested quota is valid in the given datastore
+        Return None if the usage_quota is valid
+        Return error_info if the usage_quota is invalid
+    """
+    # usage_quota on "_VM_DS" and "_ALL_DS" should be "Unset"
+    if datastore == auth_data_const.VM_DS or datastore == auth_data_const.ALL_DS:
+        if volume_totalsize_in_MB is not None:
+            error_info = generate_error_info(ErrorCode.PRIVILEGE_SET_TOTAL_VOLUME_SIZE_LIMIT_NOT_ALLOWED,
+                                             datastore)
+            return error_info
 
 @only_when_configured()
-def _tenant_access_add(name, datastore, allow_create=None, default_datastore=False,
+def _tenant_access_add(name, datastore, allow_create=None,
                        volume_maxsize_in_MB=None, volume_totalsize_in_MB=None):
     """ API to add datastore access for a tenant """
 
@@ -797,10 +897,14 @@ def _tenant_access_add(name, datastore, allow_create=None, default_datastore=Fal
         return error_info
 
     if not tenant:
-        error_info = error_code.generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
+        error_info = generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
         return error_info
 
     error_info = check_datastore(datastore)
+    if error_info:
+        return error_info
+
+    error_info = check_usage_quota(datastore, volume_totalsize_in_MB)
     if error_info:
         return error_info
 
@@ -811,7 +915,7 @@ def _tenant_access_add(name, datastore, allow_create=None, default_datastore=Fal
         return error_info
 
     if privilege_exist(existing_privileges, datastore_url):
-        error_info = error_code.generate_error_info(ErrorCode.PRIVILEGE_ALREADY_EXIST, name, datastore)
+        error_info = generate_error_info(ErrorCode.PRIVILEGE_ALREADY_EXIST, name, datastore)
         return error_info
 
     # Possible value:
@@ -823,7 +927,7 @@ def _tenant_access_add(name, datastore, allow_create=None, default_datastore=Fal
 
         if not valid:
             err_code = ErrorCode.PRIVILEGE_INVALID_ALLOW_CREATE_VALUE
-            err_msg = error_code.error_code_to_message[err_code].format(allow_create)
+            err_msg = error_code_to_message[err_code].format(allow_create)
             logging.error(err_msg)
             return ErrorInfo(err_code, err_msg)
 
@@ -845,26 +949,8 @@ def _tenant_access_add(name, datastore, allow_create=None, default_datastore=Fal
 
     error_msg = tenant.set_datastore_access_privileges(auth_mgr.conn, [privileges])
     if error_msg:
-        error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+        error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
         return error_info
-
-    error_msg, result = auth.get_row_from_privileges_table(auth_mgr.conn, tenant.id)
-    # if len(result) == 1, which means "datastore"" is the first datastore for this tenant,
-    # and should set this datastore to the "default_datastore" for this tenant
-    if error_msg:
-        error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
-        return error_info
-    logging.debug("_tenant_access_add: get_row_from_privileges_table for tenant id=%s return %s",
-                  tenant.id, result)
-
-    if len(result) == 1 or default_datastore:
-        if datastore_url == auth_data_const.DEFAULT_DS_URL:
-            #  DEFAULT privilege for DEFAULT tenant does not need default_datastore setting
-            error_msg = tenant.set_default_datastore(auth_mgr.conn, "")
-        else:
-            error_msg = tenant.set_default_datastore(auth_mgr.conn, datastore_url)
-        if error_msg:
-            error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
 
     return error_info
 
@@ -881,10 +967,14 @@ def _tenant_access_set(name, datastore, allow_create=None, volume_maxsize_in_MB=
         return error_info
 
     if not tenant:
-        error_info = error_code.generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
+        error_info = generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
         return error_info
 
     error_info = check_datastore(datastore)
+    if error_info:
+        return error_info
+
+    error_info = check_usage_quota(datastore, volume_totalsize_in_MB)
     if error_info:
         return error_info
 
@@ -895,7 +985,7 @@ def _tenant_access_set(name, datastore, allow_create=None, volume_maxsize_in_MB=
         return error_info
 
     if not privilege_exist(existing_privileges, datastore_url):
-        error_info = error_code.generate_error_info(ErrorCode.PRIVILEGE_NOT_FOUND, name, datastore)
+        error_info = generate_error_info(ErrorCode.PRIVILEGE_NOT_FOUND, name, datastore)
         return error_info
 
     logging.debug("_tenant_access_set: datastore_url=%s", datastore_url)
@@ -903,7 +993,7 @@ def _tenant_access_set(name, datastore, allow_create=None, volume_maxsize_in_MB=
 
     if not privileges:
         err_code = ErrorCode.PRIVILEGE_NOT_FOUND
-        err_msg = error_code.error_code_to_message[err_code].format(name, datastore)
+        err_msg = error_code_to_message[err_code].format(name, datastore)
         error_info = ErrorInfo(err_code, err_msg)
         return error_info
 
@@ -912,7 +1002,7 @@ def _tenant_access_set(name, datastore, allow_create=None, volume_maxsize_in_MB=
 
         if not valid:
             err_code = ErrorCode.PRIVILEGE_INVALID_ALLOW_CREATE_VALUE
-            err_msg = error_code.error_code_to_message[err_code].format(allow_create)
+            err_msg = error_code_to_message[err_code].format(allow_create)
             logging.error(err_msg)
             return ErrorInfo(err_code, err_msg)
 
@@ -937,7 +1027,7 @@ def _tenant_access_set(name, datastore, allow_create=None, volume_maxsize_in_MB=
 
     error_msg = tenant.set_datastore_access_privileges(auth_mgr.conn, [privileges_dict])
     if error_msg:
-        error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+        error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
     return error_info
 
 @only_when_configured()
@@ -949,7 +1039,7 @@ def _tenant_access_rm(name, datastore):
         return error_info
 
     if not tenant:
-        error_info = error_code.generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
+        error_info = generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
         return error_info
 
     error_info = check_datastore(datastore)
@@ -963,31 +1053,33 @@ def _tenant_access_rm(name, datastore):
         return error_info
 
     if not privilege_exist(existing_privileges, datastore_url):
-        error_info = error_code.generate_error_info(ErrorCode.PRIVILEGE_NOT_FOUND, name, datastore)
+        error_info = generate_error_info(ErrorCode.PRIVILEGE_NOT_FOUND, name, datastore)
         return error_info
 
     error_info, auth_mgr = get_auth_mgr_object()
     if error_info:
         return error_info
 
-    logging.debug("_tenant_access_rm: datastore_url=%s", datastore_url)
-    error_msg = tenant.remove_datastore_access_privileges(auth_mgr.conn, datastore_url)
-    if error_msg:
-        error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
-        return error_info
-
-    # get default_datastore, if default_datastore is the same as param "datastore"
-    # need to set default_datastore_url to "" in tenants table
+    # get dafault_datastore for this tenant
+    # if the default_datastore is equal to param "datastore", which means
+    # we are trying to remove a row in "privilege" table with datastore which is
+    # marked as default_datastore of this tenant, should return with error
     error_info, default_datastore_url = get_default_datastore_url(name)
     if error_info:
         return error_info
 
     if default_datastore_url == datastore_url:
-        error_msg = tenant.set_default_datastore(auth_mgr.conn, "")
-        if error_msg:
-            error_info = error_code.generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+        error_info = generate_error_info(ErrorCode.PRIVILEGE_REMOVE_NOT_ALLOWED)
+        return error_info
 
-    return error_info
+
+    logging.debug("_tenant_access_rm: datastore_url=%s", datastore_url)
+    error_msg = tenant.remove_datastore_access_privileges(auth_mgr.conn, datastore_url)
+    if error_msg:
+        error_info = generate_error_info(ErrorCode.INTERNAL_ERROR, error_msg)
+        return error_info
+
+    return None
 
 
 @only_when_configured(ret_obj=True)
@@ -999,7 +1091,7 @@ def _tenant_access_ls(name):
         return error_info, None
 
     if not tenant:
-        error_info = error_code.generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
+        error_info = generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
         return error_info, None
 
     return None, tenant.privileges

--- a/esx_service/utils/auth_data_const.py
+++ b/esx_service/utils/auth_data_const.py
@@ -42,3 +42,7 @@ DEFAULT_TENANT_DESCR = "This is a default vmgroup"
 DEFAULT_DS  = '_DEFAULT'
 DEFAULT_DS_URL = DEFAULT_DS + "_URL"
 ORPHAN_TENANT = "_ORPHAN"
+VM_DS = '_VM_DS'
+VM_DS_URL = VM_DS + "://"
+ALL_DS = '_ALL_DS'
+ALL_DS_URL = ALL_DS + "://"

--- a/esx_service/utils/error_code.py
+++ b/esx_service/utils/error_code.py
@@ -41,18 +41,24 @@ class ErrorCode:
     PRIVILEGE_ALREADY_EXIST = 202
     PRIVILEGE_INVALID_VOLUME_SIZE = 203
     PRIVILEGE_INVALID_ALLOW_CREATE_VALUE = 204
+    PRIVILEGE_REMOVE_NOT_ALLOWED = 205
+
+    # result returned from check_privileges_for_command function
+    PRIVILEGE_NO_PRIVILEGE = 206
+    PRIVILEGE_NO_MOUNT_PRIVILEGE = 207
+    PRIVILEGE_NO_CREATE_PRIVILEGE = 208
+    PRIVILEGE_NO_DELETE_PRIVILEGE = 209
+    PRIVILEGE_MAX_VOL_EXCEED = 210
+    PRIVILEGE_USAGE_QUOTA_EXCEED = 211
+    PRIVILEGE_SET_TOTAL_VOLUME_SIZE_LIMIT_NOT_ALLOWED = 212
     # Privilege related error code end
 
     # DATASTORE related error code start
-    DEFAULT_DS_NOT_SET = 301
+    DS_DEFAULT_NOT_SET = 301
     DS_NOT_EXIST = 302
-
-    # Indicates that config init needed for a requested operation
-    INIT_NEEDED = 303
-
-    # Catch all for SQLite errors. Note that logging() will have extra  info
-    SQLITE3_ERROR = 304
-
+    DS_DEFAULT_NAME_INVALID = 303
+    DS_DEFAULT_SET_FAILED = 304
+    DS_DEFAULT_CANNOT_USE_ALL_DS = 305
     # DATASTORE related error code end
 
     # VMODL related error code start
@@ -65,6 +71,11 @@ class ErrorCode:
     INVALID_ARGUMENT = 502
     VOLUME_NAME_INVALID = 503
     FEATURE_NOT_SUPPORTED = 504
+    # Indicates that config init needed for a requested operation
+    INIT_NEEDED = 505
+
+    # Catch all for SQLite errors. Note that logging() will have extra  info
+    SQLITE3_ERROR = 506
 
 
 error_code_to_message = {
@@ -86,15 +97,24 @@ error_code_to_message = {
     ErrorCode.VM_DUPLICATE : "VMs {0} contain duplicates, they should be unique",
     ErrorCode.VM_WITH_MOUNTED_VOLUMES : "VM '{0}' has volumes mounted.",
 
-    ErrorCode.PRIVILEGE_NOT_FOUND : "No privilege exists for ({0}, {1})",
-    ErrorCode.PRIVILEGE_ALREADY_EXIST : "Privilege for ({0}, {1}) already exists",
+    ErrorCode.PRIVILEGE_NOT_FOUND : "No access privilege exists for ({0}, {1})",
+    ErrorCode.PRIVILEGE_ALREADY_EXIST : "Access privilege for ({0}, {1}) already exists",
     ErrorCode.PRIVILEGE_INVALID_VOLUME_SIZE : "Volume max size {0}MB exceeds the total size {1}MB",
     ErrorCode.PRIVILEGE_INVALID_ALLOW_CREATE_VALUE : "Invalid value {0} for allow-create option",
+    ErrorCode.PRIVILEGE_REMOVE_NOT_ALLOWED : "Removing of access privilege to 'default_datastore' is not supported",
+    ErrorCode.PRIVILEGE_NO_PRIVILEGE : "No access privilege exists",
+    ErrorCode.PRIVILEGE_NO_MOUNT_PRIVILEGE : "No mount privilege",
+    ErrorCode.PRIVILEGE_NO_CREATE_PRIVILEGE : "No create privilege",
+    ErrorCode.PRIVILEGE_NO_DELETE_PRIVILEGE : "No delete privilege",
+    ErrorCode.PRIVILEGE_MAX_VOL_EXCEED : "Volume size exceeds the max volume size limit",
+    ErrorCode.PRIVILEGE_USAGE_QUOTA_EXCEED : "The total volume size exceeds the usage quota",
+    ErrorCode.PRIVILEGE_SET_TOTAL_VOLUME_SIZE_LIMIT_NOT_ALLOWED : "Cannot set volume-totalsize for {}",
 
-    ErrorCode.DEFAULT_DS_NOT_SET : "Default datastore is not set",
+    ErrorCode.DS_DEFAULT_NOT_SET : "Default datastore is not set for vmgroup {}",
     ErrorCode.DS_NOT_EXIST : "Datastore {0} does not exist",
-    ErrorCode.INIT_NEEDED: "Please init configuration with 'vmdkops_admin.py config init' before changing it.",
-    ErrorCode.SQLITE3_ERROR: "Sqlite3 error - see log for more info",
+    ErrorCode.DS_DEFAULT_NAME_INVALID : "Default datastore name {} is invalid",
+    ErrorCode.DS_DEFAULT_SET_FAILED : "Set default datastore for vmgroup {} failed ({})",
+    ErrorCode.DS_DEFAULT_CANNOT_USE_ALL_DS : "Cannot use _ALL_DS as default datastore. Please use specific datastore name or _VM_DS special datastore",
 
     ErrorCode.VMODL_TENANT_NAME_EMPTY : "Vmgroup name is empty",
     ErrorCode.VMODL_TENANT_NAME_TOO_LONG : "Vmgroup name exceeds 64 characters: {0}",
@@ -103,7 +123,9 @@ error_code_to_message = {
     ErrorCode.INTERNAL_ERROR : "Internal Error({0})",
     ErrorCode.INVALID_ARGUMENT : "Invalid Argument({0})",
     ErrorCode.VOLUME_NAME_INVALID : "Volume name {0} is invalid, only {1} is allowed",
-    ErrorCode.FEATURE_NOT_SUPPORTED : "This feature is not supported for vmgroup {}."
+    ErrorCode.FEATURE_NOT_SUPPORTED : "This feature is not supported for vmgroup {}.",
+    ErrorCode.INIT_NEEDED: "Please init configuration with 'vmdkops_admin.py config init' before changing it.",
+    ErrorCode.SQLITE3_ERROR: "Sqlite3 error - see log for more info",
 }
 
 class ErrorInfo:

--- a/esx_service/utils/vmdk_utils.py
+++ b/esx_service/utils/vmdk_utils.py
@@ -26,6 +26,7 @@ from pyVim import vmconfig
 from pyVmomi import vim
 import pyVim
 from pyVim.invt import GetVmFolder, FindChild
+from error_code import *
 
 import threadutils
 import vmdk_ops
@@ -391,9 +392,13 @@ def get_datastore_objects():
 def get_datastore_url(datastore_name):
     """ return datastore url for given datastore name """
 
-    # Return default datastore URL for default datastore name
-    if datastore_name == auth_data_const.DEFAULT_DS:
-        return auth_data_const.DEFAULT_DS_URL
+    # Return datastore url for datastore name "_VM_DS""
+    if datastore_name == auth_data_const.VM_DS:
+        return auth_data_const.VM_DS_URL
+
+    # Return datastore url for datastore name "_ALL_DS""
+    if datastore_name == auth_data_const.ALL_DS:
+        return auth_data_const.ALL_DS_URL
 
     # validate_datastore will refresh the cache if datastore_name is not in cache
     if not validate_datastore(datastore_name):
@@ -408,10 +413,13 @@ def get_datastore_url(datastore_name):
 
 def get_datastore_name(datastore_url):
     """ return datastore name for given datastore url """
+    # Return datastore name for datastore url "_VM_DS_URL""
+    if datastore_url == auth_data_const.VM_DS_URL:
+        return auth_data_const.VM_DS
 
-    # Return default datastore name for default datastore URL
-    if datastore_url == auth_data_const.DEFAULT_DS_URL:
-        return auth_data_const.DEFAULT_DS
+    # Return datastore name for datastore url "_ALL_DS_URL""
+    if datastore_url == auth_data_const.ALL_DS_URL:
+        return auth_data_const.ALL_DS
 
     # Query datastore name from VIM API
     # get_datastores() return a list of tuple
@@ -419,7 +427,6 @@ def get_datastore_name(datastore_url):
     res = [d[0] for d in get_datastores() if d[1] == datastore_url]
     logging.debug("get_datastore_name: res=%s", res)
     return res[0] if res else None
-
 
 def get_datastore_url_from_config_path(config_path):
     """Returns datastore url in config_path """

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -747,9 +747,8 @@ class VmdkTenantTestCase(unittest.TestCase):
         if not auth_api.privilege_exist(existing_privileges, auth_data_const.ALL_DS_URL):
             error_info = auth_api._tenant_access_add(name=auth_data_const.DEFAULT_TENANT,
                                                     datastore=auth_data_const.ALL_DS,
-                                                    allow_create=True,
-                                                    volume_maxsize_in_MB=0,
-                                                    volume_totalsize_in_MB=0)
+                                                    allow_create=True)
+
             if error_info:
                 logging.warning(error_info.msg)
             self.assertEqual(error_info, None)
@@ -758,9 +757,8 @@ class VmdkTenantTestCase(unittest.TestCase):
         if not auth_api.privilege_exist(existing_privileges, auth_data_const.VM_DS_URL):
             error_info = auth_api._tenant_access_add(name=auth_data_const.DEFAULT_TENANT,
                                                     datastore=auth_data_const.VM_DS,
-                                                    allow_create=True,
-                                                    volume_maxsize_in_MB=0,
-                                                    volume_totalsize_in_MB=0)
+                                                    allow_create=True)
+
             if error_info:
                 logging.warning(error_info.msg)
             self.assertEqual(error_info, None)
@@ -1530,9 +1528,8 @@ class VmdkTenantPolicyUsageTestCase(unittest.TestCase):
         if not auth_api.privilege_exist(existing_privileges, auth_data_const.ALL_DS_URL):
             error_info = auth_api._tenant_access_add(name=auth_data_const.DEFAULT_TENANT,
                                                     datastore=auth_data_const.ALL_DS,
-                                                    allow_create=True,
-                                                    volume_maxsize_in_MB=0,
-                                                    volume_totalsize_in_MB=0)
+                                                    allow_create=True)
+
             if error_info:
                 logging.warning(error_info.msg)
             self.assertEqual(error_info, None)
@@ -1541,9 +1538,8 @@ class VmdkTenantPolicyUsageTestCase(unittest.TestCase):
         if not auth_api.privilege_exist(existing_privileges, auth_data_const.VM_DS_URL):
             error_info = auth_api._tenant_access_add(name=auth_data_const.DEFAULT_TENANT,
                                                     datastore=auth_data_const.VM_DS,
-                                                    allow_create=True,
-                                                    volume_maxsize_in_MB=0,
-                                                    volume_totalsize_in_MB=0)
+                                                    allow_create=True)
+
             if error_info:
                 logging.warning(error_info.msg)
             self.assertEqual(error_info, None)

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -37,13 +37,16 @@ import auth
 import auth_data
 import auth_api
 import auth_data_const
-import error_code
 import vmdk_utils
 import random
 import convert
+import error_code
 from error_code import ErrorCode
+from error_code import error_code_to_message
+from error_code import generate_error_info
 from vmdkops_admin_sanity_test import ADMIN_CLI
 import glob
+import vmdkops_admin
 
 # Max volumes count we can attach to a singe VM.
 MAX_VOL_COUNT_FOR_ATTACH = 60
@@ -433,7 +436,7 @@ def create_vm(si, vm_name, datastore_name):
                 task = vm.PowerOnVM_Task()
                 vmdk_ops.wait_for_tasks(si, [task])
         else:
-            error_info = error_code.generate_error_info(ErrorCode.VM_NOT_FOUND, vm_name)
+            error_info = generate_error_info(ErrorCode.VM_NOT_FOUND, vm_name)
             logging.error("Cannot find vm %s", vm_name)
             return error_info, None
 
@@ -636,7 +639,7 @@ class VmdkAuthorizeTestCase(unittest.TestCase):
         self.assertEqual(error_info, None)
         opts={u'size': u'100MB', u'fstype': u'ext4'}
         error_info, tenant_uuid, tenant_name = auth.authorize(self.vm_uuid, self.datastore_url, auth.CMD_CREATE, opts)
-        self.assertEqual(error_info, "No create privilege" )
+        self.assertEqual(error_info, "No create privilege")
 
         # set "create_volume" privilege to true
         privileges = [{'datastore_url': self.datastore_url,
@@ -656,7 +659,7 @@ class VmdkAuthorizeTestCase(unittest.TestCase):
         opts={u'size': u'600MB', u'fstype': u'ext4'}
         error_info, tenant_uuid, tenant_name = auth.authorize(self.vm_uuid, self.datastore_url, auth.CMD_CREATE, opts)
         # create a volume with 600MB which exceed the"max_volume_size", command should fail
-        self.assertEqual(error_info, "volume size exceeds the max volume size limit")
+        self.assertEqual(error_info, "Volume size exceeds the max volume size limit")
 
         opts={u'size': u'500MB', u'fstype': u'ext4'}
         error_info, tenant_uuid, tenant_name = auth.authorize(self.vm_uuid, self.datastore_url, auth.CMD_CREATE, opts)
@@ -685,7 +688,9 @@ class VmdkTenantTestCase(unittest.TestCase):
     default_tenant_vol1_name = "default_tenant_vol1"
     default_tenant_vol2_name = "default_tenant_vol2"
     default_tenant_vol3_name = "default_tenant_vol3"
-    default_tenant_vols = [default_tenant_vol1_name, default_tenant_vol2_name, default_tenant_vol3_name]
+    default_tenant_vol4_name = "default_tenant_vol4"
+    default_tenant_vols = [default_tenant_vol1_name, default_tenant_vol2_name,
+                           default_tenant_vol3_name, default_tenant_vol4_name]
 
     # tenant1 info
     tenant1_name = "test_tenant1"
@@ -696,6 +701,8 @@ class VmdkTenantTestCase(unittest.TestCase):
     tenant1_vol3_name = 'tenant1_vol3'
     vm1_config_path = None
     tenant1_new_name = "new_test_tenant1"
+    vm3_name = generate_test_vm_name()
+    vm3 = None
 
     # tenant2 info
     tenant2_name = "test_tenant2"
@@ -722,35 +729,36 @@ class VmdkTenantTestCase(unittest.TestCase):
 
         if not tenant_uuid:
             logging.debug("create_default_tenant_and_privileges: create DEFAULT tenant")
-            error_info, auth_mgr = auth_api.get_auth_mgr_object()
-            if error_info:
-                err = error_code.TENANT_CREATE_FAILED.format(auth_data_const.DEFAULT_TENANT, error_info.msg)
-                logging.warning(err)
-            self.assertEqual(error_info, None)
-
-            error_msg, tenant = auth_mgr.create_tenant(
+            error_info, tenant = auth_api._tenant_create(
                                            name=auth_data_const.DEFAULT_TENANT,
+                                           default_datastore=auth_data_const.VM_DS,
                                            description=auth_data_const.DEFAULT_TENANT_DESCR,
-                                           vms=[],
+                                           vm_list=[],
                                            privileges=[])
 
-            if error_msg:
-                err = error_code.TENANT_CREATE_FAILED.format(auth_data_const.DEFAULT_TENANT, error_msg)
-                logging.warning(err)
-            self.assertEqual(error_msg, None)
+            if error_info:
+                logging.warning(error_info.msg)
+            self.assertEqual(error_info, None)
 
-        # create DEFAULT privilege if needed
-        error_msg, privileges = auth.get_default_privileges()
-        if error_msg:
-            logging.warning(error_msg)
-        self.assertEqual(error_msg, None)
+        error_info, existing_privileges = auth_api._tenant_access_ls(auth_data_const.DEFAULT_TENANT)
+        self.assertEqual(error_info, None)
 
-        if not privileges:
-            logging.debug("create_default_tenant_and_privileges: create DEFAULT privileges")
+        # create access privilege to datastore "_ALL_DS" for _DEFAULT tenant if needed
+        if not auth_api.privilege_exist(existing_privileges, auth_data_const.ALL_DS_URL):
             error_info = auth_api._tenant_access_add(name=auth_data_const.DEFAULT_TENANT,
-                                                    datastore=auth_data_const.DEFAULT_DS,
+                                                    datastore=auth_data_const.ALL_DS,
                                                     allow_create=True,
-                                                    default_datastore=False,
+                                                    volume_maxsize_in_MB=0,
+                                                    volume_totalsize_in_MB=0)
+            if error_info:
+                logging.warning(error_info.msg)
+            self.assertEqual(error_info, None)
+
+        # create access privilege to datastore "_VM_DS" for _DEFAULT tenant if needed
+        if not auth_api.privilege_exist(existing_privileges, auth_data_const.VM_DS_URL):
+            error_info = auth_api._tenant_access_add(name=auth_data_const.DEFAULT_TENANT,
+                                                    datastore=auth_data_const.VM_DS,
+                                                    allow_create=True,
                                                     volume_maxsize_in_MB=0,
                                                     volume_totalsize_in_MB=0)
             if error_info:
@@ -799,7 +807,17 @@ class VmdkTenantTestCase(unittest.TestCase):
         self.vm2_config_path = vmdk_utils.get_vm_config_path(self.vm2_name)
         logging.info("VmdkTenantTestCase: create vm2 name=%s Done", self.vm2_name)
 
-        # create DEFAULT tenant DEFAULT privilege if missing
+        if self.datastore1_name:
+            # create a volume from different datastore
+            error, self.vm3 = create_vm(si=si,
+                                        vm_name=self.vm3_name,
+                                        datastore_name=self.datastore1_name)
+            if error:
+                self.assertFalse(True)
+            self.vm3_config_path = vmdk_utils.get_vm_config_path(self.vm3_name)
+            logging.info("VmdkTenantTestCase: create vm3 name=%s Done", self.vm3_name)
+
+        # create DEFAULT tenant and privilege if missing
         self.create_default_tenant_and_privileges()
 
         # create tenant1 without adding any vms and privileges
@@ -810,6 +828,7 @@ class VmdkTenantTestCase(unittest.TestCase):
 
         error_info, tenant = auth_api._tenant_create(
                                                     name=name,
+                                                    default_datastore=auth_data_const.VM_DS,
                                                     description=description,
                                                     vm_list=vm_list,
                                                     privileges=privileges)
@@ -823,6 +842,7 @@ class VmdkTenantTestCase(unittest.TestCase):
 
         error_info, tenant = auth_api._tenant_create(
                                                     name=name,
+                                                    default_datastore=auth_data_const.VM_DS,
                                                     description=description,
                                                     vm_list=vm_list,
                                                     privileges=privileges)
@@ -862,18 +882,22 @@ class VmdkTenantTestCase(unittest.TestCase):
         si = vmdk_ops.get_si()
         remove_vm(si, self.vm1)
         remove_vm(si, self.vm2)
+        if self.vm3:
+            remove_vm(si, self.vm3)
 
     def test_vmdkops_on_default_tenant_vm(self):
         """ Test vmdk life cycle on a VM which belongs to DEFAULT tenant """
         # This test test the following cases:
-        # 1. DEFAULT tenant and DEFAULT privileges are present, vmdk_ops from VM which is not owned by any tenant,
-        #    vmdk_ops should succeed
-        # 2. set the default_datastore for DEFAULT tenant,  volume create with short name should be created in the
+        # 1. DEFAULT tenant, privilege to datastore "_ALL_DS", and privilege to datastore "_VM_DS""
+        # are present, vmdk_ops from VM which is not owned by any tenant, vmdk_ops should succeed, and the volumes
+        # will be created in the _VM_DS
+        # 2. change the default_datastore for DEFAULT tenant,  volume create with short name should be created in the
         # default datastore instead of VM datastore
-        # 3. REMOVE DEFAULT privileges, "create volume" should fail
+        # 3. Only privilege to  "_VM_DS" present, "create volume" should succed
         # 4. REMOVE DEFAULT tenant, "create volume" should fail
 
-        # run create, attach, detach, remove command when DEFAULT tenant and DEFAULT privileges are present
+        # run create, attach, detach, remove command when DEFAULT tenant and  privileges to "_ALL_DS" and "_VM_DS" are present
+        # This is the case after user fresh install
         logging.info("test_vmdkops_on_default_tenant_vm")
         vm1_uuid = vmdk_utils.get_vm_uuid_by_name(self.vm1_name)
 
@@ -897,7 +921,7 @@ class VmdkTenantTestCase(unittest.TestCase):
         self.assertEqual(None, error_info)
 
         # create a volume with default size
-        # default_datastore is not set for _DEFAULT tenant yet, a volume will be
+        # default_datastore for _DEFAULT tenant is set to "VM_DS", a volume will be
         # tried to create on the vm_datastore, which is self.datastore_name
         opts={u'fstype': u'ext4'}
         error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.default_tenant_vol1_name, opts)
@@ -905,16 +929,11 @@ class VmdkTenantTestCase(unittest.TestCase):
 
         # Only run this test if second datastore exists
         if self.datastore1_name:
-            # Add a new access privilege for _DEFAULT tenant to second datastore "self.datastore1_name"
-            # and set the default_datastore for _DEFAULT tenant to "self.datastore1_name"
-            volume_maxsize_in_MB = convert.convert_to_MB("500MB")
-            volume_totalsize_in_MB = convert.convert_to_MB("2GB")
-            error_info = auth_api._tenant_access_add(name=auth_data_const.DEFAULT_TENANT,
-                                                    datastore=self.datastore1_name,
-                                                    allow_create=True,
-                                                    default_datastore=True,
-                                                    volume_maxsize_in_MB=volume_maxsize_in_MB,
-                                                    volume_totalsize_in_MB=volume_totalsize_in_MB)
+            # Change the "default_datastore" of _DEFAULT tenant to second datastore "self.datastore1_name"
+            # Then the full access privilege will be created to this new "default_datastore"
+            error_info = auth_api._tenant_update(name=auth_data_const.DEFAULT_TENANT,
+                                                 default_datastore=self.datastore1_name,
+                                                 )
             # create a volume with default size
             # default_datastore is set for _DEFAULT tenant, a volume will be
             # tried to create on the default_datastore, which is "self.datastore1_name"
@@ -934,14 +953,44 @@ class VmdkTenantTestCase(unittest.TestCase):
             # remove privilege to datastore "self.datastore1_name"
             error_info = auth_api._tenant_access_rm(name=auth_data_const.DEFAULT_TENANT,
                                                     datastore=self.datastore1_name)
+            # datastore "self.datastore1_name" is still the "default_datastore" for _DEFAULT tenant, cannot remove
+            self.assertNotEqual(None, error_info)
+
+            # change the "default_datastore" for _DEFAULT tenant to "_ALL_DS", which should fail
+            # "_ALL_DS" cannot be set as "default_datastore"
+            error_info = auth_api._tenant_update(name=auth_data_const.DEFAULT_TENANT,
+                                                 default_datastore=auth_data_const.ALL_DS)
+            self.assertNotEqual(None, error_info)
+
+            # set the "default_datastore" for _DEFAULT tenant to "_VM_DS", which should succeed
+            error_info = auth_api._tenant_update(name=auth_data_const.DEFAULT_TENANT,
+                                                 default_datastore=auth_data_const.VM_DS)
             self.assertEqual(None, error_info)
 
-        # remove DEFAULT privileges, and run create command, which should fail
-        error_info = auth_api._tenant_access_rm(auth_data_const.DEFAULT_TENANT, auth_data_const.DEFAULT_DS)
+            # remove the access privilege to "self.datastore1_name"
+            error_info = auth_api._tenant_access_rm(auth_data_const.DEFAULT_TENANT, self.datastore1_name)
+            self.assertEqual(None, error_info)
+
+        # remove "_ALL_DS"" privileges, and run create command, which should succeed since we still have
+        # access privilege to "_VM_DS"
+        error_info = auth_api._tenant_access_rm(auth_data_const.DEFAULT_TENANT, auth_data_const.ALL_DS)
         self.assertEqual(None, error_info)
 
         opts={u'size': u'100MB', u'fstype': u'ext4'}
         error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.default_tenant_vol3_name, opts)
+        self.assertEqual(None, error_info)
+
+        # try to create volume on a different datastore, which should fail
+        if self.datastore1_name:
+            full_vol_name = self.default_tenant_vol4_name + "@" + self.datastore1_name
+            opts={u'size': u'100MB', u'fstype': u'ext4'}
+            error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, full_vol_name, opts)
+            self.assertNotEqual(None, error_info)
+
+        # remove "_VM_DS" privilege, which should fail since "_VM_DS"
+        # is the "default_datastore" of _DEFAULT tenant
+        # cannot remove it
+        error_info = auth_api._tenant_access_rm(auth_data_const.DEFAULT_TENANT, auth_data_const.VM_DS)
         self.assertNotEqual(None, error_info)
 
         # remove DEFAULT tenant, and run create command, which should fail
@@ -949,11 +998,18 @@ class VmdkTenantTestCase(unittest.TestCase):
         self.assertEqual(None, error_info)
 
         opts={u'size': u'100MB', u'fstype': u'ext4'}
-        error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.default_tenant_vol2_name, opts)
+        error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.default_tenant_vol4_name, opts)
         self.assertNotEqual(None, error_info)
+
 
     def test_vmdkops_on_tenant_vm(self):
         """ Test vmdk life cycle on a VM which belongs to a tenant """
+        # 1. named tenant "tenant1" is created with default_datastore set to "VM_DS", test volume
+        # create with short name and full name.  With short name, volume is created in the default_datastore
+        # which is the vm_datastore. Also test volume remove/attach/detach/ls.
+        # 2. change the default_datastore to from "VM_DS" to a real datastore, and set the "volume_maxsize" and
+        # "usage_quota" to test volume create with different sizes
+        # 3. rename the "tenant1" to "new_tenant1", after that, test basic volume create/attach/detach/remove/ls
         logging.info("test_vmdkops_on_tenant_vm")
         vm1_uuid = vmdk_utils.get_vm_uuid_by_name(self.vm1_name)
         # add vm to tenant
@@ -963,11 +1019,27 @@ class VmdkTenantTestCase(unittest.TestCase):
         self.assertEqual(None, error_info)
 
         # run create command, which should succeed
-        # "default_datastore" is not specified for "tenant1"
+        # "default_datastore" is set to "_VM_DS" for "tenant1"
         # the volume will be created in the datastore where the vm lives in
         # vm lives in self.datastore_name
+        # the default volume size is 100MB
         opts={u'fstype': u'ext4'}
         error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.tenant1_vol1_name, opts)
+        self.assertEqual(None, error_info)
+
+        error_info, privileges = auth_api._tenant_access_ls(self.tenant1_name)
+        _, rows = vmdkops_admin.generate_tenant_access_ls_rows(privileges, self.tenant1_name)
+        print(rows)
+        # try to create the volume with full name at self.datastore_name
+        # should succeed even only have privilege to "_VM_DS", since
+        # the VM is created on self.datastore_name
+        full_vol_name = self.tenant1_vol2_name + "@" + self.datastore_name
+        opts={u'fstype': u'ext4'}
+        error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, full_vol_name, opts)
+        self.assertEqual(None, error_info)
+
+        # remove that volume with short name
+        error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_REMOVE, self.tenant1_vol2_name, opts)
         self.assertEqual(None, error_info)
 
         # list volumes
@@ -989,16 +1061,31 @@ class VmdkTenantTestCase(unittest.TestCase):
         error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_DETACH, self.tenant1_vol1_name, opts)
         self.assertEqual(None, error_info)
 
-        # set access privileges, create a volume with 100MB
+        # update access privileges to "_VM_DS"
+        # try to change the "usage_quota" which should fail
+        # since change "usage_quota" to "_VM_DS" and "_ALL_DS" is not allowed
         volume_maxsize_in_MB = convert.convert_to_MB("500MB")
         volume_totalsize_in_MB = convert.convert_to_MB("1GB")
+        error_info = auth_api._tenant_access_set(name=self.tenant1_name,
+                                                 datastore=auth_data_const.VM_DS,
+                                                 allow_create=True,
+                                                 volume_maxsize_in_MB=volume_maxsize_in_MB,
+                                                 volume_totalsize_in_MB=volume_totalsize_in_MB)
+        self.assertNotEqual(None, error_info)
 
-        # add access privilege for tenant1, after this, default_datastore will be set to
-        # self.datastore_name
-        error_info = auth_api._tenant_access_add(name=self.tenant1_name,
+        # change "default_datastore" for tenant1 to self.datastore_name
+        # a full access privilege to self.datastore will be created after this update
+        error_info = auth_api._tenant_update(name=self.tenant1_name,
+                                             default_datastore=self.datastore_name)
+        self.assertEqual(None, error_info)
+
+        # update the access privilege to self.datastore_name
+        # to set the "max_vol_size" and "usage_quota"
+        volume_maxsize_in_MB = convert.convert_to_MB("500MB")
+        volume_totalsize_in_MB = convert.convert_to_MB("1GB")
+        error_info = auth_api._tenant_access_set(name=self.tenant1_name,
                                                  datastore=self.datastore_name,
                                                  allow_create=True,
-                                                 default_datastore=False,
                                                  volume_maxsize_in_MB=volume_maxsize_in_MB,
                                                  volume_totalsize_in_MB=volume_totalsize_in_MB)
         self.assertEqual(None, error_info)
@@ -1006,13 +1093,14 @@ class VmdkTenantTestCase(unittest.TestCase):
         # create a volume with 600MB which exceed the volume_maxsize
         opts={u'size': u'600MB', u'fstype': u'ext4'}
         error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.tenant1_vol2_name, opts)
-        self.assertEqual({u'Error': 'volume size exceeds the max volume size limit'}, error_info)
+        self.assertEqual({u'Error': 'Volume size exceeds the max volume size limit'}, error_info)
 
+        # create a volume with 500MB
         opts={u'size': u'500MB', u'fstype': u'ext4'}
         error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.tenant1_vol2_name, opts)
         self.assertEqual(None, error_info)
 
-        # create a volume with 500MB, and total_storeage used by this tenant will exceed volume_totalsize
+        # create another volume with 500MB, and total_storeage used by this tenant will exceed volume_totalsize
         opts={u'size': u'500mb', u'fstype': u'ext4'}
         error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.tenant1_vol3_name, opts)
         self.assertEqual({u'Error': 'The total volume size exceeds the usage quota'}, error_info)
@@ -1050,10 +1138,13 @@ class VmdkTenantTestCase(unittest.TestCase):
 
         # listVMDK return vol name with the format like vol@datastore
         # "result"" should have two volumes :tenant1_vol2@default_datastore, and  tenant1_vol3@datastore
-        # these volumes are created at default_datastore, which is self.datastore_name
+        # now the "default_datastore" for tenant1 is set to "_VM_DS"
+        # by default, those volume will be created on the datastore where the VM lives
+        # VM lives in self.datastore_name
         self.assertEqual(2, len(result))
         volume_names = ["tenant1_vol2@" + self.datastore_name, "tenant1_vol3@" + self.datastore_name]
         self.assertTrue(checkIfVolumeExist(volume_names,result))
+
         # rename the tenant
         error_info = auth_api._tenant_update(name=self.tenant1_name,
                                              new_name=self.tenant1_new_name)
@@ -1064,7 +1155,6 @@ class VmdkTenantTestCase(unittest.TestCase):
         error_info = auth_api._tenant_access_set(name=self.tenant1_new_name,
                                                  datastore=self.datastore_name,
                                                  volume_totalsize_in_MB=volume_totalsize_in_MB)
-
         self.assertEqual(None, error_info)
 
         # test the vmdkops after rename
@@ -1100,6 +1190,10 @@ class VmdkTenantTestCase(unittest.TestCase):
 
     def test_vmdkops_on_different_tenants(self):
         """ Test vmdkops on VMs which belong to different tenant """
+        # 1. Two tenants are created with "default_datastore" set to "_VM_DS"
+        # 2. For each tenant, update the "default_datastore" to a real datastore (self.datastore), and try to update
+        # the privilege to this datastore, test volume with different sizes, run volume ls to make sure each tenant
+        # can only see the volumes belong to that tenant
         logging.info("test_vmdkops_on_different_tenants")
         # add vm1 to tenant1
         vm1_uuid = vmdk_utils.get_vm_uuid_by_name(self.vm1_name)
@@ -1108,15 +1202,29 @@ class VmdkTenantTestCase(unittest.TestCase):
                                          vm_list=[self.vm1_name])
         self.assertEqual(None, error_info)
 
-        # set access privileges, create a volume with 100MB
+        # After setup(), the "default_datastore" of tenant1 has been set to "_VM_DS"
+        # A full access privilege to datastore "_VM_DS" has been created for tenant1
+        # change "default_datastore" for tenant1 to self.datastore_name
+        # a full access privilege to self.datastore will be created after this update
+        error_info = auth_api._tenant_update(name=self.tenant1_name,
+                                             default_datastore=self.datastore_name)
+        self.assertEqual(None, error_info)
+
+        # update the access privilege to self.datastore_name
+        # to set the "max_vol_size" and "usage_quota"
         volume_maxsize_in_MB = convert.convert_to_MB("500MB")
         volume_totalsize_in_MB = convert.convert_to_MB("2GB")
-        error_info = auth_api._tenant_access_add(name=self.tenant1_name,
+        error_info = auth_api._tenant_access_set(name=self.tenant1_name,
                                                  datastore=self.datastore_name,
                                                  allow_create=True,
-                                                 default_datastore=False,
                                                  volume_maxsize_in_MB=volume_maxsize_in_MB,
                                                  volume_totalsize_in_MB=volume_totalsize_in_MB)
+        self.assertEqual(None, error_info)
+
+        error_info = auth_api._tenant_access_rm(name=self.tenant1_name,
+                                                datastore=auth_data_const.VM_DS)
+        self.assertEqual(None, error_info)
+
         # create a volume with default size
         opts={u'fstype': u'ext4'}
         error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.tenant1_vol1_name, opts)
@@ -1139,15 +1247,30 @@ class VmdkTenantTestCase(unittest.TestCase):
                                          vm_list=[self.vm2_name])
         self.assertEqual(None, error_info)
 
-        # set access privileges, create a volume with 100MB
+
+         # After setup(), the "default_datastore" of tenant1 has been set to "_VM_DS"
+        # A full access privilege to datastore "_VM_DS" has been created for tenant1
+        # change "default_datastore" for tenant1 to self.datastore_name
+        # a full access privilege to self.datastore will be created after this update
+        error_info = auth_api._tenant_update(name=self.tenant2_name,
+                                             default_datastore=self.datastore_name)
+        self.assertEqual(None, error_info)
+
+        # update the access privilege to self.datastore_name
+        # to set the "max_vol_size" and "usage_quota"
         volume_maxsize_in_MB = convert.convert_to_MB("500MB")
         volume_totalsize_in_MB = convert.convert_to_MB("2GB")
-        error_info = auth_api._tenant_access_add(name=self.tenant2_name,
+        error_info = auth_api._tenant_access_set(name=self.tenant2_name,
                                                  datastore=self.datastore_name,
                                                  allow_create=True,
-                                                 default_datastore=False,
                                                  volume_maxsize_in_MB=volume_maxsize_in_MB,
                                                  volume_totalsize_in_MB=volume_totalsize_in_MB)
+        self.assertEqual(None, error_info)
+
+        error_info = auth_api._tenant_access_rm(name=self.tenant2_name,
+                                                datastore=auth_data_const.VM_DS)
+        self.assertEqual(None, error_info)
+
         # create a volume with default size
         opts={u'fstype': u'ext4'}
         error_info = vmdk_ops.executeRequest(vm2_uuid, self.vm2_name, self.vm2_config_path, auth.CMD_CREATE, self.tenant2_vol1_name, opts)
@@ -1179,9 +1302,18 @@ class VmdkTenantTestCase(unittest.TestCase):
         volume_names = generate_volume_names("tenant2", self.datastore_name, 3)
         self.assertTrue(checkIfVolumeExist(volume_names,result))
 
+
     @unittest.skipIf(len(vmdk_utils.get_datastores()) < 2,
                      "second datastore is not found - skipping this test")
     def test_vmdkops_for_default_datastore(self):
+        # 1. Named tenant "tenant1" is created with "default_datastore" set to "VM_DS"
+        # 2. Test volume create with short name succeeds with "VM_DS"
+        # 3. Modify the privilege "VM_DS" to disallow create, then volume create with short name failed
+        # 4. set the "default_datastore" to a real datastore, make sure volume create succeeds and volume is
+        # created on the "default_datastore"
+        # 5. modify the "default_datastore" to a different real datastore, make sure volume create succeeds and
+        # volue is created on the new "default_datastore"
+
         """ Test vmdkops for default_datastore """
         logging.info("test_vmdkops_for_default_datastore")
         # add vm1 to tenant1, vm1 is created on self.datastore_name
@@ -1191,71 +1323,168 @@ class VmdkTenantTestCase(unittest.TestCase):
                                          vm_list=[self.vm1_name])
         self.assertEqual(None, error_info)
 
-        # set access privileges on self.datastore1, and default_datastore will be set to
-        # self.datastore1 for tenant1 since this is the first privilege added for tenant1
-        # access privilege on self.datastore is mount_only
-        volume_maxsize_in_MB = convert.convert_to_MB("500MB")
-        volume_totalsize_in_MB = convert.convert_to_MB("2GB")
-        error_info = auth_api._tenant_access_add(name=self.tenant1_name,
-                                                 datastore=self.datastore1_name,
-                                                 allow_create=False,
-                                                 default_datastore=False,
-                                                 volume_maxsize_in_MB=volume_maxsize_in_MB,
-                                                 volume_totalsize_in_MB=volume_totalsize_in_MB)
-
-        # set access privileges on self.datastore, with allow_create=True
-        # keep the default_datastore to self.datastore1 for tenant1
-        error_info = auth_api._tenant_access_add(name=self.tenant1_name,
-                                                 datastore=self.datastore_name,
-                                                 allow_create=True,
-                                                 default_datastore=False,
-                                                 volume_maxsize_in_MB=volume_maxsize_in_MB,
-                                                 volume_totalsize_in_MB=volume_totalsize_in_MB)
-
-        # create a volume with default size
-        # a volume will be tried to create on the default_datastore, which is self.datastore1_name
-        # create should fail since on default_datastore, it does not have "allow_create"" set to True
+        # After setup(), the "default_datastore" of tenant1 has been set to "_VM_DS"
+        # A full access privilege to datastore "_VM_DS" has been created for tenant1
+        # try to create a volume, which should succeed
+        # a volume will be tried to create on the default_datastore, which is "_VM_DS"
         opts =  {u'fstype': u'ext4'}
         error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.tenant1_vol1_name, opts)
+        self.assertEqual(None, error_info)
+
+        # Modify the access privilege to "_VM_DS" to disallow create
+        error_info = auth_api._tenant_access_set(name=self.tenant1_name,
+                                                 datastore=auth_data_const.VM_DS,
+                                                 allow_create=False)
+
+        self.assertEqual(None, error_info)
+        # create second volume with default size
+        # a volume will be tried to create on the default_datastore, which is "_VM_DS"
+        # create should fail since on default_datastore, since access privilege to "_VM_DS" does
+        # not have "allow_create"" set to True
+        opts =  {u'fstype': u'ext4'}
+        error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.tenant1_vol2_name, opts)
         self.assertNotEqual(None, error_info)
 
-        # try to create this volume on self.datastore, which has "allow_create" set to True
-        # since self.datastore is not the "default_datastore" for tenant1
-        # we should use full_vol_name like vol_name@datastore_name
-        full_name_vol1 = self.tenant1_vol1_name + "@" + self.datastore_name
-        opts={u'fstype': u'ext4'}
-        error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, full_name_vol1, opts)
-        self.assertEqual(None, error_info)
+        # delete the access privilege to "_VM_DS"
+        # which should fail since the "default_datastore" for tenant1 is still set to "_VM_DS"
+        error_info = auth_api._tenant_access_rm(name=self.tenant1_name,
+                                                datastore=auth_data_const.VM_DS)
+        self.assertNotEqual(None, error_info)
 
-        # switch "default_datastore" to self.datastore
-        error_info = auth_api._tenant_update(name=self.tenant1_name,
+        # update the "default_datastore" for tenant1 to self.datastore_name
+        # a full access privileg to self.datastore_name will be created
+        error_into = auth_api._tenant_update(name=self.tenant1_name,
                                              default_datastore=self.datastore_name)
-        self.assertEqual(None, error_info)
 
+        # try to create the volume again, which should succeed, since
+        # we create an access privilege to "self.datastore_name" which allowed to create
+        opts =  {u'fstype': u'ext4'}
         error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.tenant1_vol2_name, opts)
         self.assertEqual(None, error_info)
 
-        # list volumes
-        opts = {}
-        result = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, 'list', None, opts)
-
-        # there should be two volumes shown as "tenant1_vol1"" and "tenant1_vol2"
-        self.assertEqual(len(result), 2)
-        self.assertEqual("tenant1_vol1@"+self.datastore_name, result[0]['Name'])
-        self.assertEqual("tenant1_vol2@"+self.datastore_name, result[1]['Name'])
-
-        # switch "default_datastore" to self.datastore1
+        # change the "default_datastore" for tenant1 to "self.datastore1_name"
+        # it also create full access privilege to "self.datastore1_name"
+        # now the volume will be create on "self.datastore1_name"
         error_info = auth_api._tenant_update(name=self.tenant1_name,
                                              default_datastore=self.datastore1_name)
+        opts =  {u'fstype': u'ext4'}
+        error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.tenant1_vol3_name, opts)
         self.assertEqual(None, error_info)
 
         # list volumes
         opts = {}
         result = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, 'list', None, opts)
 
-        # there should be two volumes which are created at self.datastore_name
-        # since the "default_datastore" is set to self.datastore1_name
-        # list volumes will shown volumes with full_vol_name like volume_name@datastore
+        # there should be three volumes
+        # "tenant1_vol1"" and "tenant1_vol2" which are created on "self.datastore_name""
+        # "tenant1_vol3" which is created on "self.datastore1_name"
+        self.assertEqual(len(result), 3)
+        self.assertEqual("tenant1_vol1@"+self.datastore_name, result[0]['Name'])
+        self.assertEqual("tenant1_vol2@"+self.datastore_name, result[1]['Name'])
+        self.assertEqual("tenant1_vol3@"+self.datastore1_name, result[2]['Name'])
+
+
+    @unittest.skipIf(len(vmdk_utils.get_datastores()) < 2,
+                     "second datastore is not found - skipping this test")
+    def test_vmdkops_for_vm_ds(self):
+        # Only privilege to "_VM_DS" present, test volume create and ls
+        # Change the privilege to "_VM_DS" to disallow create, test volume create failed
+        # Change the privilege to "_VM_DS" to allow create, and set the "max_volsize", make
+        # sure can only create volume which size is smaller than "max_volsize", and test volume remove
+
+        logging.info("test_vmdkops_for_vm_ds")
+        # add vm1 to tenant1, vm1 is created on self.datastore_name
+        vm1_uuid =  vmdk_utils.get_vm_uuid_by_name(self.vm1_name)
+        error_info = auth_api._tenant_vm_add(
+                                         name=self.tenant1_name,
+                                         vm_list=[self.vm1_name])
+        self.assertEqual(None, error_info)
+
+        # add vm3 to tenant1, vm3 is created on self.datastore1_name
+        vm3_uuid =  vmdk_utils.get_vm_uuid_by_name(self.vm3_name)
+        error_info = auth_api._tenant_vm_add(
+                                         name=self.tenant1_name,
+                                         vm_list=[self.vm3_name])
+        #print error_info.msg
+        self.assertEqual(None, error_info)
+
+        # After setup(), the "default_datastore" of tenant1 has been set to "_VM_DS"
+        # A full access privilege to datastore "_VM_DS" has been created for tenant1
+        # try to create a volume from vm1, which should succeed
+        # a volume will be tried to create on the default_datastore, which is "_VM_DS"(self.datastore_name)
+        opts =  {u'fstype': u'ext4'}
+        error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.tenant1_vol1_name, opts)
+        self.assertEqual(None, error_info)
+
+        # try to create a volume from vm3, which should succeed
+        # a volume will be tried to create on the default_datastore, which is "_VM_DS"(self.datastore1_name)
+        opts =  {u'fstype': u'ext4'}
+        error_info = vmdk_ops.executeRequest(vm3_uuid, self.vm3_name, self.vm3_config_path, auth.CMD_CREATE, self.tenant1_vol2_name, opts)
+        self.assertEqual(None, error_info)
+
+        # list volumes
+        opts = {}
+        result = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, 'list', None, opts)
+
+        # there should be three volumes
+        # "tenant1_vol1" will be created on "self.datastore_name"
+        # "tenant1_vol2" which is created on "self.datastore1_name"
+        self.assertEqual(len(result), 2)
+        self.assertEqual("tenant1_vol1@"+self.datastore_name, result[0]['Name'])
+        self.assertEqual("tenant1_vol2@"+self.datastore1_name, result[1]['Name'])
+
+        # Remove those two volumes
+        error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_REMOVE, self.tenant1_vol1_name, opts)
+        self.assertEqual(None, error_info)
+
+        error_info = vmdk_ops.executeRequest(vm3_uuid, self.vm3_name, self.vm3_config_path, auth.CMD_REMOVE, self.tenant1_vol2_name, opts)
+        self.assertEqual(None, error_info)
+
+        # Modify the privilege to "_VM_DS" to disallow create
+        error_info = auth_api._tenant_access_set(name=self.tenant1_name,
+                                                 datastore=auth_data_const.VM_DS,
+                                                 allow_create=False)
+        self.assertEqual(None, error_info)
+
+        # try to create volume, which should fail
+        # since privilege to "_VM_DS" does not allow_create
+        error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.tenant1_vol1_name, opts)
+        self.assertNotEqual(None, error_info)
+
+        # Modify the privilege to "_VM_DS" to allow create and set
+        # the vol_maxsize
+        volume_maxsize_in_MB = convert.convert_to_MB("500MB")
+        error_info = auth_api._tenant_access_set(name=self.tenant1_name,
+                                                 datastore=auth_data_const.VM_DS,
+                                                 allow_create=True,
+                                                 volume_maxsize_in_MB=volume_maxsize_in_MB)
+        self.assertEqual(None, error_info)
+
+        # Try to create the volume with size 600MB, which should fail
+        opts={u'size': u'600MB', u'fstype': u'ext4'}
+        error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.tenant1_vol1_name, opts)
+        self.assertNotEqual(None, error_info)
+
+        # Try to create the volume with size 500MB, which should succeed
+        opts={u'size': u'500MB', u'fstype': u'ext4'}
+        error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, self.tenant1_vol1_name, opts)
+        self.assertEqual(None, error_info)
+
+        # Try to create a volume at self.datastore_name which also the vm_datastore
+        # Even if we don't have any privilege to "self.datastore_name"
+        # create should succeed since we have privilege to "_VM_DS"
+        full_vol_name = self.tenant1_vol2_name + "@" + self.datastore_name
+        opts={u'fstype': u'ext4'}
+        error_info = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, auth.CMD_CREATE, full_vol_name, opts)
+        self.assertEqual(None, error_info)
+
+        # list volumes
+        opts = {}
+        result = vmdk_ops.executeRequest(vm1_uuid, self.vm1_name, self.vm1_config_path, 'list', None, opts)
+
+        # there should be three volumes
+        # "tenant1_vol1" will be created on "self.datastore_name"
+        # "tenant1_vol2" which is created on "self.datastore_name"
         self.assertEqual(len(result), 2)
         self.assertEqual("tenant1_vol1@"+self.datastore_name, result[0]['Name'])
         self.assertEqual("tenant1_vol2@"+self.datastore_name, result[1]['Name'])
@@ -1284,27 +1513,40 @@ class VmdkTenantPolicyUsageTestCase(unittest.TestCase):
         if not tenant_uuid:
             logging.debug("create_default_tenant_and_privileges: create DEFAULT tenant")
             error_info, tenant = auth_api._tenant_create(
-                                           name=auth_data_const.DEFAULT_TENANT,
-                                           description=auth_data_const.DEFAULT_TENANT_DESCR,
-                                           vm_list=[],
-                                           privileges=[])
-        if error_info:
-            err = error_code.TENANT_CREATE_FAILED.format(auth.DEFAULT_TENANT, error_info)
-            logging.warning(err)
+                                            name=auth_data_const.DEFAULT_TENANT,
+                                            default_datastore=auth_data_const.VM_DS,
+                                            description=auth_data_const.DEFAULT_TENANT_DESCR,
+                                            vm_list=[],
+                                            privileges=[])
 
-        # create DEFAULT privilege if needed
-        error_info, privileges = auth.get_default_privileges()
-        if not privileges:
-            logging.debug("create_default_tenant_and_privileges: create DEFAULT privileges")
+            if error_info:
+                logging.warning(error_info.msg)
+            self.assertEqual(error_info, None)
+
+        error_info, existing_privileges = auth_api._tenant_access_ls(auth_data_const.DEFAULT_TENANT)
+        self.assertEqual(error_info, None)
+
+        # create access privilege to datastore "_ALL_DS" for _DEFAULT tenant if needed
+        if not auth_api.privilege_exist(existing_privileges, auth_data_const.ALL_DS_URL):
             error_info = auth_api._tenant_access_add(name=auth_data_const.DEFAULT_TENANT,
-                                                    datastore=auth_data_const.DEFAULT_DS_URL,
+                                                    datastore=auth_data_const.ALL_DS,
                                                     allow_create=True,
-                                                    default_datastore=False,
                                                     volume_maxsize_in_MB=0,
                                                     volume_totalsize_in_MB=0)
             if error_info:
-                err = error_code.TENANT_SET_ACCESS_PRIVILEGES_FAILED.format(auth_data_const.DEFAULT_TENANT, auth_data_const.DEFAULT_DS, error_info)
-                logging.warning(err)
+                logging.warning(error_info.msg)
+            self.assertEqual(error_info, None)
+
+        # create access privilege to datastore "_VM_DS" for _DEFAULT tenant if needed
+        if not auth_api.privilege_exist(existing_privileges, auth_data_const.VM_DS_URL):
+            error_info = auth_api._tenant_access_add(name=auth_data_const.DEFAULT_TENANT,
+                                                    datastore=auth_data_const.VM_DS,
+                                                    allow_create=True,
+                                                    volume_maxsize_in_MB=0,
+                                                    volume_totalsize_in_MB=0)
+            if error_info:
+                logging.warning(error_info.msg)
+            self.assertEqual(error_info, None)
 
     @unittest.skipIf(not vsan_info.get_vsan_datastore(),
                      "VSAN is not found - skipping policy usage tests")
@@ -1332,7 +1574,7 @@ class VmdkTenantPolicyUsageTestCase(unittest.TestCase):
         self.vm1_config_path = vmdk_utils.get_vm_config_path(self.vm1_name)
         logging.info("VmdkTenantPolicyUsageTestCase: create vm1 name=%s Done", self.vm1_name)
 
-        # create DEFAULT tenant DEFAULT privilege if missing
+        # create DEFAULT tenant and privilege if missing
         self.create_default_tenant_and_privileges()
 
     def tearDown(self):


### PR DESCRIPTION
This PR includes the most fix needed for #1143. For the detailed design, please refer to that issue.
**With this PR:**
1. _DEFAULT tenant will be created with two privileges (```__ALL_DS``` and ```__VM_DS```) after install.
2. "--default-datastore" is a required field for "vmgroup create" command
3. user can modify "default_datastore" through "vmgroup update" command
4. when "default_datastore" is set or modified, our code will try to create a privilege to the "default_datastore" with full access privilege if it does not exist
5. user cannot set "default_datastore" to ```__ALL_DS```, an error will be generated.
6. user cannot remove a privilege if the datastore in that privilege is the "default_datastore". An error will be generated.
7. change the vmdkops_test.py and vmdkops_admin_test.py accordingly

**Not covered in this PR,but needed to fix issue #1143 completely:**
1. upgrade related code: Without this fix, _DEFAULT tenant is created with ```default_privilege``` after install, we don't have the ```default_privilege``` any more, need to replace with two privileges ```__VM_DS``` and ```ALL_DS```
2. upgrade related code:  for any vmgroup, if the "default_datastore" is set, need to create a full access privilege to that datastore if it does not exist; and need to set the "default_datastore" to ```__VM_DS``` if it does not set since with the fix in this PR,  any "vmgroup" need set "default_datastore" field
3. The upgrade code is dependent on Shahzeb's PR, I plan to work on it after his PR is merged
4. Change the AdminCLI document accordingly


**Test Summary**

The following automated test has been modified or added for the new behavior of default_datastore handling introduced in this PR.

**vmdkops_test**

- test for default vmgroup
 1. DEFAULT vmgroup, privilege to datastore "__ALL_DS", and privilege to datastore "__VM_DS""
     are present post install, issue vmdk_ops from VM which is not owned by any vmgroup vmdk_ops 
     should succeed, and the volume create with short name will be created in the vm_datastore 
     where VM lives
  2. change the default_datastore for DEFAULT vmgroup to a real datastore,  volume create with short name should be created in the default datastore instead of VM datastore
  3. Remove privilege to "__ALL_DS" and let only privilege to  "__VM_DS" present, "create volume" with short name should succeed; while try to create a volume with full name like volume@datastore, and datastore is not the vm_datastore, the creation should fail
  4.  Remove privilege to "__VM_DS" and now no privilege available for _DEFAULT vmgroup, "create volume" should fail
  5. REMOVE DEFAULT vmgroup, "create volume" should fail

- test for named vmgroup
1. named vmgroup "tenant1" is created with default_datastore set to "VM_DS", test volume
create with short name and full name.  With short name, volume is created in the default_datastore which is the vm_datastore. Also test volume remove/attach/detach/ls.
 2. change the default_datastore to from "VM_DS" to a real datastore, and set the "volume_maxsize" an "usage_quota" to test volume create with different sizes to make sure
volume create can only succeed with the "volume_maxsize" and "usage_quota" limit.
 3. rename the "tenant11" to "new_tenant1", after that, test basic volume create/attach/detach/remove/ls

- test for vmdkops on two different vmgroups
1. Two vmgroups are created with "default_datastore" set to "__VM_DS"
2. For each vmgroup, update the "default_datastore" to a real datastore (self.datastore), and try to update the privilege to this datastore, test volume create with different sizes . Run volume ls to make sure each vmgroup can only see the volumes belong to that vmgroup

- test for default_datastore
1. Named vmgroup "tenant1" is created with "default_datastore" set to "VM_DS"
2. Test volume create with short name succeeds and the volume is created in the vm_datastore
3. Modify the privilege "VM_DS" to disallow create, then volume create with short name failed
4. set the "default_datastore" to a real datastore, make sure volume create succeeds and volume is created on the "default_datastore"
 5. modify the "default_datastore" to a different real datastore, make sure volume create succeeds and volume is created on the new "default_datastore"

**AminCLI test for "vmgroup" management**

- vmgroup create
1. “vmgroup create” without  “—default-datastore” failed
2. “vmgroup create” with –default-datastore=datastore1 succeed
3. “vmgroup create” with –default-datastore=__VM_DS succeed
4. “vmgroup create” with –default-datastore=__ALL_DS failed
5. “vmgroup create” with –default-datastore=invalid_datastore_name failed
 
 

- vmgroup update
1. “vmgroup update” with --default-datastore=valid_datastore_name succeeds
2. “vmgroup update” with –default-datastore=__ALL_DS failed
 

- vmgroup access add
1. add  “usage_quota” for privilege to “__ALL_DS” and “__VM_DS” is not allowed
 

- vmgroup access set
1. change  “usage_quota” for privilege to “__ALL_DS” and “__VM_DS” is not allowed
 
 

- vmgroup access rm
1. Remove privilege to “default_datastore” failed