### PR TITLE
Implement "config rm --unlink".

### DIFF
--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -1333,7 +1333,7 @@ def config_rm(args):
     elif mode == auth_data.DBMode.SingleNode:
         if args.unlink:
             return err_out("'rm --unlink' is not supported when " + DB_REF + " is in SingleNode mode."
-                        " Use 'rm --local' to remove the local link to shared DB.")
+                        " Use 'rm --local' to remove the local link or local DB.")
     else:
         raise Exception("Fatal: Internal error - unknown mode: {}".format(mode))
 

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -1307,10 +1307,22 @@ def config_rm(args):
 
     if not args.local and not args.unlink:
         return err_out("""
-        Shared DB removal is not supported. For removing  local configuration, use --local flag.
-        For removing shared DB,  run 'vmdkops_admin config rm --unlink' on ESX hosts using this DB,
-        and manually remove the {} file from shared storage.
+        DB removal is irreversible operation. Please use '--local' flag for removing DB in SingleNode mode,
+        and use '--unlink' to unlink from DB in MultiNode mode.
+        Note that '--unlink' will not remove a shared DB, but simply configure the current ESXi host to stop using it.
+        For removing shared DB, run 'vmdkops_admin config rm --unlink' on ESXi hosts using this DB, and then manually
+        remove the actual DB file '{}' from shared storage.
         """.format(auth_data.CONFIG_DB_NAME))
+
+    if args.local and args.unlink:
+        return err_out("""
+        Cannot use '--local' and '--unlink' together. Please use '--local' flag for removing DB in SingleNode mode,
+        and use '--unlink' to unlink from DB in MultiNode mode.
+        """
+        )
+
+    if not args.confirm:
+        return err_out("Warning: For extra safety, removal operation requires '--confirm' flag.")
 
     # Check the existing config mode
     with auth_data.AuthorizationDataManager() as auth:
@@ -1321,38 +1333,38 @@ def config_rm(args):
         except auth_data.DbAccessError as ex:
             return err_out(str(ex))
 
-    if not args.confirm:
-        return err_out("Warning: For extra safety, removal operation requires '--confirm' flag.")
-
+    # mode is NotConfigured, path does not exist
     if mode == auth_data.DBMode.NotConfigured:
-        pass
-    elif mode == auth_data.DBMode.MultiNode:
-        if args.local:
-            return err_out("'rm --local' is not supported when " + DB_REF + "is in MultiNode mode."
-                        "Use 'rm --unlink' to remove the local link to shared DB.")
-    elif mode == auth_data.DBMode.SingleNode:
-        if args.unlink:
-            return err_out("'rm --unlink' is not supported when " + DB_REF + " is in SingleNode mode."
-                        " Use 'rm --local' to remove the local link or local DB.")
-    else:
-        raise Exception("Fatal: Internal error - unknown mode: {}".format(mode))
+        print("Nothing to do - Mode={}.".format(str(mode)))
 
     link_path = auth_data.AUTH_DB_PATH # local DB or link
     if not os.path.lexists(link_path):
         return None
 
-    try:
-        if not os.path.islink(link_path) and not args.no_backup:
-            print("Moved {} to backup file {}".format(link_path,
-                                                       db_move_to_backup(link_path)))
+    if mode == auth_data.DBMode.MultiNode:
+        if args.local:
+            return err_out("'rm --local' is not supported when " + DB_REF + "is in MultiNode mode."
+                           " Use 'rm --unlink' to remove the local link to shared DB.")
         else:
-            os.remove(link_path)
-            print("Removed link {}".format(link_path))
-    except Exception as ex:
-        print(" Failed to remove {}: {}".format(link_path, ex))
+            try:
+                os.remove(link_path)
+                print("Removed link {}".format(link_path))
+            except Exception as ex:
+                print(" Failed to remove {}: {}".format(link_path, ex))
+            return service_reset()
 
-    return service_reset()
+    if mode == auth_data.DBMode.SingleNode:
+        if args.unlink:
+            return err_out("'rm --unlink' is not supported when " + DB_REF + "is in SingleNode mode."
+                           " Use 'rm --local' to remove local DB configuration.")
+        else:
+            if not args.no_backup:
+                print("Moved {} to backup file {}".format(link_path,
+                                                        db_move_to_backup(link_path)))
+            return service_reset()
 
