### PR TITLE
DB upgrade fix for changes to handle default_datastore.

### DIFF
--- a/esx_service/utils/auth_data.py
+++ b/esx_service/utils/auth_data.py
@@ -579,16 +579,8 @@ class AuthorizationDataManager:
             cur = self.conn.execute("SELECT * FROM tenants")
             result = cur.fetchall()
 
-            # go through tenants table, insert full access privilege to "default_datastore" for each tenant if not present
-            # for r in result:
-            #     id = r['id']
-            #     ds_url = r['default_datastore_url']
-            #     privilege = (id, ds_url, 1, 0, 0)
-            #     self.conn.execute("INSERT OR IGNORE INTO privileges(tenant_id, datastore_url, allow_create, max_volume_size, usage_quota) VALUES (?, ?, ?, ?, ?)",
-            #                       privilege)
-
             self.conn.execute("INSERT OR IGNORE INTO privileges(tenant_id, datastore_url, allow_create, max_volume_size, usage_quota)"
-                                 "SELECT tenant.id, tenant.default_datastore_url, 1, 0, 0 FROM tenants")
+                                 "SELECT tenants.id, tenants.default_datastore_url, 1, 0, 0 FROM tenants")
             logging.debug("handle_upgrade_1_1_to_1_2: Insert privilege to default_datastore in privileges table")
 
             cur = self.conn.execute("SELECT * FROM tenants WHERE id = ?",

--- a/esx_service/utils/auth_data.py
+++ b/esx_service/utils/auth_data.py
@@ -556,7 +556,7 @@ class AuthorizationDataManager:
         to "__VM_DS" and "__ALL_DS" need to be inserted
         """
         try:
-            logging.debug("handle_upgrade_1_1_to_1_2: Start")
+            logging.info("handle_upgrade_1_1_to_1_2: Start")
             self.conn.create_function('name_from_uuid', 1, vmdk_utils.get_vm_name_by_uuid)
             # Alter vms table to add a new column name vm_name to store vm name
             # update all the existing records with the vm_name.
@@ -569,19 +569,20 @@ class AuthorizationDataManager:
             sql_script = script.format(DB_MAJOR_VER, DB_MINOR_VER)
             self.conn.executescript(sql_script)
 
-            logging.debug("handle_upgrade_1_1_to_1_2: update vms table Done")
+            logging.info("handle_upgrade_1_1_to_1_2: update vms table Done")
 
             # update the tenants table to set "default_datastore" to "__VM_DS" if "default_datastore" is ""
             self.conn.execute("UPDATE OR IGNORE tenants SET default_datastore_url = ?  where default_datastore_url = \"\"",
                               (auth_data_const.VM_DS_URL,))
-            logging.debug("handle_upgrade_1_1_to_1_2: update default_datastore in tenants table")
+            logging.info("handle_upgrade_1_1_to_1_2: update default_datastore in tenants table")
 
             cur = self.conn.execute("SELECT * FROM tenants")
             result = cur.fetchall()
 
-            self.conn.execute("INSERT OR IGNORE INTO privileges(tenant_id, datastore_url, allow_create, max_volume_size, usage_quota)"
-                                 "SELECT tenants.id, tenants.default_datastore_url, 1, 0, 0 FROM tenants")
-            logging.debug("handle_upgrade_1_1_to_1_2: Insert privilege to default_datastore in privileges table")
+            self.conn.execute("""INSERT OR IGNORE INTO privileges(tenant_id, datastore_url, allow_create, max_volume_size, usage_quota)
+                                     SELECT tenants.id, tenants.default_datastore_url, 1, 0, 0 FROM tenants
+                              """)
+            logging.info("handle_upgrade_1_1_to_1_2: Insert privilege to default_datastore in privileges table")
 
             cur = self.conn.execute("SELECT * FROM tenants WHERE id = ?",
                                     (auth_data_const.DEFAULT_TENANT_UUID,)
@@ -595,11 +596,11 @@ class AuthorizationDataManager:
                 all_ds_privilege = (auth_data_const.DEFAULT_TENANT_UUID, auth_data_const.ALL_DS_URL, 1, 0, 0)
                 self.conn.execute("INSERT INTO privileges(tenant_id, datastore_url, allow_create, max_volume_size, usage_quota) VALUES (?, ?, ?, ?, ?)",
                                   all_ds_privilege)
-                logging.debug("handle_upgrade_1_1_to_1_2: Insert privilege to __ALL_DS for _DEFAULT tenant in privileges table")
+                logging.info("handle_upgrade_1_1_to_1_2: Insert privilege to __ALL_DS for _DEFAULT tenant in privileges table")
                 # remove access privilege to "DEFAULT_DS"
                 self.conn.execute("DELETE FROM privileges WHERE tenant_id = ? AND datastore_url = ?",
                                 [auth_data_const.DEFAULT_TENANT_UUID, auth_data_const.DEFAULT_DS_URL])
-                logging.debug("handle_upgrade_1_1_to_1_2: Remove privilege to _DEFAULT_DS for _DEFAULT tenant in privileges table")
+                logging.info("handle_upgrade_1_1_to_1_2: Remove privilege to _DEFAULT_DS for _DEFAULT tenant in privileges table")
             self.conn.commit()
             return None
         except sqlite3.Error as e:

--- a/esx_service/utils/auth_data_const.py
+++ b/esx_service/utils/auth_data_const.py
@@ -42,6 +42,7 @@ DEFAULT_TENANT_DESCR = "This is a default vmgroup"
 DEFAULT_DS  = '_DEFAULT'
 DEFAULT_DS_URL = DEFAULT_DS + "_URL"
 ORPHAN_TENANT = "_ORPHAN"
+
 VM_DS = '_VM_DS'
 VM_DS_URL = VM_DS + "://"
 ALL_DS = '_ALL_DS'

--- a/esx_service/utils/log_config.py
+++ b/esx_service/utils/log_config.py
@@ -30,7 +30,7 @@ import os.path
 # since we rely on it to locate log file name after config is loaded.
 LOG_CONFIG_FILE = "/etc/vmware/vmdkops/log_config.json"
 
-LOG_LEVEL_DEFAULT = 'INFO'
+LOG_LEVEL_DEFAULT = 'DEBUG'
 
 # Defaults for log files - used to generate conf file if it is missing
 # Note: log file location should be synced with CI and 'make'

--- a/esx_service/utils/log_config.py
+++ b/esx_service/utils/log_config.py
@@ -30,7 +30,7 @@ import os.path
 # since we rely on it to locate log file name after config is loaded.
 LOG_CONFIG_FILE = "/etc/vmware/vmdkops/log_config.json"
 
-LOG_LEVEL_DEFAULT = 'DEBUG'
+LOG_LEVEL_DEFAULT = 'INFO'
 
 # Defaults for log files - used to generate conf file if it is missing
 # Note: log file location should be synced with CI and 'make'


### PR DESCRIPTION
PR #1155 introduced the change to  handle default_datastore.  With that change, it requires:
1. each tenant in tenants table must have "default_datastore" field set
2. For each tenant in tenants table, it must has a privilege to "default_datastore"
3. For "_DEFAULT" tenant,  remove privilege to "_DEFAULT_DS" and insert privilege to "__VM_DS" and "__ALL_DS".

This change is to upgrade the DB to meet the above requirement when upgrading DB from old version (1.1) to new version(1.2). 

**Testing:**

**1. "DEFAULT" vmgroup present**

**_Configuration:_**
"_DEFAULT" vmgroup has a privilege to "_DEFAULT_DS"
"vmgroup1" has "default_datastore" set, also has privilege to the "default_datastore"
"vmgroup2" has no "default_datastore" field set

```
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
Uuid                                  Name      Description                Default_datastore  VM_list 
------------------------------------  --------  -------------------------  -----------------  ------- 
11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  
 
root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=vmgroup1 --vm-list=photon-VM1.1
vmgroup 'vmgroup1' is created.  Do not forget to run 'vmgroup vm add' and 'vmgroup access add' commands to enable access control.
 
root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=sharedVmfs-1 --allow-create --volume-maxsize=500MB --volume-totalsize
=1GB
vmgroup access add succeeded
[root@sc2-rdops-vm01-dhcp-52-142:~]
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=_DEFAULT
Datastore  Allow_create  Max_volume_size  Total_size 
---------  ------------  ---------------  ---------- 
           True          Unset            Unset      
 
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
Datastore     Allow_create  Max_volume_size  Total_size 
------------  ------------  ---------------  ---------- 
sharedVmfs-1  True          500.00MB         1.00GB     


root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=vmgroup2 
vmgroup 'vmgroup2' is created.  Do not forget to run 'vmgroup vm add' and 'vmgroup access add' commands to enable access control.
```

_**After upgrade**_: 
For tenant "_DEFAULT", "default_datastore" is set to "_VM_DS", full access privileges to "_VM_DS" and "_ALL_DS" have been created; while access privilege to "_DEFAULT_DS" has been removed

For tenant "vmgroup1", "default_datastore" remains unchanged (```sharedVmfs-1```) and the access privilege to that datastore remains unchanged

For tenant "vmgroup2", "default_datastore" is set to "_VM_DS", and a full  access privilege to "_VM_DS" has been added
```
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
Uuid                                  Name      Description                Default_datastore  VM_list      
------------------------------------  --------  -------------------------  -----------------  ------------ 
11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS                          
8b6a72f8-ef22-4f8c-9dc0-03c442808823  vmgroup1                             sharedVmfs-1       photon-VM1.1 
08646fd0-cbbb-4177-8031-8da38433b321  vmgroup2                             _VM_DS                          
 
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=_DEFAULT
Datastore  Allow_create  Max_volume_size  Total_size 
---------  ------------  ---------------  ---------- 
_ALL_DS    True          Unset            Unset      
_VM_DS     True          Unset            Unset      
 
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
Datastore     Allow_create  Max_volume_size  Total_size 
------------  ------------  ---------------  ---------- 
sharedVmfs-1  True          500.00MB         1.00GB     
 
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup2
Datastore  Allow_create  Max_volume_size  Total_size 
---------  ------------  ---------------  ---------- 
_VM_DS     True          Unset            Unset      
```

**2. "DEFAULT" vmgroup does not present**

**_Configuration:_**
"vmgroup1" has "default_datastore" set, also has privilege to the "default_datastore"
"vmgroup2" has no "default_datastore" field set

```
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
Uuid                                  Name      Description                Default_datastore  VM_list      
------------------------------------  --------  -------------------------  -----------------  ------------ 
11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup                                  
1dccf853-61c3-4245-a07b-180f9d4df832  vmgroup1                             sharedVmfs-1       photon-VM1.1 
bde7a773-17f3-47c0-9fae-23431fb4bc28  vmgroup2   

[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup rm --name=_DEFAULT --remove-volumes
All Volumes will be removed
vmgroup rm succeeded

[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
Datastore     Allow_create  Max_volume_size  Total_size 
------------  ------------  ---------------  ---------- 
sharedVmfs-1  True          500.00MB         1.00GB                                                                
```

**_After upgrade:_** 
No tenant "_DEFAULT" presents.
For tenant "vmgroup1", "default_datastore" remains unchanged (```sharedVmfs-1```) and the access privilege to that datastore remains unchanged

For tenant "vmgroup2", "default_datastore" is set to "_VM_DS", and a full  access privilege to "_VM_DS" has been added

```
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
Uuid                                  Name      Description  Default_datastore  VM_list      
------------------------------------  --------  -----------  -----------------  ------------ 
1dccf853-61c3-4245-a07b-180f9d4df832  vmgroup1               sharedVmfs-1       photon-VM1.1 
bde7a773-17f3-47c0-9fae-23431fb4bc28  vmgroup2               _VM_DS                          
 
[root@sc2-rdops-vm01-dhcp-52-142:~]
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
Datastore     Allow_create  Max_volume_size  Total_size 
------------  ------------  ---------------  ---------- 
sharedVmfs-1  True          500.00MB         1.00GB     
 
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup2
Datastore  Allow_create  Max_volume_size  Total_size 
---------  ------------  ---------------  ---------- 
_VM_DS     True          Unset            Unset      
```