### PR TITLE
First shot at shared in-memory DB cache (PREVIEW) 

### DIFF
--- a/esx_service/Makefile
+++ b/esx_service/Makefile
@@ -198,7 +198,7 @@ TEST_PATTERN ?= '*'
 test-esx:
 	@echo "Copying files to $(ESX):$(TMP_LOC) and running .py unittests ..."
 	$(SSH) root@$(ESX) 'mkdir -p $(TMP_LOC)'
-	$(SCP) $(TEST_FILES) $(TO_ESX_BIN) $(TO_ESX_PY) root@$(ESX):$(TMP_LOC)
+	$(SCP) $(TEST_FILES) $(TO_ESX_BIN) $(TO_ESX_PY) $(PY_SQLITE) $(SO_SQLITE) root@$(ESX):$(TMP_LOC)
 	$(SSH) root@$(ESX) \
 		'for i in $(TMP_LOC)/$(TEST_PATTERN)_test.py ; \
 				do echo Running unit tests in $$i... ; python $$i ; \

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -23,6 +23,7 @@ import signal
 import os.path
 import shutil
 import time
+import logging
 
 import vmdk_ops
 # vmdkops python utils are in PY_LOC, so add to path.
@@ -50,6 +51,7 @@ VOL_ALLOC = 'allocated'
 
 def main():
     log_config.configure()
+    logging.info("==== Running vmdkops_admin pid=%d ====", os.getpid())
     kv.init()
     if not vmdk_ops.is_service_available():
        sys.exit('Unable to connect to the host-agent on this host, ensure the ESXi host agent is running before retrying.')

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -23,7 +23,6 @@ import signal
 import os.path
 import shutil
 import time
-import logging
 
 import vmdk_ops
 # vmdkops python utils are in PY_LOC, so add to path.
@@ -51,7 +50,6 @@ VOL_ALLOC = 'allocated'
 
 def main():
     log_config.configure()
-    logging.info("==== Running vmdkops_admin pid=%d ====", os.getpid())
     kv.init()
     if not vmdk_ops.is_service_available():
        sys.exit('Unable to connect to the host-agent on this host, ensure the ESXi host agent is running before retrying.')

--- a/esx_service/utils/auth.py
+++ b/esx_service/utils/auth.py
@@ -202,7 +202,7 @@ def get_privileges(tenant_uuid, datastore_url):
     # TBD return _auth_mgr.get_defaut_privileges_dict() when both params matchm otherwise return std err
 
     privileges = []