+    # All other cases
+    print("Nothing to do - Mode={}.".format(str(mode)))
 
 def config_mv(args):
     """[Not Supported Yet]


### PR DESCRIPTION
Fixed #1138.
This PR includes the change to implement "config rm --unlink".

[ ]  In SingleNode, ```rm --local``` will remove the local DB, ```rm --unlink``` will return an error message to say this command is not supported in SingleNode configuration.

[ ] In MultiNode, ```rm --unlink``` will print a message and remove the local symlink. ```rm --local```  will return an error message to say ```rm --unlink``` is not support in MultiNode configuration.

**Testing:**

**Configured in SingleNodeMode:**

- run ```config rm```
```
[root@sc2-rdops-vm01-dhcp-34-30:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py config rm
 
        Shared DB removal is not supported. For removing  local configuration, use --local flag.
        For removing shared DB,  run 'vmdkops_admin config rm --unlink' on ESX hosts using this DB,
        and manually remove the vmdkops_config.db file from shared storage.
       
```

- run ```config rm --unlink```

```
[root@sc2-rdops-vm01-dhcp-34-30:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py config rm --unlink
Warning: For extra safety, removal operation requires '--confirm' flag.
[root@sc2-rdops-vm01-dhcp-34-30:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py config rm --unlink --confirm
'rm --unlink' is not supported when Config DB  is in SingleNode mode. Use 'rm --local' to remove the local link or local DB.
```

- run ```config rm --local```
```
root@sc2-rdops-vm01-dhcp-34-30:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py config rm --local --confirm
Moved /etc/vmware/vmdkops/auth-db to backup file /etc/vmware/vmdkops/auth-db.bak_Thu_Apr_20_23:13:07_2017

[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py config rm --unlink --confirm
Removed link /etc/vmware/vmdkops/auth-db
[root@sc2-rdops-vm01-dhcp-52-142:~]
[root@sc2-rdops-vm01-dhcp-52-142:~]
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py status
=== Service:
Version: 0.13.87ce18c-0.0.1
Status: Running
Pid: 734227
Port: 1019
LogConfigFile: /etc/vmware/vmdkops/log_config.json
LogFile: /var/log/vmware/vmdk_ops.log
LogLevel: INFO
=== Authorization Config DB:
DB_SharedLocation: N/A
DB_Mode: NotConfigured (no local DB, no symlink to shared DB)
DB_LocalPath: N/A
```

**Configured in MultiNodeMode:**
- run ``` config rm ```
```
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py config rm
 
        Shared DB removal is not supported. For removing  local configuration, use --local flag.
        For removing shared DB,  run 'vmdkops_admin config rm --unlink' on ESX hosts using this DB,
        and manually remove the vmdkops_config.db file from shared storage.
```

-  run ``` config rm --local ```
```
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py config rm --local
Warning: For extra safety, removal operation requires '--confirm' flag.
[root@sc2-rdops-vm01-dhcp-52-142:~]
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py config rm --local --confirm
'rm --local' is not supported when Config DB is in MultiNode mode.Use 'rm --unlink' to remove the local link to shared DB.
```

- run ``` config rm --unlink ```
```
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py config rm --unlink --confirm
Removed link /etc/vmware/vmdkops/auth-db
[root@sc2-rdops-vm01-dhcp-52-142:~]
[root@sc2-rdops-vm01-dhcp-52-142:~]
[root@sc2-rdops-vm01-dhcp-52-142:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py status
=== Service:
Version: 0.13.87ce18c-0.0.1
Status: Running
Pid: 734227
Port: 1019
LogConfigFile: /etc/vmware/vmdkops/log_config.json
LogFile: /var/log/vmware/vmdk_ops.log
LogLevel: INFO
=== Authorization Config DB:
DB_SharedLocation: N/A
DB_Mode: NotConfigured (no local DB, no symlink to shared DB)
DB_LocalPath: N/A
```