### PR TITLE
In multinode mode, disallow deleting vmgroup which are not empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Warning for Photon OS user**: Docker managed plugin installation support on Photon OS is broken due to known [Photon OS Issue](https://github.com/vmware/photon/issues/640)
+
 [![Build Status](https://ci.vmware.run/api/badges/vmware/docker-volume-vsphere/status.svg)](https://ci.vmware.run/vmware/docker-volume-vsphere)
 [![Go Report Card](https://goreportcard.com/badge/github.com/vmware/docker-volume-vsphere)](https://goreportcard.com/report/github.com/vmware/docker-volume-vsphere)
 [![Join the chat at https://gitter.im/vmware/docker-volume-vsphere](https://badges.gitter.im/vmware/docker-volume-vsphere.svg)](https://gitter.im/vmware/docker-volume-vsphere?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Docker Pulls](https://img.shields.io/badge/docker-pull-blue.svg)](https://store.docker.com/plugins/vsphere-docker-volume-service?tab=description) [![VIB_Download](https://api.bintray.com/packages/vmware/vDVS/VIB/images/download.svg)](https://bintray.com/vmware/vDVS/VIB/_latestVersion)
@@ -148,7 +150,7 @@ logging config format for content details.
    - Needs Upstart or systemctl to start and stop the service
    - Needs [open vm tools or VMware Tools installed](https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=340) ```sudo apt-get install open-vm-tools```
 - RedHat and CentOS
-- [Photon 1.0, Revision 2](https://github.com/vmware/photon/wiki/Downloading-Photon-OS#photon-os-10-revision-2-binaries) (v4.4.51 or later)
+- [Photon 1.0, Revision 2](https://github.com/vmware/photon/wiki/Downloading-Photon-OS#photon-os-10-revision-2-binaries) (v4.4.51 or later) => **Note**: Managed plugin installation is not supported due to known [Photon OS Issue](https://github.com/vmware/photon/issues/640). In the meantime, you can try one of alternative proposed in [#1215](https://github.com/vmware/docker-volume-vsphere/issues/1215#issuecomment-298841769)  (manually upgrade to latest Docker release or use RPM)
 
 **Docker**: 1.12 and higher (Recommended 1.13/17.03 and above to use managed plugin)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-**Warning for Photon OS user**: Docker managed plugin installation support on Photon OS is broken due to known [Photon OS Issue](https://github.com/vmware/photon/issues/640)
-
 [![Build Status](https://ci.vmware.run/api/badges/vmware/docker-volume-vsphere/status.svg)](https://ci.vmware.run/vmware/docker-volume-vsphere)
 [![Go Report Card](https://goreportcard.com/badge/github.com/vmware/docker-volume-vsphere)](https://goreportcard.com/report/github.com/vmware/docker-volume-vsphere)
 [![Join the chat at https://gitter.im/vmware/docker-volume-vsphere](https://badges.gitter.im/vmware/docker-volume-vsphere.svg)](https://gitter.im/vmware/docker-volume-vsphere?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Docker Pulls](https://img.shields.io/badge/docker-pull-blue.svg)](https://store.docker.com/plugins/vsphere-docker-volume-service?tab=description) [![VIB_Download](https://api.bintray.com/packages/vmware/vDVS/VIB/images/download.svg)](https://bintray.com/vmware/vDVS/VIB/_latestVersion)
@@ -150,7 +148,7 @@ logging config format for content details.
    - Needs Upstart or systemctl to start and stop the service
    - Needs [open vm tools or VMware Tools installed](https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=340) ```sudo apt-get install open-vm-tools```
 - RedHat and CentOS
-- [Photon 1.0, Revision 2](https://github.com/vmware/photon/wiki/Downloading-Photon-OS#photon-os-10-revision-2-binaries) (v4.4.51 or later) => **Note**: Managed plugin installation is not supported due to known [Photon OS Issue](https://github.com/vmware/photon/issues/640). In the meantime, you can try one of alternative proposed in [#1215](https://github.com/vmware/docker-volume-vsphere/issues/1215#issuecomment-298841769)  (manually upgrade to latest Docker release or use RPM)
+- [Photon 1.0, Revision 2](https://github.com/vmware/photon/wiki/Downloading-Photon-OS#photon-os-10-revision-2-binaries) (v4.4.51 or later)
 
 **Docker**: 1.12 and higher (Recommended 1.13/17.03 and above to use managed plugin)
 

--- a/docs/user-guide/admin-cli.md
+++ b/docs/user-guide/admin-cli.md
@@ -283,9 +283,9 @@ Uuid                                  Name      Description                 Defa
 11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup
 ```
 
-In multinode mode, VMs from different hosts can be a part of a vmgroup.
+In MultiNode mode, VMs from different hosts can be a part of a vmgroup.
 When in this mode, vmgroup which has member VMs in it cannot be directly deleted.
-First remove remove the VMs individually from the vmgroup using admin cli
+First remove the VMs individually from the vmgroup using admin cli
 on the same host on which the VM resides.
 Then remove the vmgroup.
 #### Help
@@ -360,7 +360,7 @@ Note: If the VMs have volumes attached (containers running), their membership ch
 they belong is not permitted. Make sure no volumes are attached.
 To do so:
 1. Get the list of containers running. (docker ps)
-2. If the container has any dvs volume mounted (docker inspect container_name), stop the container.
+2. If the container has any vDVS volume mounted (docker inspect container_name), stop the container.
 3. Ensure that the dvs volumes have status detached (docker volume inspect)
 
 #### Help

--- a/docs/user-guide/admin-cli.md
+++ b/docs/user-guide/admin-cli.md
@@ -64,7 +64,7 @@ of their usage.
 
 ## Vmgroup
 
-vm-groups allow placing access control restrictions on all Docker storage requests issued from a group of VMs. Administrator can create a vmgroup, place a set of VMs in it (`create` and ``vm add`` subcommands, and then associate this group with a specific set of Datastores and access privileges (`access` and `update` subcommands).
+vmgroups allow placing access control restrictions on all Docker storage requests issued from a group of VMs. Administrator can create a vmgroup, place a set of VMs in it (`create` and ``vm add`` subcommands, and then associate this group with a specific set of Datastores and access privileges (`access` and `update` subcommands).
 
 ### Help
 ```bash
@@ -824,7 +824,7 @@ Successfully removed policy: some-policy
 
 **THIS FEATURE IS EXPERIMENTAL**
 
-Creates, removes, moves and reports on status of Authorization config DB (referred to as `Config DB`). Config DB keeps authorization information - vm-groups, datastore access control, quota information -  and without initializing it no access control is supported. Also, before Config DB is initialized, any attempt to configure access control will fail, e.g.
+Creates, removes, moves and reports on status of Authorization config DB (referred to as `Config DB`). Config DB keeps authorization information - vmgroups, datastore access control, quota information -  and without initializing it no access control is supported. Also, before Config DB is initialized, any attempt to configure access control will fail, e.g.
 ```
 [root@localhost:~] vmdkops_admin vmgroup create --name MY
 Internal Error(Error: Please init configuration in vmdkops_admin before trying to change it)
@@ -834,7 +834,7 @@ If the Config DB is not initialized, Docker Volume Service will use  "Config DB 
 
 After initialization the service can use SingleNode mode - when the DB itself is located on the local ESXi node in `/etc/vmware/vmdkps/auth-db` file, or MultiNode mode - when the above location is a symlin to a shared datastore location.
 
-In SingleNode mode all vm-groups and authorization control is local for each ESXi node, and node do not share this information.
+In SingleNode mode all vmgroups and authorization control is local for each ESXi node, and node do not share this information.
 
 In MultiNode mode, VSphere Docker Volume Service Authorization Config DB needs to be initialized on each ESXi host (`config init --datastore=<ds>`, and the nodes will share the authoration control.
 

--- a/docs/user-guide/admin-cli.md
+++ b/docs/user-guide/admin-cli.md
@@ -283,6 +283,11 @@ Uuid                                  Name      Description                 Defa
 11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup
 ```
 
+In multinode mode, VMs from different hosts can be a part of a vmgroup.
+When in this mode, vmgroup which has member VMs in it cannot be directly deleted.
+First remove remove the VMs individually from the vmgroup using admin cli
+on the same host on which the VM resides.
+Then remove the vmgroup.
 #### Help
 ```
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup rm -h
@@ -350,6 +355,13 @@ Uuid                                  Name
 ------------------------------------  --------
 564d99a2-4097-9966-579f-3dc4082b10c9  photon7
 ```
+
+Note: If the VMs have volumes attached (containers running), their membership change i.e. changing the vmgroup to which
+they belong is not permitted. Make sure no volumes are attached.
+To do so:
+1. Get the list of containers running. (docker ps)
+2. If the container has any dvs volume mounted (docker inspect container_name), stop the container.
+3. Ensure that the dvs volumes have status detached (docker volume inspect)
 
 #### Help
 ```
@@ -460,7 +472,7 @@ _ALL_DS    True          500.00MB         Unset
 ```
 
 
-##### Help 
+##### Help
 ```bash
 [root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add -h
 usage: vmdkops_admin.py vmgroup access add [-h]

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -1237,7 +1237,7 @@ def check_ds_local_args(args):
 
 def config_init(args):
     """
-    Init Config DB to allows quotas and access groups (vm-groups)
+    Init Config DB to allows quotas and access groups (vmgroups)
     :return: None for success, string for error
     """
 

--- a/esx_service/cli/vmdkops_admin_test.py
+++ b/esx_service/cli/vmdkops_admin_test.py
@@ -569,8 +569,8 @@ class TestTenant(unittest.TestCase):
 
     def cleanup(self):
         # cleanup existing tenants
-        vmdk_ops_test.cleanup_tenant(self.tenant1_name)
-        vmdk_ops_test.cleanup_tenant(self.tenant1_new_name)
+        test_utils.cleanup_tenant(self.tenant1_name)
+        test_utils.cleanup_tenant(self.tenant1_new_name)
 
         # remove VM
         si = vmdk_ops.get_si()

--- a/esx_service/cli/vmdkops_admin_test.py
+++ b/esx_service/cli/vmdkops_admin_test.py
@@ -568,14 +568,9 @@ class TestTenant(unittest.TestCase):
         self.cleanup()
 
     def cleanup(self):
-        # cleanup existing tenant
-        error_info = auth_api._tenant_rm(
-                                         name=self.tenant1_name,
-                                         remove_volumes=True)
-
-        error_info = auth_api._tenant_rm(
-                                         name=self.tenant1_new_name,
-                                         remove_volumes=True)
+        # cleanup existing tenants
+        vmdk_ops_test.cleanup_tenant(self.tenant1_name)
+        vmdk_ops_test.cleanup_tenant(self.tenant1_new_name)
 
         # remove VM
         si = vmdk_ops.get_si()
@@ -685,7 +680,7 @@ class TestTenant(unittest.TestCase):
 
         self.assertEqual(expected_output, actual_output)
 
-        # remove access privileg to "_VM_DS"
+        # remove access privilege to "_VM_DS"
         error_info = auth_api._tenant_access_rm(name=self.tenant1_name,
                                                 datastore=auth_data_const.VM_DS)
         self.assertEqual(None, error_info)
@@ -730,7 +725,7 @@ class TestTenant(unittest.TestCase):
             new_name=self.tenant1_new_name)
         self.assertEqual(None, error_info)
 
-	# verify default vmgroup can't be renamed
+        # verify default vmgroup can't be renamed
         error_info  = auth_api._tenant_update(name=auth_data_const.DEFAULT_TENANT,
                                               new_name=self.tenant1_new_name)
         self.assertNotEqual(None, error_info)
@@ -753,6 +748,10 @@ class TestTenant(unittest.TestCase):
 
 
         # tenant rm to remove the tenant
+        error_info = auth_api._tenant_vm_rm(name=self.tenant1_new_name,
+                                            vm_list=vm_list)
+        self.assertEqual(None, error_info)
+
         error_info = auth_api._tenant_rm(
                                          name=self.tenant1_new_name,
                                          remove_volumes=True)

--- a/esx_service/utils/auth_api.py
+++ b/esx_service/utils/auth_api.py
@@ -566,7 +566,6 @@ def _tenant_rm(name, remove_volumes=False):
         return error_info
 
     error_info, auth_mgr = get_auth_mgr_object()
-
     if error_info:
         return error_info
 

--- a/esx_service/utils/auth_api.py
+++ b/esx_service/utils/auth_api.py
@@ -565,27 +565,14 @@ def _tenant_rm(name, remove_volumes=False):
         error_info = generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
         return error_info
 
+    if tenant.vms:
+        error_info = generate_error_info(ErrorCode.TENANT_NOT_EMPTY, name)
+        logging.error(error_info.msg)
+        return error_info
+
     error_info, auth_mgr = get_auth_mgr_object()
     if error_info:
         return error_info
-
-    # check if vms that are a part of this tenant have any volumes mounted.
-    # If they have, can't delete the tenant.
-    if tenant.vms:
-        logging.info("_tenant_rm. VMs in tenant are %s", tenant.vms)
-
-        # in multinode mode, we cannot find VM residing on another host so stopping
-        # tenant deletion gracefully
-        if auth_mgr.mode == auth_data.DBMode.MultiNode:
-            error_info = generate_error_info(ErrorCode.TENANT_NOT_EMPTY, name)
-            logging.error(error_info.msg)
-            return error_info
-
-        error_info = vmdk_utils.check_volumes_mounted(tenant.vms)
-        if error_info:
-            error_info.msg = "Cannot complete vmgroup rm. " + error_info.msg
-            logging.error(error_info.msg)
-            return error_info
 
     error_msg = auth_mgr.remove_tenant(tenant.id, remove_volumes)
     if error_msg:

--- a/esx_service/utils/auth_api.py
+++ b/esx_service/utils/auth_api.py
@@ -565,21 +565,28 @@ def _tenant_rm(name, remove_volumes=False):
         error_info = generate_error_info(ErrorCode.TENANT_NOT_EXIST, name)
         return error_info
 
+    error_info, auth_mgr = get_auth_mgr_object()
+
+    if error_info:
+        return error_info
+
     # check if vms that are a part of this tenant have any volumes mounted.
     # If they have, can't delete the tenant.
     if tenant.vms:
         logging.info("_tenant_rm. VMs in tenant are %s", tenant.vms)
+
+        # in multinode mode, we cannot find VM residing on another host
+        # so a gracefull way to admin know about the error
+        if auth_mgr.mode == auth_data.DBMode.MultiNode:
+            error_info = generate_error_info(ErrorCode.TENANT_NOT_EMPTY, name)
+            logging.error(error_info.msg)
+            return error_info
 
         error_info = vmdk_utils.check_volumes_mounted(tenant.vms)
         if error_info:
             error_info.msg = "Cannot complete vmgroup rm. " + error_info.msg
             logging.error(error_info.msg)
             return error_info
-
-    error_info, auth_mgr = get_auth_mgr_object()
-
-    if error_info:
-        return error_info
 
     error_msg = auth_mgr.remove_tenant(tenant.id, remove_volumes)
     if error_msg:

--- a/esx_service/utils/auth_api.py
+++ b/esx_service/utils/auth_api.py
@@ -575,8 +575,8 @@ def _tenant_rm(name, remove_volumes=False):
     if tenant.vms:
         logging.info("_tenant_rm. VMs in tenant are %s", tenant.vms)
 
-        # in multinode mode, we cannot find VM residing on another host
-        # so a gracefull way to admin know about the error
+        # in multinode mode, we cannot find VM residing on another host so stopping
+        # tenant deletion gracefully
         if auth_mgr.mode == auth_data.DBMode.MultiNode:
             error_info = generate_error_info(ErrorCode.TENANT_NOT_EMPTY, name)
             logging.error(error_info.msg)

--- a/esx_service/utils/error_code.py
+++ b/esx_service/utils/error_code.py
@@ -23,6 +23,7 @@ class ErrorCode:
     TENANT_SET_ACCESS_PRIVILEGES_FAILED = 6
     TENANT_GET_FAILED = 7
     TENANT_NAME_INVALID = 8
+    TENANT_NOT_EMPTY = 9 # only used in multinode mode
     # Tenant related error code end
 
     # VM related error code start
@@ -87,6 +88,7 @@ error_code_to_message = {
     ErrorCode.TENANT_SET_ACCESS_PRIVILEGES_FAILED : "Vmgroup {0} set access privileges on datastore {1} failed with err: {2}",
     ErrorCode.TENANT_GET_FAILED : "Get vmgroup {0} failed",
     ErrorCode.TENANT_NAME_INVALID : "Vmgroup name {0} is invalid, only {1} is allowed",
+    ErrorCode.TENANT_NOT_EMPTY : "Cannot delete non empty Vmgroup {0} in Multinode mode. Remove VMs from the Vmgroup before deleting it.",
 
     ErrorCode.VM_NOT_FOUND : "Cannot find vm {0}",
     ErrorCode.REPLACE_VM_EMPTY : "Replace VM cannot be empty",

--- a/esx_service/utils/error_code.py
+++ b/esx_service/utils/error_code.py
@@ -88,7 +88,7 @@ error_code_to_message = {
     ErrorCode.TENANT_SET_ACCESS_PRIVILEGES_FAILED : "Vmgroup {0} set access privileges on datastore {1} failed with err: {2}",
     ErrorCode.TENANT_GET_FAILED : "Get vmgroup {0} failed",
     ErrorCode.TENANT_NAME_INVALID : "Vmgroup name {0} is invalid, only {1} is allowed",
-    ErrorCode.TENANT_NOT_EMPTY : "Cannot delete non empty vmgroup {0} in Multinode mode. Remove VMs from the vmgroup before deleting it.",
+    ErrorCode.TENANT_NOT_EMPTY : "Cannot delete non-empty vmgroup {0} in MultiNode mode. Remove VMs from the vmgroup before deleting it.",
 
     ErrorCode.VM_NOT_FOUND : "Cannot find vm {0}",
     ErrorCode.REPLACE_VM_EMPTY : "Replace VM cannot be empty",

--- a/esx_service/utils/error_code.py
+++ b/esx_service/utils/error_code.py
@@ -88,7 +88,7 @@ error_code_to_message = {
     ErrorCode.TENANT_SET_ACCESS_PRIVILEGES_FAILED : "Vmgroup {0} set access privileges on datastore {1} failed with err: {2}",
     ErrorCode.TENANT_GET_FAILED : "Get vmgroup {0} failed",
     ErrorCode.TENANT_NAME_INVALID : "Vmgroup name {0} is invalid, only {1} is allowed",
-    ErrorCode.TENANT_NOT_EMPTY : "Cannot delete non empty Vmgroup {0} in Multinode mode. Remove VMs from the Vmgroup before deleting it.",
+    ErrorCode.TENANT_NOT_EMPTY : "Cannot delete non empty vmgroup {0} in Multinode mode. Remove VMs from the vmgroup before deleting it.",
 
     ErrorCode.VM_NOT_FOUND : "Cannot find vm {0}",
     ErrorCode.REPLACE_VM_EMPTY : "Replace VM cannot be empty",

--- a/esx_service/utils/error_code.py
+++ b/esx_service/utils/error_code.py
@@ -23,7 +23,7 @@ class ErrorCode:
     TENANT_SET_ACCESS_PRIVILEGES_FAILED = 6
     TENANT_GET_FAILED = 7
     TENANT_NAME_INVALID = 8
-    TENANT_NOT_EMPTY = 9 # only used in multinode mode
+    TENANT_NOT_EMPTY = 9
     # Tenant related error code end
 
     # VM related error code start
@@ -88,7 +88,7 @@ error_code_to_message = {
     ErrorCode.TENANT_SET_ACCESS_PRIVILEGES_FAILED : "Vmgroup {0} set access privileges on datastore {1} failed with err: {2}",
     ErrorCode.TENANT_GET_FAILED : "Get vmgroup {0} failed",
     ErrorCode.TENANT_NAME_INVALID : "Vmgroup name {0} is invalid, only {1} is allowed",
-    ErrorCode.TENANT_NOT_EMPTY : "Cannot delete non-empty vmgroup {0} in MultiNode mode. Remove VMs from the vmgroup before deleting it.",
+    ErrorCode.TENANT_NOT_EMPTY : "Cannot delete non-empty vmgroup {0}. Remove VMs from the vmgroup before deleting it.",
 
     ErrorCode.VM_NOT_FOUND : "Cannot find vm {0}",
     ErrorCode.REPLACE_VM_EMPTY : "Replace VM cannot be empty",

--- a/esx_service/utils/test_utils.py
+++ b/esx_service/utils/test_utils.py
@@ -163,3 +163,11 @@ def create_default_tenant_and_privileges(test_obj):
             logging.warning(error_info.msg)
         test_obj.assertEqual(error_info, None)
 
+def cleanup_tenant(name):
+    error_info, vms = auth_api._tenant_vm_ls(name)
+    if vms:
+        vm_names = [vm_name for (_, vm_name) in vms]
+        auth_api._tenant_vm_rm(name=name,
+                               vm_list=vm_names)
+    auth_api._tenant_rm(name=name,
+                        remove_volumes=True)

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -395,6 +395,15 @@ class ValidationTestCase(unittest.TestCase):
                 vmdk_ops.validate_opts(opts, self.path)
 
 
+def cleanup_tenant(name):
+    error_info, vms = auth_api._tenant_vm_ls(name)
+    if vms:
+        vm_names = [vm_name for (_, vm_name) in vms]
+        auth_api._tenant_vm_rm(name=name,
+                               vm_list=vm_names)
+    auth_api._tenant_rm(name=name,
+                        remove_volumes=True)
+
 class VmdkAttachDetachTestCase(unittest.TestCase):
     """ Unit test for VMDK Attach and Detach ops """
 
@@ -737,18 +746,10 @@ class VmdkTenantTestCase(unittest.TestCase):
                     logging.debug("cleanup: remove volume %s", vmdk_path)
                     vmdk_ops.removeVMDK(vmdk_path)
 
-        # cleanup existing tenant
-        error_info = auth_api._tenant_rm(
-                                         name=self.tenant1_name,
-                                         remove_volumes=True)
-
-        error_info = auth_api._tenant_rm(
-                                         name=self.tenant1_new_name,
-                                         remove_volumes=True)
-
-        error_info = auth_api._tenant_rm(
-                                         name=self.tenant2_name,
-                                         remove_volumes=True)
+        # cleanup existing tenants
+        cleanup_tenant(self.tenant1_name)
+        cleanup_tenant(self.tenant1_new_name)
+        cleanup_tenant(self.tenant2_name)
 
         # remove VM
         si = vmdk_ops.get_si()

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -394,25 +394,6 @@ class ValidationTestCase(unittest.TestCase):
             with self.assertRaises(vmdk_ops.ValidationError):
                 vmdk_ops.validate_opts(opts, self.path)
 
-
-def cleanup_tenant(name):
-    error_info, vms = auth_api._tenant_vm_ls(name)
-    if vms:
-        vm_names = [vm_name for (_, vm_name) in vms]
-        auth_api._tenant_vm_rm(name=name,
-                               vm_list=vm_names)
-    auth_api._tenant_rm(name=name,
-                        remove_volumes=True)
-
-def cleanup_tenant(name):
-    error_info, vms = auth_api._tenant_vm_ls(name)
-    if vms:
-        vm_names = [vm_name for (_, vm_name) in vms]
-        auth_api._tenant_vm_rm(name=name,
-                               vm_list=vm_names)
-    auth_api._tenant_rm(name=name,
-                        remove_volumes=True)
-
 class VmdkAttachDetachTestCase(unittest.TestCase):
     """ Unit test for VMDK Attach and Detach ops """
 
@@ -756,9 +737,9 @@ class VmdkTenantTestCase(unittest.TestCase):
                     vmdk_ops.removeVMDK(vmdk_path)
 
         # cleanup existing tenants
-        cleanup_tenant(self.tenant1_name)
-        cleanup_tenant(self.tenant1_new_name)
-        cleanup_tenant(self.tenant2_name)
+        test_utils.cleanup_tenant(self.tenant1_name)
+        test_utils.cleanup_tenant(self.tenant1_new_name)
+        test_utils.cleanup_tenant(self.tenant2_name)
 
         # remove VM
         si = vmdk_ops.get_si()

--- a/plugin/config.json
+++ b/plugin/config.json
@@ -36,7 +36,7 @@
 		}
 	],
 	"Network": {
-		"Type": "none"
+		"Type": ""
 	},
 	"Interface" : {
 		"Types": ["docker.volumedriver/1.0"],


### PR DESCRIPTION
If vmgroup contains VMs, do now allow vmgroup rm. This is due to limitation of ESX host doesn't have information about VM residing on another host. This limitation only happens in MultiNode mode, but to keep consistency, we are enforcing this in both SingleNode and MultiNode.

Following are the test.
Two esx hosts, configured in multinode and each of them have one VMs. They are added to a shared vmgroup.

ESX1:
```
[root@sc2-rdops-vm06-dhcp-219-119:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name sharedVMGroup --vm-list ubuntu-VM0.1 --default-datastore sharedVmfs-0
vmgroup 'sharedVMGroup' is created. Do not forget to run 'vmgroup vm add' to add vm to vmgroup.
[root@sc2-rdops-vm06-dhcp-219-119:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
Uuid                                  Name           Description                Default_datastore  VM_list
------------------------------------  -------------  -------------------------  -----------------  ------------
11111111-1111-1111-1111-111111111111  _DEFAULT       This is a default vmgroup  _VM_DS
b44b173a-cbe6-4d05-ae3c-8c90e3287558  sharedVMGroup                             sharedVmfs-0       ubuntu-VM0.1
```

ESX2
```
[root@sc2-rdops-vm06-dhcp-209-223:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup vm add --name sharedVMGroup --vm-list ubuntu-VM0.2
vmgroup vm add succeeded

[root@sc2-rdops-vm06-dhcp-209-223:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup vm ls --name sharedVMGroup
Uuid                                  Name
------------------------------------  ------------
564d1a2a-8d8e-1c4f-a1b6-dacf99d3e2b0  ubuntu-VM0.1
564db3f0-b9e9-d036-51f2-c83d54edd602  ubuntu-VM0.2

[root@sc2-rdops-vm06-dhcp-209-223:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup rm --name sharedVMGroup
Cannot delete non empty Vmgroup sharedVMGroup in Multinode mode. Remove VMs from the Vmgroup before deleting it.
```

Fixes #1188