-    logging.debug("get_privileges tenant_uuid=%s datastore_url=%s", tenant_uuid, datastore_url)
+    #logging.debug("get_privileges tenant_uuid=%s datastore_url=%s", tenant_uuid, datastore_url)
     try:
         cur = _auth_mgr.conn.execute(
             "SELECT * FROM privileges WHERE tenant_id = ? and datastore_url = ?",
@@ -415,12 +415,8 @@ def authorize(vm_uuid, datastore_url, cmd, opts):
         None
         - tenant_name: If the VM belongs to a tenant, return tenant_name, otherwise, return
         None
-
     """
-    logging.debug("Authorize: vm_uuid=%s", vm_uuid)
-    logging.debug("Authorize: datastore_url=%s", datastore_url)
-    logging.debug("Authorize: cmd=%s", cmd)
-    logging.debug("Authorize: opt=%s", opts)
+    logging.debug("Authorize: cmd=%s opts=`%s' vm_uuid=%s, datastore_url=%s", cmd, opts, vm_uuid, datastore_url)
 
     error_msg, _auth_mgr = get_auth_mgr()
     if error_msg:
@@ -452,13 +448,13 @@ def authorize(vm_uuid, datastore_url, cmd, opts):
         error_msg, privileges = get_privileges(tenant_uuid, datastore_url)
         if error_msg:
             return error_msg, None, None
-        logging.debug("authorize: tenant_uuid=%s, datastore_url=%s, privileges=%s",
-                       tenant_uuid, datastore_url, privileges)
         result = check_privileges_for_command(cmd, opts, tenant_uuid, datastore_url, privileges)
+        logging.debug("authorize: vmgroup_name=%s, datastore_url=%s, privileges=%s, result %s",
+                      tenant_name, datastore_url, privileges, result)
 
-        if not result:
-            logging.info("cmd %s with opts %s on tenant_uuid %s datastore_url %s is allowed to execute",
-                         cmd, opts, tenant_uuid, datastore_url)
+        if result is None:
+            logging.info("cmd=%s opts=%s vmgroup=%s datastore_url=%s is allowed to execute",
+                         cmd, opts, tenant_name, datastore_url)
 
         return result, tenant_uuid, tenant_name
 

--- a/esx_service/utils/auth.py
+++ b/esx_service/utils/auth.py
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Module to provide APIs for authorization checking for VMDK ops.
+""" Module to provide APIs for authorization checking for VMDK ops."""
 
-"""
+
 import logging
-import auth_data
 import sqlite3
 import convert
-import auth_data_const
-import volume_kv as kv
 import threadutils
 import log_config
+import auth_data
+import auth_data_const
 import error_code
 import vmdk_utils
+import volume_kv as kv
 
 # All supported vmdk commands that need authorization checking
 CMD_CREATE = 'create'
@@ -35,18 +35,18 @@ CMD_DETACH = 'detach'
 SIZE = 'size'
 
 # thread local storage in this module namespace
-thread_local = threadutils.get_local_storage()
+_thread_local = threadutils.get_local_storage()
 
 def get_auth_mgr():
     """ Get a connection to auth DB. """
-    global thread_local
-    if not hasattr(thread_local, '_auth_mgr'):
+
+    if not hasattr(_thread_local, '_auth_mgr'):
         try:
-            thread_local._auth_mgr = auth_data.AuthorizationDataManager()
-            thread_local._auth_mgr.connect()
+            _thread_local._auth_mgr = auth_data.AuthorizationDataManager()
+            _thread_local._auth_mgr.connect()
         except (auth_data.DbConnectionError, auth_data.DbAccessError) as err:
             return str(err), None
-    return None, thread_local._auth_mgr
+    return None, _thread_local._auth_mgr
 
 def get_default_tenant():
     """

--- a/esx_service/utils/auth_api.py
+++ b/esx_service/utils/auth_api.py
@@ -1006,3 +1006,11 @@ def _tenant_access_ls(name):
         return error_info, None
 
     return None, tenant.privileges
+
+
+def db_cache_enable():
+    """
+    API wrapper to enable in-memory cache of on-disk auth. DB when
+    used in ReadOnly mode
+    """
+    auth_data.AuthorizationDataManager.cache_enable()

--- a/esx_service/utils/auth_data.py
+++ b/esx_service/utils/auth_data.py
@@ -1129,9 +1129,6 @@ class AuthorizationDataManager(object):
                 description = r[auth_data_const.COL_DESCRIPTION]
                 default_datastore_url = r[auth_data_const.COL_DEFAULT_DATASTORE_URL]
 
-                logging.debug("id=%s name=%s description=%s default_datastore_url=%s",
-                              id, name, description, default_datastore_url)
-
                 # search vms for this tenant
                 vms = []
                 cur = self.conn.execute(

--- a/esx_service/utils/auth_data.py
+++ b/esx_service/utils/auth_data.py
@@ -582,7 +582,7 @@ class DBCacheManager(object):
 
         # Schedule the next refresh
         self._timer = threading.Timer(frequency_sec,
-                                      self._memdb_refresh_periodically, frequency_sec)
+                                      self._memdb_refresh_periodically, [self, frequency_sec])
         self._timer.start()
 
     def manager_register(self):

--- a/esx_service/utils/auth_data.py
+++ b/esx_service/utils/auth_data.py
@@ -421,16 +421,15 @@ class DockerVolumeTenant:
         return None
 
 class DBCacheManager(object):
-    """Support for thread--shared in-memory RO cache."""
+    """
+    Support for thread--shared in-memory RO cache.
 
-    """TBD change to factory:
-    - factory keeps a connectoin to in-mem DB to prevent it from cleaning up static)
-    -  on first enable, check we are not enabled, populate the DB
+    - uses sqlite3 in -memory shared DB. One connection per thread is expected.
+    - keeps a connetion to in-mem DB to prevent it from cleaning up static cache
+    - on first enable, check we are not enabled, populate the DB
     - gets NEW connection when asked: conn = cache.new_connection()
-    - the rest is the same.
-    - Row can be set on each conenctoin, not cache
-    - on refresh, drain in flight, drop global connection (that will deleted the DB) and recreate cache
-
+    - on refresh, drains in flight Auth managers using the hshared cache,
+       drop  connection (that will deleted the DB when sqlite refcount drops to 0) and recreate cache
     """
 
     # this is in-memory shared DB URL
@@ -567,7 +566,6 @@ class DBCacheManager(object):
             self.__class__._make_connection_readonly(memdb_con)
             self._memdb_con = memdb_con
 
-        # TODO - read sqlite again on sharing connectionb between threads
         # TODO - check we call commit before close() for main DB in ADmin CLI
         return None
 

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -765,7 +765,7 @@ def get_full_vol_name(vmdk_name, datastore):
     Forms full volume name from vmdk file name an datastore as volume@datastore
     """
     vol_name = vmdk_utils.strip_vmdk_extension(vmdk_name)
-    logging.debug("get_full_vol_name: %s %s", vmdk_name, datastore)
+    #logging.debug("get_full_vol_name: %s %s", vmdk_name, datastore)
     return "{0}@{1}".format(vol_name, datastore)
 
 def datastore_path_exist(datastore_name):

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -82,7 +82,6 @@ import vmdk_utils
 import vsan_policy
 import vsan_info
 import auth
-import sqlite3
 import convert
 import error_code
 import auth_data_const
@@ -1625,9 +1624,9 @@ def main():
     try:
         # Load and use DLL with vsocket shim to listen for docker requests
         load_vmci()
-
         kv.init()
         connectLocalSi()
+        auth_api.db_cache_enable()
         handleVmciRequests(port)
     except Exception as e:
         logging.exception(e)

--- a/vmdk_plugin/Makefile
+++ b/vmdk_plugin/Makefile
@@ -348,7 +348,7 @@ e2e-dkrVolDriver-test:
 
 .PHONY:clean-vm clean-esx clean-all clean-docker
 clean-vm:
-	$(CLEANVM_SH) "$(VMS)" "$(TEST_VOL_NAME)"
+	-$(CLEANVM_SH) "$(VMS)" "$(TEST_VOL_NAME)"
 
 clean-esx:
 	$(CLEANESX_SH) "$(ESX)" esx-vmdkops-service


### PR DESCRIPTION
### Status
This is not ready for merge (more testing needed) but I'd love to get first feedback. 

### Request 
Can you take a look  ?  

The key changes are in the new DBCacheManager and some new methods in AuthDataManager
Also, test suggestions are welcomed.

@pdhamdhere @andrewjstone - I am wondering if it's clear enough,.and if there are some obvious races and suspicious code pieces.

Do not not pay attention to individual commits (it will be fixed), just the total diff.
The diff also picks up a couple of formatting changes and log clan up changes (sorry). 

### Issue 

multiple ESX hosts lock the db file (VMFS lock), We currently fail but will need to retry - but in any kind of multi-node load the retries are bound to create lots of delays for user commands , since each delay is easily 2-3 secs and they all accumulate in MultiNode since the same DB is accessed. 
  
### Solution

vmdk_ops really need readonly access to DB, so if we can grab the DB and cache it in-memory for 10-15 min, we will guarantee smooth sailing for this period, and even on refreshes we will have very low probability of file being locked, since only refresh will lock and regular requests do not.

This PR introduces shared in-memory config DB cache. Each 15 min (default, can be change via env variable) the code will grab the current state of the config DB and safe in in read-only in-memory sqliteDB.

All connection requests from this point will be provided with a connection to the cache. When it's time to refresh the DB content from on-disk DB, the code will block new requests, wait until all requests using the current cache complete, refresh the cache and allow new requests. 

On the bad side, when refresh is happening we need to wait until all "in-flight" requests to complete, so requests coming in at this moment may have a shot hiccup

## TBD
add retry of connect() to real DB fails .
Potential improvement (not done) : do stat() on the file and skip the refresh if it's not changed

### Test
test: only basic 'make test-esx' and some interactive playing with different configurations. 
 