### PR TITLE
Refactor VMCI Sources

### DIFF
--- a/esx_service/Makefile
+++ b/esx_service/Makefile
@@ -53,7 +53,7 @@ PY_VMODL := $(filter-out %_test.py, $(wildcard vmodl/*.py))
 PY_CLI   := $(filter-out %_test.py, $(wildcard cli/[a-z]*.py))
 PY_UTILS := $(filter-out %_test.py, $(wildcard utils/*.py))
 
-C_SRC  := vmci/vmci_server.c
+C_SRC  := ../vmci/vmci_server.c
 
 # Build both a 32-bit and a 64-bit library for vmci.
 CFLAGS  := -fPIC -m32 -shared

--- a/vmci/connection_types.h
+++ b/vmci/connection_types.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // Shared info (magic, err. codes, etc) on vSocket command channel
+#pragma once
 
 #ifndef _CONNECTION_TYPES_H_
 #define _CONNECTION_TYPES_H_
@@ -61,4 +62,3 @@ vsock_get_family(void)
 }
 
 #endif // _CONNECTION_TYPES_H_
-

--- a/vmci/vmci_client.h
+++ b/vmci/vmci_client.h
@@ -1,0 +1,155 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+//
+// VMCI sockets communication - client side.
+//
+// Called mainly from Go code.
+//
+// API: Exposes only Vmci_GetReply. The call is blocking.
+//
+//
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdint.h>
+#include <assert.h>
+
+#include "vmci_sockets.h"
+#include "connection_types.h"
+
+#define ERR_BUF_LEN 512
+
+// operations status. 0 is OK
+typedef int be_sock_status;
+
+//
+// Booking structure for opened VMCI / vSocket
+//
+typedef struct {
+   int sock_id; // socket id for socket APIs
+   struct sockaddr_vm addr; // held here for bookkeeping and reporting
+} be_sock_id;
+
+//
+// Protocol message structure: request and reply
+//
+
+typedef struct be_request {
+   uint32_t mlen;   // length of message (including trailing \0)
+   const char *msg; // null-terminated immutable JSON string.
+} be_request;
+
+#define MAXBUF 1024 * 1024 // Safety limit. We do not expect json string > 1M
+#define MAX_CLIENT_PORT 1023 // Last privileged port
+#define START_CLIENT_PORT 100 // Where to start client port
+
+// Retry entire range on bind failures
+#define BIND_RETRY_COUNT (MAX_CLIENT_PORT - START_CLIENT_PORT)
+
+typedef struct be_answer {
+   char *buf;                  // response buffer
+   char errBuf[ERR_BUF_LEN];   // error response buffer
+} be_answer;
+
+//
+// Interface for communication to "command execution" server.
+//
+typedef struct be_funcs {
+   const char *shortName; // name of the interaface (key to access it)
+   const char *name;      // longer explanation (human help)
+
+   // init the channel, return status and ID
+   be_sock_status
+   (*init_sock)(be_sock_id *id, int cid, int port);
+   // release the channel - clean up
+   void
+   (*release_sock)(be_sock_id *id);
+
+   // send a request and get  reply - blocking
+   be_sock_status
+   (*get_reply)(be_sock_id *id, be_request *r, be_answer* a);
+} be_funcs;
+
+// support communication interfaces
+#define VSOCKET_BE_NAME "vsocket" // backend to communicate via vSocket
+#define ESX_VMCI_CID    2  		  // ESX host VMCI CID ("address")
+#define DUMMY_BE_NAME "dummy"     // backend which only returns OK, for unit test
+
+
+// Get backend by name
+static be_funcs *
+get_backend(const char *shortName);
+
+// "dummy" interface implementation
+// Used for manual testing mainly,
+// to make sure data arrives to backend
+//----------------------------------
+static be_sock_status
+dummy_init(be_sock_id *id, int cid, int port);
+
+static void
+dummy_release(be_sock_id *id);
+
+static be_sock_status
+dummy_get_reply(be_sock_id *id, be_request *r, be_answer* a);
+
+
+// vsocket interface implementation
+//---------------------------------
+
+
+
+// Create and connect VMCI socket.
+// return CONN_SUCCESS (0) or CONN_FAILURE (-1)
+static be_sock_status
+vsock_init(be_sock_id *id, int cid, int port);
+
+//
+// Send request (r->msg) and wait for reply.
+// returns 0 on success , -1 (or potentially errno) on error
+// On success , allocates a->buf ( caller needs to free it) and placed reply there
+// Expects r and a to be allocated by the caller.
+//
+//
+static be_sock_status
+vsock_get_reply(be_sock_id *s, be_request *r, be_answer* a);
+
+// release socket and vmci info
+static void
+vsock_release(be_sock_id *id);
+
+//
+// Handle one request using BE interface
+// Yes,  we DO create and bind socket for each request - it's management
+// so we can afford overhead, and it allows connection to be stateless.
+//
+static be_sock_status
+host_request(be_funcs *be, be_request* req, be_answer* ans, int cid, int port);
+
+//
+//
+// Entry point for vsocket requests.
+// Returns NULL for success, -1 for err, and sets errno if needed
+// <ans> is allocated upstairs
+//
+const be_sock_status
+Vmci_GetReply(int port, const char* json_request, const char* be_name,
+              be_answer* ans);
+
+void
+Vmci_FreeBuf(be_answer *ans);

--- a/vmci/vmci_server.c
+++ b/vmci/vmci_server.c
@@ -31,12 +31,10 @@
 #include <errno.h>
 #include <stdint.h>
 
+#include "vmci_server.h"
 #include "vmci_sockets.h"
 #include "connection_types.h"
 
-
-// SO_QSIZE maximum number of connections (requests) in socket queue.
-int SO_QSIZE = 128;
 
 // Returns vSocket to listen on, or -1.
 // errno indicates the reason for a failure, if any.

--- a/vmci/vmci_server.h
+++ b/vmci/vmci_server.h
@@ -1,0 +1,61 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// Simple C library to do VMCI / vSocket listen
+//
+// Based on vsocket usage example so quite clumsy.
+
+// TODO: return meaningful error codes. Issue #206
+
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <stdint.h>
+
+#include "vmci_sockets.h"
+#include "connection_types.h"
+
+
+// SO_QSIZE maximum number of connections (requests) in socket queue.
+int SO_QSIZE = 128;
+
+// Returns vSocket to listen on, or -1.
+// errno indicates the reason for a failure, if any.
+int
+vmci_init(unsigned int port);
+
+// Returns vSocket to communicate on (which needs to be closed later),
+// or -1 on error
+int
+vmci_get_one_op(const int s,    // socket to listen on
+         uint32_t *vmid, // cartel ID for VM
+         char *buf,      // external buffer to return json string
+         const int bsize // buffer size
+     );
+
+// Sends a single reply on a socket.
+// Returns 0 on OK and -1 on error (errno is set in this case.
+// For errors, "reply" contains extra error info (specific for vmci_reply)
+int
+vmci_reply(const int client_socket,      // socket to use
+         const char *reply // (json) to send back
+     );
+
+// Closes a socket.
+void
+vmci_close(int s);

--- a/vmci/vmci_sockets.h
+++ b/vmci/vmci_sockets.h
@@ -22,6 +22,7 @@
  *
  *    vSockets public constants and types.
  */
+#pragma once
 
 #ifndef _VMCI_SOCKETS_H_
 #define _VMCI_SOCKETS_H_
@@ -841,4 +842,3 @@ struct uuid_2_cid {
 
 
 #endif // _VMCI_SOCKETS_H_
-

--- a/vmdk_plugin/Makefile
+++ b/vmdk_plugin/Makefile
@@ -69,7 +69,8 @@ UPSTART_INIT := $(PACKAGE)/etc/init/
 
 # esx service for docker volume ops
 ESX_SRC     := ../esx_service
-VMCI_SRC    := $(ESX_SRC)/vmci/*.h $(ESX_SRC)/vmci/vmci_client.c
+VMCI_SRC    := ../vmci/vmci_client.c $(wildcard ../vmci/*.h)
+VMCI_SRC    := $(filter-out vmci_server.h,$(VMCI_SRC))
 
 #  binaries location
 PLUGIN_BIN = $(BIN)/$(PLUGNAME)
@@ -86,10 +87,11 @@ PLUGIN := github.com/$(GOPATH_ORG)/$(GOPATH_PLUGNAME)
 GO := GO15VENDOREXPERIMENT=1 go
 FPM := fpm
 
-# make sure we rebuild of vmkdops or Dockerfile change (since we develop them together)
+# make sure we rebuild of vmkdops or Dockerfile change (since we develop
+# them together)
 VMDKOPS_MODULE := drivers/vmdk/vmdkops
 VMDKOPS_TEST_MODULE := vmdkops
-VMDKOPS_MODULE_SRC = $(VMDKOPS_MODULE)/*.go $(VMCI_SRC)
+VMDKOPS_MODULE_SRC = $(VMDKOPS_MODULE)/*.go $(VMCI_SRC) ../vmci/vmci.go
 
 # All sources. We rebuild if anything changes here
 SRC = main.go log_formatter.go utils/refcount/refcnt.go \

--- a/vmdk_plugin/drivers/vmdk/vmdk_driver.go
+++ b/vmdk_plugin/drivers/vmdk/vmdk_driver.go
@@ -17,7 +17,8 @@ package vmdk
 //
 // VMWare vSphere Docker Data Volume plugin.
 //
-// Provide support for --driver=vsphere in Docker, when Docker VM is running under ESX.
+// Provide support for --driver=vsphere in Docker, when Docker VM is running
+// under ESX.
 //
 // Serves requests from Docker Engine related to VMDK volume operations.
 // Depends on vmdk-opsd service to be running on hosting ESX
@@ -25,15 +26,18 @@ package vmdk
 ///
 
 import (
+	"bytes"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
-	"github.com/docker/go-plugins-helpers/volume"
-	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/drivers/vmdk/vmdkops"
-	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/fs"
-	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/refcount"
 	"path/filepath"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/go-plugins-helpers/volume"
+	"github.com/vmware/docker-volume-vsphere/vmci"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/drivers/vmdk/vmdkops"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/fs"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/refcount"
 )
 
 const (
@@ -52,11 +56,15 @@ type VolumeDriver struct {
 
 var mountRoot string
 
-// NewVolumeDriver creates Driver which to real ESX (useMockEsx=False) or a mock
-func NewVolumeDriver(port int, useMockEsx bool, mountDir string, driverName string) *VolumeDriver {
+// NewVolumeDriver instantiates and returns a new VolumeDriver object.
+//
+// The flag useMockESX indicates whether or not to use a mock driver.
+func NewVolumeDriver(
+	port int, useMockEsx bool, mountDir, driverName string) *VolumeDriver {
+
 	var d *VolumeDriver
 
-	vmdkops.EsxPort = port
+	vmci.EsxPort = port
 	mountRoot = mountDir
 
 	if useMockEsx {
@@ -69,7 +77,7 @@ func NewVolumeDriver(port int, useMockEsx bool, mountDir string, driverName stri
 		d = &VolumeDriver{
 			useMockEsx: false,
 			ops: vmdkops.VmdkOps{
-				Cmd: vmdkops.EsxVmdkCmd{
+				Cmd: vmci.EsxVmdkCmd{
 					Mtx: &sync.Mutex{},
 				},
 			},
@@ -80,28 +88,51 @@ func NewVolumeDriver(port int, useMockEsx bool, mountDir string, driverName stri
 	d.refCounts.Init(d, mountDir, driverName)
 	log.WithFields(log.Fields{
 		"version":  version,
-		"port":     vmdkops.EsxPort,
+		"port":     vmci.EsxPort,
 		"mock_esx": useMockEsx,
-	}).Info("Docker VMDK plugin started ")
+	}).Info("Docker VMDK plugin started")
 
 	return d
 }
 
-// Return the number of references for the given volume
-func (d *VolumeDriver) getRefCount(vol string) uint { return d.refCounts.GetCount(vol) }
+// getRefCount returns the number of references for the given volume.
+func (d *VolumeDriver) getRefCount(vol string) uint {
+	return d.refCounts.GetCount(vol)
+}
 
-// Increment the reference count for the given volume
-func (d *VolumeDriver) incrRefCount(vol string) uint { return d.refCounts.Incr(vol) }
+// incrRefCount increments the reference count for the given volume.
+func (d *VolumeDriver) incrRefCount(vol string) (refcnt uint) {
+	defer func() {
+		log.WithFields(log.Fields{
+			"name":   vol,
+			"refcnt": refcnt,
+		}).Debug("incremented ref count")
+	}()
+	return d.refCounts.Incr(vol)
+}
 
-// Decrement the reference count for the given volume
-func (d *VolumeDriver) decrRefCount(vol string) (uint, error) { return d.refCounts.Decr(vol) }
+// decrRefCount decrements the reference count for the given volume.
+func (d *VolumeDriver) decrRefCount(vol string) (refcnt uint, err error) {
+	defer func() {
+		if err != nil {
+			log.WithField("name", vol).WithError(err).Error(
+				"error decrementing ref count")
+			return
+		}
+		log.WithFields(log.Fields{
+			"name":   vol,
+			"refcnt": refcnt,
+		}).Debug("decremented ref count")
+	}()
+	return d.refCounts.Decr(vol)
+}
 
-// Returns the given volume mountpoint
+// getMountPoint returns the mount point for the given volume.
 func getMountPoint(volName string) string {
 	return filepath.Join(mountRoot, volName)
 }
 
-// Get info about a single volume
+// Get returns info about a single volume.
 func (d *VolumeDriver) Get(r volume.Request) volume.Response {
 	status, err := d.GetVolume(r.Name)
 	if err != nil {
@@ -113,7 +144,7 @@ func (d *VolumeDriver) Get(r volume.Request) volume.Response {
 		Status:     status}}
 }
 
-// List volumes known to the driver
+// List returns the volumes known to the driver.
 func (d *VolumeDriver) List(r volume.Request) volume.Response {
 	volumes, err := d.ops.List()
 	if err != nil {
@@ -128,7 +159,7 @@ func (d *VolumeDriver) List(r volume.Request) volume.Response {
 	return volume.Response{Volumes: responseVolumes}
 }
 
-// GetVolume - return volume meta-data.
+// GetVolume returns a volume's meta-data.
 func (d *VolumeDriver) GetVolume(name string) (map[string]interface{}, error) {
 	return d.ops.Get(name)
 }
@@ -136,15 +167,18 @@ func (d *VolumeDriver) GetVolume(name string) (map[string]interface{}, error) {
 // MountVolume - Request attach and them mounts the volume.
 // Actual mount - send attach to ESX and do the in-guest magic
 // Returns mount point and  error (or nil)
-func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isReadOnly bool, skipAttach bool) (string, error) {
+func (d *VolumeDriver) MountVolume(
+	name, fstype, id string,
+	isReadOnly, skipAttach bool) (string, error) {
+
 	mountpoint := getMountPoint(name)
 
 	// First, make sure  that mountpoint exists.
-	err := fs.Mkdir(mountpoint)
-	if err != nil {
-		log.WithFields(
-			log.Fields{"name": name, "dir": mountpoint},
-		).Error("Failed to make directory for volume mount ")
+	if err := fs.Mkdir(mountpoint); err != nil {
+		log.WithFields(log.Fields{
+			"name": name,
+			"dir":  mountpoint,
+		}).WithError(err).Error("Failed to make directory for volume mount")
 		return mountpoint, err
 	}
 
@@ -177,14 +211,12 @@ func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isRead
 	return mountpoint, fs.Mount(mountpoint, fstype, device, isReadOnly)
 }
 
-// UnmountVolume - Unmounts the volume and then requests detach
+// UnmountVolume unmounts the volume then submits a detach request.
 func (d *VolumeDriver) UnmountVolume(name string) error {
 	mountpoint := getMountPoint(name)
-	err := fs.Unmount(mountpoint)
-	if err != nil {
-		log.WithFields(
-			log.Fields{"mountpoint": mountpoint, "error": err},
-		).Error("Failed to unmount volume. Now trying to detach... ")
+	if err := fs.Unmount(mountpoint); err != nil {
+		log.WithField("mountpoint", mountpoint).WithError(err).Error(
+			"Failed to unmount volume. Now trying to detach...")
 		// Do not return error. Continue with detach.
 	}
 	return d.ops.Detach(name, nil)
@@ -194,24 +226,25 @@ func (d *VolumeDriver) UnmountVolume(name string) error {
 // (until Mount is called).
 // Name and driver specific options passed through to the ESX host
 
-// Create - create a volume.
+// Create submits a volume creation request.
 func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 
 	if r.Options == nil {
 		r.Options = make(map[string]string)
 	}
+
 	// If cloning a existent volume, create and return
-	if _, result := r.Options["clone-from"]; result == true {
-		errClone := d.ops.Create(r.Name, r.Options)
-		if errClone != nil {
-			log.WithFields(log.Fields{"name": r.Name, "error": errClone}).Error("Clone volume failed ")
-			return volume.Response{Err: errClone.Error()}
+	if _, ok := r.Options["clone-from"]; ok {
+		if err := d.ops.Create(r.Name, r.Options); err != nil {
+			log.WithField("name", r.Name).WithError(err).Error(
+				"Clone volume failed")
+			return volume.Response{Err: err.Error()}
 		}
 		return volume.Response{Err: ""}
 	}
 
 	// Use default fstype if not specified
-	if _, result := r.Options["fstype"]; result == false {
+	if _, ok := r.Options["fstype"]; !ok {
 		r.Options["fstype"] = fs.FstypeDefault
 	}
 
@@ -219,60 +252,66 @@ func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 	supportedFs := fs.MkfsLookup()
 
 	// Verify the existence of fstype mkfs
-	mkfscmd, result := supportedFs[r.Options["fstype"]]
-	if result == false {
-		msg := "Not found mkfs for " + r.Options["fstype"]
-		msg += "\nSupported filesystems found: "
-		validfs := ""
+	mkfscmd, ok := supportedFs[r.Options["fstype"]]
+	if !ok {
+		buf := &bytes.Buffer{}
+		fmt.Fprintf(buf, "Not found mkfs for %s\n", r.Options["fstype"])
+		fmt.Fprint(buf, "Supported filesystems found: ")
+		lenSupportedFS := len(supportedFs)
+		x := 0
 		for fs := range supportedFs {
-			if validfs != "" {
-				validfs += ", " + fs
-			} else {
-				validfs += fs
+			fmt.Fprint(buf, fs)
+			if x < lenSupportedFS-1 {
+				fmt.Fprint(buf, ", ")
 			}
+			x++
 		}
-		log.WithFields(log.Fields{"name": r.Name,
-			"fstype": r.Options["fstype"]}).Error("Not found ")
-		return volume.Response{Err: msg + validfs}
+		log.WithFields(log.Fields{
+			"name":   r.Name,
+			"fstype": r.Options["fstype"],
+		}).Error("Not found")
+		return volume.Response{Err: buf.String()}
 	}
 
-	errCreate := d.ops.Create(r.Name, r.Options)
-	if errCreate != nil {
-		log.WithFields(log.Fields{"name": r.Name, "error": errCreate}).Error("Create volume failed ")
-		return volume.Response{Err: errCreate.Error()}
+	if err := d.ops.Create(r.Name, r.Options); err != nil {
+		log.WithField("name", r.Name).WithError(err).Error(
+			"Create volume failed")
+		return volume.Response{Err: err.Error()}
 	}
 
 	// Handle filesystem creation
-	log.WithFields(log.Fields{"name": r.Name,
-		"fstype": r.Options["fstype"]}).Info("Attaching volume and creating filesystem ")
+	log.WithFields(log.Fields{
+		"name":   r.Name,
+		"fstype": r.Options["fstype"],
+	}).Info("Attaching volume and creating filesystem")
 
 	watcher, skipInotify := fs.DevAttachWaitPrep(r.Name, watchPath)
 
 	dev, errAttach := d.ops.Attach(r.Name, nil)
 	if errAttach != nil {
-		log.WithFields(log.Fields{"name": r.Name,
-			"error": errAttach}).Error("Attach volume failed, removing the volume ")
-		// An internal error for the attach may have the volume attached to this client,
-		// detach before removing below.
+		log.WithField("name", r.Name).WithError(errAttach).Error(
+			"Attach volume failed; removing the volume")
+		// An internal error for the attach may have the volume attached to
+		// this client, detach before removing below.
 		d.ops.Detach(r.Name, nil)
-		errRemove := d.ops.Remove(r.Name, nil)
-		if errRemove != nil {
-			log.WithFields(log.Fields{"name": r.Name, "error": errRemove}).Warning("Remove volume failed ")
+		if err := d.ops.Remove(r.Name, nil); err != nil {
+			log.WithField("name", r.Name).WithError(err).Warning(
+				"Remove volume failed")
 		}
 		return volume.Response{Err: errAttach.Error()}
 	}
 
 	device, errGetDevicePath := fs.GetDevicePath(dev)
 	if errGetDevicePath != nil {
-		log.WithFields(log.Fields{"name": r.Name,
-			"error": errGetDevicePath}).Error("Could not find attached device, removing the volume ")
-		errDetach := d.ops.Detach(r.Name, nil)
-		if errDetach != nil {
-			log.WithFields(log.Fields{"name": r.Name, "error": errDetach}).Warning("Detach volume failed ")
+		log.WithField("name", r.Name).WithError(errGetDevicePath).Error(
+			"Could not find attached device; removing the volume")
+		if err := d.ops.Detach(r.Name, nil); err != nil {
+			log.WithField("name", r.Name).WithError(err).Warn(
+				"Detach volume failed")
 		}
-		errRemove := d.ops.Remove(r.Name, nil)
-		if errRemove != nil {
-			log.WithFields(log.Fields{"name": r.Name, "error": errRemove}).Warning("Remove volume failed ")
+		if err := d.ops.Remove(r.Name, nil); err != nil {
+			log.WithField("name", r.Name).WithError(err).Warn(
+				"Remove volume failed")
 		}
 		return volume.Response{Err: errGetDevicePath.Error()}
 	}
@@ -284,49 +323,53 @@ func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 		// in which case we continue creating the file system.
 		fs.DevAttachWait(watcher, r.Name, device)
 	}
-	errMkfs := fs.Mkfs(mkfscmd, r.Name, device)
-	if errMkfs != nil {
-		log.WithFields(log.Fields{"name": r.Name,
-			"error": errMkfs}).Error("Create filesystem failed, removing the volume ")
-		errDetach := d.ops.Detach(r.Name, nil)
-		if errDetach != nil {
-			log.WithFields(log.Fields{"name": r.Name, "error": errDetach}).Warning("Detach volume failed ")
+	if err := fs.Mkfs(mkfscmd, r.Name, device); err != nil {
+		log.WithField("name", r.Name).WithError(err).Error(
+			"Create filesystem failed, removing the volume")
+		if err := d.ops.Detach(r.Name, nil); err != nil {
+			log.WithField("name", r.Name).WithError(err).Warn(
+				"Detach volume failed")
 		}
-		errRemove := d.ops.Remove(r.Name, nil)
-		if errRemove != nil {
-			log.WithFields(log.Fields{"name": r.Name, "error": errRemove}).Warning("Remove volume failed ")
+		if err := d.ops.Remove(r.Name, nil); err != nil {
+			log.WithField("name", r.Name).WithError(err).Warn(
+				"Remove volume failed")
 		}
-		return volume.Response{Err: errMkfs.Error()}
+		return volume.Response{Err: err.Error()}
 	}
 
-	errDetach := d.ops.Detach(r.Name, nil)
-	if errDetach != nil {
-		log.WithFields(log.Fields{"name": r.Name, "error": errDetach}).Error("Detach volume failed ")
-		return volume.Response{Err: errDetach.Error()}
+	if err := d.ops.Detach(r.Name, nil); err != nil {
+		log.WithField("name", r.Name).WithError(err).Error(
+			"Detach volume failed")
+		return volume.Response{Err: err.Error()}
 	}
 
-	log.WithFields(log.Fields{"name": r.Name,
-		"fstype": r.Options["fstype"]}).Info("Volume and filesystem created ")
+	log.WithFields(log.Fields{
+		"name":   r.Name,
+		"fstype": r.Options["fstype"],
+	}).Info("Volume and filesystem created")
 	return volume.Response{Err: ""}
 }
 
-// Remove - removes individual volume. Docker would call it only if is not using it anymore
+// Remove - removes individual volume. Docker would call it only if is not
+// using it anymore
 func (d *VolumeDriver) Remove(r volume.Request) volume.Response {
-	log.WithFields(log.Fields{"name": r.Name}).Info("Removing volume ")
+	log.WithField("name", r.Name).Info("Removing volume")
 
-	// Docker is supposed to block 'remove' command if the volume is used. Verify.
-	if d.getRefCount(r.Name) != 0 {
+	// Docker is supposed to block 'remove' command if the volume is used.
+	// Verify.
+	if refcnt := d.getRefCount(r.Name); refcnt != 0 {
+		log.WithFields(log.Fields{
+			"name":   r.Name,
+			"refcnt": refcnt,
+		}).Error("remove failure; volume is still mounted")
 		msg := fmt.Sprintf("Remove failure - volume is still mounted. "+
-			" volume=%s, refcount=%d", r.Name, d.getRefCount(r.Name))
-		log.Error(msg)
+			" volume=%s, refcount=%d", r.Name, refcnt)
 		return volume.Response{Err: msg}
 	}
 
-	err := d.ops.Remove(r.Name, r.Options)
-	if err != nil {
-		log.WithFields(
-			log.Fields{"name": r.Name, "error": err},
-		).Error("Failed to remove volume ")
+	if err := d.ops.Remove(r.Name, r.Options); err != nil {
+		log.WithField("name", r.Name).WithError(err).Error(
+			"Failed to remove volume")
 		return volume.Response{Err: err.Error()}
 	}
 
@@ -338,74 +381,80 @@ func (d *VolumeDriver) Path(r volume.Request) volume.Response {
 	return volume.Response{Mountpoint: getMountPoint(r.Name)}
 }
 
-// Mount - Provide a volume to docker container - called once per container start.
-// We need to keep refcount and unmount on refcount drop to 0
+// Mount - Provide a volume to docker container - called once per container
+// start. We need to keep refcount and unmount on refcount drop to 0.
 //
 // The serialization of operations per volume is assured by the volume/store
 // of the docker daemon.
+//
 // As long as the refCountsMap is protected is unnecessary to do any locking
 // at this level during create/mount/umount/remove.
 //
 func (d *VolumeDriver) Mount(r volume.MountRequest) volume.Response {
-	log.WithFields(log.Fields{"name": r.Name}).Info("Mounting volume ")
+	log.WithField("name", r.Name).Info("Mounting volume")
 
 	// If the volume is already mounted , just increase the refcount.
 	//
 	// Note: We are deliberately incrementing refcount first, before trying
 	// to do anything else. If Mount fails, Docker will send Unmount request,
-	// and we will happily decrement the refcount there, and will fail the unmount
-	// since the volume will have been never mounted.
+	// and we will happily decrement the refcount there, and will fail the
+	// unmount since the volume will have been never mounted.
+	//
 	// Note: for new keys, GO maps return zero value, so no need for if_exists.
 
-	refcnt := d.incrRefCount(r.Name) // save map traversal
-	log.Debugf("volume name=%s refcnt=%d", r.Name, refcnt)
-	if refcnt > 1 {
-		log.WithFields(
-			log.Fields{"name": r.Name, "refcount": refcnt},
-		).Info("Already mounted, skipping mount. ")
+	if refcnt := d.incrRefCount(r.Name); refcnt > 1 { // save map traversal
+		log.WithFields(log.Fields{
+			"name":   r.Name,
+			"refcnt": refcnt,
+		}).Debug("already mounted; skipping mount")
 		return volume.Response{Mountpoint: getMountPoint(r.Name)}
 	}
 
 	// This is the first time we are asked to mount the volume, so comply
 	status, err := d.ops.Get(r.Name)
-
-	fstype := fs.FstypeDefault
-	isReadOnly := false
 	if err != nil {
 		d.decrRefCount(r.Name)
 		return volume.Response{Err: err.Error()}
 	}
+
+	var (
+		ok         bool
+		value      string
+		isReadOnly bool
+
+		fstype = fs.FstypeDefault
+	)
+
 	// Check access type.
-	value, exists := status["access"].(string)
-	if !exists {
-		msg := fmt.Sprintf("Invalid access type for %s, assuming read-write access.", r.Name)
-		log.WithFields(log.Fields{"name": r.Name, "error": msg}).Error("")
+	if value, ok = status["access"].(string); !ok {
+		log.WithField("name", r.Name).Error(
+			"invalid access type; assuming RW access")
 		isReadOnly = false
 	} else if value == "read-only" {
 		isReadOnly = true
 	}
 
 	// Check file system type.
-	value, exists = status["fstype"].(string)
-	if !exists {
-		msg := fmt.Sprintf("Invalid filesystem type for %s, assuming type as %s.",
-			r.Name, fstype)
-		log.WithFields(log.Fields{"name": r.Name, "error": msg}).Error("")
+	if value, ok = status["fstype"].(string); !ok {
+		log.WithFields(log.Fields{
+			"name":        r.Name,
+			"assumedType": fstype,
+		}).Error("invalid FS type; using assumed type")
 		// Fail back to a default version that we can try with.
 		value = fs.FstypeDefault
 	}
+
 	fstype = value
 
 	mountpoint, err := d.MountVolume(r.Name, fstype, "", isReadOnly, false)
 	if err != nil {
-		log.WithFields(
-			log.Fields{"name": r.Name, "error": err.Error()},
-		).Error("Failed to mount ")
+		log.WithField("name", r.Name).WithError(err).Error("failed to mount")
 
-		refcnt, _ := d.decrRefCount(r.Name)
-		if refcnt == 0 {
-			log.Infof("Detaching %s - it is not used anymore", r.Name)
-			d.ops.Detach(r.Name, nil) // try to detach before failing the request for volume
+		if refcnt, _ := d.decrRefCount(r.Name); refcnt == 0 {
+			log.WithField("name", r.Name).Info("detaching unused volume")
+
+			// try to detach before failing the request for volume
+			d.ops.Detach(r.Name, nil)
 		}
 		return volume.Response{Err: err.Error()}
 	}
@@ -416,30 +465,29 @@ func (d *VolumeDriver) Mount(r volume.MountRequest) volume.Response {
 // Unmount request from Docker. If mount refcount is drop to 0.
 // Unmount and detach from VM
 func (d *VolumeDriver) Unmount(r volume.UnmountRequest) volume.Response {
-	log.WithFields(log.Fields{"name": r.Name}).Info("Unmounting Volume ")
+	log.WithField("name", r.Name).Info("Unmounting Volume")
 
 	// if the volume is still used by other containers, just return OK
 	refcnt, err := d.decrRefCount(r.Name)
 	if err != nil {
 		// something went wrong - yell, but still try to unmount
-		log.WithFields(
-			log.Fields{"name": r.Name, "refcount": refcnt},
-		).Error("Refcount error - still trying to unmount...")
+		log.WithFields(log.Fields{
+			"name":     r.Name,
+			"refcount": refcnt,
+		}).Error("Refcount error - still trying to unmount...")
 	}
-	log.Debugf("volume name=%s refcnt=%d", r.Name, refcnt)
+
 	if refcnt >= 1 {
-		log.WithFields(
-			log.Fields{"name": r.Name, "refcount": refcnt},
-		).Info("Still in use, skipping unmount request. ")
+		log.WithFields(log.Fields{
+			"name":     r.Name,
+			"refcount": refcnt,
+		}).Debug("volume still in used; skipping unmount request")
 		return volume.Response{Err: ""}
 	}
 
 	// and if nobody needs it, unmount and detach
-	err = d.UnmountVolume(r.Name)
-	if err != nil {
-		log.WithFields(
-			log.Fields{"name": r.Name, "error": err.Error()},
-		).Error("Failed to unmount ")
+	if err := d.UnmountVolume(r.Name); err != nil {
+		log.WithField("name", r.Name).WithError(err).Error("failed to mount")
 		return volume.Response{Err: err.Error()}
 	}
 	return volume.Response{Err: ""}


### PR DESCRIPTION
This PR replaces PR #1192.

This patch updates the VMCI sources (both C and Go) so that they may be utilized by external actors. The VMCI sources were previously found in these locations:

Directory | File
----------|----
`esx_service/vmci` | `connection_types.h`
 | | `vmci_client.c`
 | | `vmci_server.c`
 | | `vmci_sockets.h`
`vmdk_plugin/drivers/vmdk/vmdkops` | `esx_vmdkcmd.go`

The Go file `esx_vmdkcmd.go` included `vmci_client.c` via Cgo and in doing so linked to the C code statically. However, due to the way Cgo works this meant that external actors that imported the package `github.com/vmware/docker-volume-vsphere/vmdk_plugin/drivers/vmdk/vmdkops` would receive Cgo errors about type redeclaration. This is because the `esx_vmdkcmd.go` file linked directly to a source file instead of a header that used `#pragma once` or `ifdef` statements to guard itself against being included twice.

PR #1192 evolved into a discussion about possible solutions to this issue:

* Create a dynamic, shared library from the C sources which this project and others could utilize by including a `vmci_client.h` header and linking to the shared library. This was rejected due to the need to ensure that the external, shared library would be present on systems with Go programs that required it. It's an external dependency and thus a hassle and unnecessary burden.

* A second option is for external actors to simply copy the C sources to their own projects. This would work unless that project imported the `github.com/vmware/docker-volume-vsphere/vmdk_plugin/drivers/vmdk/vmdkops` package, causing type redeclarations. Additionally this solution would mean that updates to the original sources would not be applied to copies.

@msterin and I agreed that the best and simplest solution is to place the Go source file `esx_vmdkcmd.go` alongside the C sources causing Go to link to it statically but also make it possible to include the C code via a header guarded against redeclaration. 

This patch relocates the following files:

Old | New
----------|----
`esx_service/vmci/connection_types.h` | `vmci/connection_types.h`
`esx_service/vmci/vmci_client.c` | `vmci/vmci_client.c`
 | | `vmci/vmci_client.h`
`esx_service/vmci/vmci_server.c` | `vmci/vmci_server.c`
 | | `vmci/vmci_server.h`
`esx_service/vmci/vmci_sockets.h` | `vmci/vmci_sockets.h`
`vmdk_plugin/drivers/vmdk/vmdkops/esx_vmdkcmd.go` | `vmci/vmci.go`

The Go file `vmdk_plugin/drivers/vmdk/vmdk_driver.go` now imports the package `github.com/vmware/docker-volume-vsphere/vmci` in order to load the ESXi type that satisfies the interface `github.com/vmware/docker-volume-vsphere/vmdk_plugin/drivers/vmdk/vmdkops.VmdkCmdRunner`.

This patch also sanitizes some Go source code in order for it to match de facto as well as de jure standards. Examples include:

* Using `ok` as the boolean flag indicating whether or not a key is a member of a map.
* Using `WithError` instead of including the error as a member of a log entry's fields
* Respecting a maxchar of 80 and wrapping code for readability
* Using natural language for code comments and beginning a comment with the name of the function or field

cc / @msterin, @pdhamdhere 