### PR TITLE
Retain Attachment Information

### DIFF
--- a/esx_service/volume_kv.py
+++ b/esx_service/volume_kv.py
@@ -39,6 +39,8 @@ CREATED_BY = 'created-by'
 ATTACHED_VM_UUID = 'attachedVMUuid'
 # The name of the VM that the volume is attached to
 ATTACHED_VM_NAME = "attachedVMName"
+# The device to which the volume is attached.
+ATTACHED_VM_DEV = "attachedVMDevice"
 
 # Dictionary of options passed in by the user
 VOL_OPTS = 'volOpts'
@@ -82,7 +84,7 @@ DEFAULT_ACCESS = ACCESS_READWRITE
 ACCESS_TYPES = [ACCESS_READWRITE, ACCESS_READONLY]
 
 # Filesystem type
-# This option is handled in the volume-plugin at the docker host, and tracked in volume metadata. 
+# This option is handled in the volume-plugin at the docker host, and tracked in volume metadata.
 FILESYSTEM_TYPE = 'fstype'
 DEFAULT_FILESYSTEM_TYPE = 'ext4'
 


### PR DESCRIPTION
This patch handles issue #1199 by enabling the retention of a VMDK's attachment information upon being attached to a VM. The information is also removed when the VMDK is detached. The information is provided when a VMDK is introspected via a Get operation.

Here is an example of the output using libStorage unit tests that perform first an attach and then get via the vmdkops vmci client:

### VolumeAttach
```bash
[root@yellow libstorage]# VMDK_PORT=1019 DRIVERS=vmdk ./got ./drivers/storage/vmdk/tests -v -run TestVolumeAttach
=== RUN   TestVolumeAttach
--- PASS: TestVolumeAttach (0.38s)
	vmdk_test.go:104: tok={"ControllerPciSlotNumber": "192", "Unit": "0"}, &{Attachments:[] AttachmentState:0 AvailabilityZone: Encrypted:false IOPS:0 Name:vmdkops NetworkName: Size:104857600 Status: ID:vmdkops Type:datastore1 Fields:map[attached to VM:centos7 diskformat:thin created:Tue Apr 25 02:52:40 2017 access:read-write status:attached clone-from:None attachedVMDevice:map[ControllerPciSlotNumber:192 Unit:0] attach-as:independent_persistent created by VM:centos7]}
PASS
ok  	github.com/codedellemc/libstorage/drivers/storage/vmdk/tests	0.487s
```

### VolumeInspect
```bash
[root@yellow libstorage]# VMDK_PORT=1019 DRIVERS=vmdk ./got ./drivers/storage/vmdk/tests -v -run TestVolumeInspect 
=== RUN   TestVolumeInspect
--- PASS: TestVolumeInspect (0.09s)
	vmdk_test.go:78: &{Attachments:[] AttachmentState:0 AvailabilityZone: Encrypted:false IOPS:0 Name:vmdkops NetworkName: Size:104857600 Status: ID:vmdkops Type:datastore1 Fields:map[created:Tue Apr 25 02:52:40 2017 clone-from:None access:read-write diskformat:thin attach-as:independent_persistent status:attached attachedVMDevice:map[Unit:0 ControllerPciSlotNumber:192] created by VM:centos7 attached to VM:centos7]}
PASS
ok  	github.com/codedellemc/libstorage/drivers/storage/vmdk/tests	0.194s
```

### VolumeDetach
```
[root@yellow libstorage]# VMDK_PORT=1019 DRIVERS=vmdk ./got ./drivers/storage/vmdk/tests -v -run TestVolumeDetach
=== RUN   TestVolumeDetach
--- PASS: TestVolumeDetach (0.22s)
	vmdk_test.go:117: &{Attachments:[] AttachmentState:0 AvailabilityZone: Encrypted:false IOPS:0 Name:vmdkops NetworkName: Size:104857600 Status: ID:vmdkops Type:datastore1 Fields:map[status:detached diskformat:thin created:Tue Apr 25 02:52:40 2017 created by VM:centos7 clone-from:None access:read-write attach-as:independent_persistent]}
PASS
ok  	github.com/codedellemc/libstorage/drivers/storage/vmdk/tests	0.321s
```

As illustrated above, the volume retains the information about to which device it is attached for subsequent introspection attempts, and the information is then removed upon detach.

cc/ @msterin @pdhamdhere 