### PR TITLE
Avoiding redundant mounts by using /proc/mount info

### DIFF
--- a/misc/scripts/refcnt_test.sh
+++ b/misc/scripts/refcnt_test.sh
@@ -67,10 +67,11 @@ function check_files {
 }
 
 function check_recovery_record {
-    line=`tail -10 /var/log/docker-volume-vsphere.log | $GREP 'Volume name=' | $GREP 'mounted=true'`
-    expected="name=$vname count=$count mounted=true"
+    # restart generates some log.
+    line=`tail -50 /var/log/docker-volume-vsphere.log | $GREP 'Volume name=' | $GREP 'mounted=true'`
+    expected="count=$count mounted=true"
 
-    echo $line | $GREP -q "$expected" ; if [ $? -ne 0 ] ; then
+    echo $line | $GREP "$vname" | $GREP -q "$expected" ; if [ $? -ne 0 ] ; then
        echo Found:  \"$line\"
        echo Expected pattern: \"$expected\"
        return 1
@@ -80,20 +81,20 @@ function check_recovery_record {
 
 function test_crash_recovery {
     timeout=$1
-    echo "Checking recovery for VMDK plugin kill -9"
-    kill -9 `pidof docker-volume-vsphere`
-    until pids=$(pidof docker-volume-vsphere)
+    echo "Checking recovery through docker kill"
+    pkill -9 dockerd
+    until pids=$(pidof dockerd)
     do
-        echo "Waiting for docker-volume-vsphere to restart"
+        echo "Waiting for docker to restart"
         sleep 1
     done
 
     echo "Waiting for plugin init"
-    sleep 3
+    sleep 5
     sync  # give log the time to flush
     wait_for check_recovery_record $timeout
     if [ "$?" -ne 0 ] ; then
-        echo PLUGIN RESTART TEST FAILED. Did not find proper recovery record
+        echo DOCKER RESTART TEST FAILED. Did not find proper recovery record
         exit 1
     fi
 }
@@ -115,8 +116,8 @@ fi
 echo "$(docker volume ls)"
 for i in `seq 1 $count`
 do
-  $DOCKER run -d -v $vname:/v busybox sh -c "touch /v/file$i; sync ; \
-      sleep $timeout"
+  $DOCKER run -d --restart=always -v $vname:/v busybox sh -c "touch /v/file$i; sync ; \
+      while true; do sleep $timeout; done"
 done
 
 echo "Checking the last refcount and mount record"

--- a/misc/scripts/refcnt_test.sh
+++ b/misc/scripts/refcnt_test.sh
@@ -67,7 +67,7 @@ function check_files {
 }
 
 function check_recovery_record {
-    # restart generates some log.
+    # log contains refcounting attempts and after success logs summary.
     line=`tail -50 /var/log/docker-volume-vsphere.log | $GREP 'Volume name=' | $GREP 'mounted=true'`
     expected="count=$count mounted=true"
 
@@ -82,6 +82,7 @@ function check_recovery_record {
 function test_crash_recovery {
     timeout=$1
     echo "Checking recovery through docker kill"
+    # kill docker daemon forcefully
     pkill -9 dockerd
     until pids=$(pidof dockerd)
     do
@@ -116,6 +117,7 @@ fi
 echo "$(docker volume ls)"
 for i in `seq 1 $count`
 do
+  # run containers with restart flag so they restart after docker restart
   $DOCKER run -d --restart=always -v $vname:/v busybox sh -c "touch /v/file$i; sync ; \
       while true; do sleep $timeout; done"
 done

--- a/vmdk_plugin/Makefile
+++ b/vmdk_plugin/Makefile
@@ -93,7 +93,7 @@ VMDKOPS_MODULE_SRC = $(VMDKOPS_MODULE)/*.go $(VMCI_SRC)
 
 # All sources. We rebuild if anything changes here
 SRC = main.go log_formatter.go utils/refcount/refcnt.go \
-	utils/fs/fs.go utils/config/config.go utils/TestInputParamsUtil.go \
+	utils/fs/fs.go utils/config/config.go utils/TestInputParamsUtil.go utils/plugin_utils/plugin_utils.go\
 	drivers/photon/photon_driver.go drivers/vmdk/vmdk_driver.go
 
 # Canned recipe

--- a/vmdk_plugin/drivers/driver.go
+++ b/vmdk_plugin/drivers/driver.go
@@ -20,4 +20,5 @@ type VolumeDriver interface {
 	MountVolume(string, string, string, bool, bool) (string, error)
 	UnmountVolume(string) error
 	GetVolume(string) (map[string]interface{}, error)
+	VolumesInRefMap() []string
 }

--- a/vmdk_plugin/drivers/photon/photon_driver.go
+++ b/vmdk_plugin/drivers/photon/photon_driver.go
@@ -363,20 +363,21 @@ func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isRead
 	return mountpoint, fs.MountWithID(mountpoint, fstype, id, isReadOnly)
 }
 
-//VolumesInRefMap - get list of volumes from refmap
+// VolumesInRefMap - get list of volumes names from refmap
+// names are in format volume@datastore
 func (d *VolumeDriver) VolumesInRefMap() []string {
 	return d.refCounts.GetVolumeNames()
 }
 
 // private function that does the job of mounting volume in conjunction with refcounting
 func (d *VolumeDriver) processMount(r volume.MountRequest) volume.Response {
-	volname, volumeMeta, err := plugin_utils.GetFullNameAndMeta(r.Name, "", d)
+	volumeInfo, err := plugin_utils.GetVolumeInfo(r.Name, "", d)
 	if err != nil {
-		log.Errorf("Unable to get full name for volume %s. err:%v", r.Name, err)
+		log.Errorf("Unable to get volume info for volume %s. err:%v", r.Name, err)
 		return volume.Response{Err: err.Error()}
 	}
-	r.Name = volname
-	d.mountIDtoName[r.ID] = volname
+	r.Name = volumeInfo.VolumeName
+	d.mountIDtoName[r.ID] = r.Name
 
 	// If the volume is already mounted , just increase the refcount.
 	// Note: for new keys, GO maps return zero value, so no need for if_exists.
@@ -395,8 +396,10 @@ func (d *VolumeDriver) processMount(r volume.MountRequest) volume.Response {
 	}
 
 	// get volume metadata if required
+	volumeMeta := volumeInfo.VolumeMeta
 	if volumeMeta == nil {
 		if volumeMeta, err = d.GetVolume(r.Name); err != nil {
+			d.decrRefCount(r.Name)
 			return volume.Response{Err: err.Error()}
 		}
 	}
@@ -642,12 +645,12 @@ func (d *VolumeDriver) Unmount(r volume.UnmountRequest) volume.Response {
 		r.Name = fullVolName
 		delete(d.mountIDtoName, r.ID) //cleanup the map
 	} else {
-		fullVolName, _, err := plugin_utils.GetFullNameAndMeta(r.Name, "", d)
+		volumeInfo, err := plugin_utils.GetVolumeInfo(r.Name, "", d)
 		if err != nil {
-			log.Errorf("Unable to get full name for volume %s. err:%v", r.Name, err)
+			log.Errorf("Unable to get volume info for volume %s. err:%v", r.Name, err)
 			return volume.Response{Err: err.Error()}
 		}
-		r.Name = fullVolName
+		r.Name = volumeInfo.VolumeName
 	}
 
 	// if refcount has been succcessful, Normal flow.

--- a/vmdk_plugin/drivers/photon/photon_driver.go
+++ b/vmdk_plugin/drivers/photon/photon_driver.go
@@ -363,20 +363,20 @@ func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isRead
 	return mountpoint, fs.MountWithID(mountpoint, fstype, id, isReadOnly)
 }
 
+//VolumesInRefMap - get list of volumes from refmap
+func (d *VolumeDriver) VolumesInRefMap() []string {
+	return d.refCounts.GetVolumeNames()
+}
+
 // private function that does the job of mounting volume in conjunction with refcounting
 func (d *VolumeDriver) processMount(r volume.MountRequest) volume.Response {
-	// get volume metadata
-	volumeMeta, err := d.GetVolume(r.Name)
-
-	if err != nil {
-		return volume.Response{Err: err.Error()}
-	}
-
-	r.Name, err = plugin_utils.GetFullVolumeName(r.Name, volumeMeta["datastore"].(string), d)
+	volname, volumeMeta, err := plugin_utils.GetFullNameAndMeta(r.Name, "", d)
 	if err != nil {
 		log.Errorf("Unable to get full name for volume %s. err:%v", r.Name, err)
 		return volume.Response{Err: err.Error()}
 	}
+	r.Name = volname
+	d.mountIDtoName[r.ID] = volname
 
 	// If the volume is already mounted , just increase the refcount.
 	// Note: for new keys, GO maps return zero value, so no need for if_exists.
@@ -392,6 +392,13 @@ func (d *VolumeDriver) processMount(r volume.MountRequest) volume.Response {
 	if plugin_utils.AlreadyMounted(r.Name, d.mountRoot) {
 		log.WithFields(log.Fields{"name": r.Name}).Info("Already mounted, skipping mount. ")
 		return volume.Response{Mountpoint: d.getMountPoint(r.Name)}
+	}
+
+	// get volume metadata if required
+	if volumeMeta == nil {
+		if volumeMeta, err = d.GetVolume(r.Name); err != nil {
+			return volume.Response{Err: err.Error()}
+		}
 	}
 
 	fstype, exists := volumeMeta[fsTypeTag]
@@ -635,7 +642,7 @@ func (d *VolumeDriver) Unmount(r volume.UnmountRequest) volume.Response {
 		r.Name = fullVolName
 		delete(d.mountIDtoName, r.ID) //cleanup the map
 	} else {
-		fullVolName, err := plugin_utils.GetFullVolumeName(r.Name, "", d)
+		fullVolName, _, err := plugin_utils.GetFullNameAndMeta(r.Name, "", d)
 		if err != nil {
 			log.Errorf("Unable to get full name for volume %s. err:%v", r.Name, err)
 			return volume.Response{Err: err.Error()}

--- a/vmdk_plugin/drivers/vmdk/vmdk_driver.go
+++ b/vmdk_plugin/drivers/vmdk/vmdk_driver.go
@@ -92,6 +92,11 @@ func NewVolumeDriver(port int, useMockEsx bool, mountDir string, driverName stri
 	return d
 }
 
+//VolumesInRefMap - get list of volumes from refmap
+func (d *VolumeDriver) VolumesInRefMap() []string {
+	return d.refCounts.GetVolumeNames()
+}
+
 // In following three operations on refcount, if refcount
 // map hasn't been initialized, return 1 to prevent detach and remove.
 
@@ -215,18 +220,13 @@ func (d *VolumeDriver) UnmountVolume(name string) error {
 
 // private function that does the job of mounting volume in conjunction with refcounting
 func (d *VolumeDriver) processMount(r volume.MountRequest) volume.Response {
-	// get volume metadata
-	volumeMeta, err := d.ops.Get(r.Name)
-
-	if err != nil {
-		return volume.Response{Err: err.Error()}
-	}
-
-	r.Name, err = plugin_utils.GetFullVolumeName(r.Name, volumeMeta["datastore"].(string), d)
+	volname, volumeMeta, err := plugin_utils.GetFullNameAndMeta(r.Name, "", d)
 	if err != nil {
 		log.Errorf("Unable to get full name for volume %s. err:%v", r.Name, err)
 		return volume.Response{Err: err.Error()}
 	}
+	r.Name = volname
+	d.mountIDtoName[r.ID] = volname
 
 	// If the volume is already mounted , just increase the refcount.
 	// Note: for new keys, GO maps return zero value, so no need for if_exists.
@@ -242,6 +242,13 @@ func (d *VolumeDriver) processMount(r volume.MountRequest) volume.Response {
 	if plugin_utils.AlreadyMounted(r.Name, mountRoot) {
 		log.WithFields(log.Fields{"name": r.Name}).Info("Already mounted, skipping mount. ")
 		return volume.Response{Mountpoint: getMountPoint(r.Name)}
+	}
+
+	// get volume metadata if required
+	if volumeMeta == nil {
+		if volumeMeta, err = d.ops.Get(r.Name); err != nil {
+			return volume.Response{Err: err.Error()}
+		}
 	}
 
 	fstype := fs.FstypeDefault
@@ -479,7 +486,7 @@ func (d *VolumeDriver) Unmount(r volume.UnmountRequest) volume.Response {
 		r.Name = fullVolName
 		delete(d.mountIDtoName, r.ID) //cleanup the map
 	} else {
-		fullVolName, err := plugin_utils.GetFullVolumeName(r.Name, "", d)
+		fullVolName, _, err := plugin_utils.GetFullNameAndMeta(r.Name, "", d)
 		if err != nil {
 			log.Errorf("Unable to get full name for volume %s. err:%v", r.Name, err)
 			return volume.Response{Err: err.Error()}

--- a/vmdk_plugin/utils/plugin_utils/plugin_utils.go
+++ b/vmdk_plugin/utils/plugin_utils/plugin_utils.go
@@ -1,0 +1,85 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin_utils
+
+// This file holds utility/helper methods required in plugin module
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+const (
+	linuxMountsFile = "/proc/mounts"
+)
+
+// GetMountInfo - return a map of mounted volumes and devices
+func GetMountInfo(mountRoot string) (map[string]string, error) {
+	volumeMap := make(map[string]string)
+	data, err := ioutil.ReadFile(linuxMountsFile)
+
+	if err != nil {
+		log.Errorf("Can't get info from %s (%v)", linuxMountsFile, err)
+		return volumeMap, err
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		field := strings.Fields(line)
+		if len(field) < 2 {
+			continue // skip empty line and lines too short to have our mount
+		}
+		// fields format: [/dev/sdb /mnt/vmdk/vol1 ext2 rw,relatime 0 0]
+		if filepath.Dir(field[1]) != mountRoot {
+			continue
+		}
+		volumeMap[filepath.Base(field[1])] = field[0]
+	}
+	return volumeMap, nil
+}
+
+// CheckAlreadyMounted - check if volume is already mounted on the mountRoot
+func CheckAlreadyMounted(name string, mountRoot string) bool {
+	volumeMap, err := GetMountInfo(mountRoot)
+
+	if err != nil {
+		return false
+	}
+
+	if _, ok := volumeMap[name]; ok {
+		return true
+	}
+	return false
+}
+
+// GetDatastore - get datastore from volume metadata
+// Note "datastore" key is defined in vmdkops service
+func GetDatastore(name string, volumeMeta map[string]interface{}) string {
+	datastore, _ := volumeMeta["datastore"].(string)
+	return datastore
+}
+
+// GetFullVolumeName - append datastore to the volume name
+func GetFullVolumeName(name string, datastore string) string {
+	s := []string{name, datastore}
+	return strings.Join(s, "@")
+}
+
+// IsFullVolumeName - return if name is full volume name i.e. volume@datastore
+func IsFullVolumeName(name string) bool {
+	return strings.ContainsAny(name, "@")
+}

--- a/vmdk_plugin/utils/plugin_utils/plugin_utils.go
+++ b/vmdk_plugin/utils/plugin_utils/plugin_utils.go
@@ -118,8 +118,9 @@ func GetNameFromRefmap(volName string, d drivers.VolumeDriver) string {
 	return fullname
 }
 
-// GetVolumeInfo - return VolumeInfo which a qualified volume name,
-// datastore name volume metadata if retrieved
+// GetVolumeInfo - return VolumeInfo with a qualified volume name.
+// Optionally returns datastore and volume metadata if retrieved from ESX.
+// If Volume Metadata is nil then caller can use getVolume()
 func GetVolumeInfo(name string, datastoreName string, d drivers.VolumeDriver) (*VolumeInfo, error) {
 	// if fullname already, return
 	if IsFullVolName(name) {

--- a/vmdk_plugin/utils/refcount/refcnt.go
+++ b/vmdk_plugin/utils/refcount/refcnt.go
@@ -264,6 +264,19 @@ func (r *RefCountsMap) GetCount(vol string) uint {
 	return rc.count
 }
 
+//GetVolumeNames - return volume names of entries in refmap
+func (r *RefCountsMap) GetVolumeNames() []string {
+	r.mtx.RLock()
+	defer r.mtx.RUnlock()
+	var volumeList []string
+
+	for k := range r.refMap {
+		volumeList = append(volumeList, k)
+	}
+
+	return volumeList
+}
+
 // Incr refCount for the volume vol. Creates new entry if needed.
 func (r *RefCountsMap) Incr(vol string) uint {
 	// Locks the RefCountsMap
@@ -391,14 +404,14 @@ func (r *RefCountsMap) discoverAndSync(c *client.Client, d drivers.VolumeDriver)
 			volname := mount.Name
 			// gets hit once to retrieve the default datastore. datastoreName is reused henceforth
 			if datastoreName == "" {
-				datastoreName, err = plugin_utils.GetDatastore(volname, d)
+				datastoreName, _, err = plugin_utils.GetDatastore(volname, d)
 				if err != nil {
 					log.Errorf("Unable to get datastore for volume %s. err:%v", volname, err)
 					return err
 				}
 			}
 
-			volname, err = plugin_utils.GetFullVolumeName(volname, datastoreName, d)
+			volname, _, err = plugin_utils.GetFullNameAndMeta(volname, datastoreName, d)
 			if err != nil {
 				log.Errorf("Unable to get full name for volume %s. err:%v", volname, err)
 				return err

--- a/vmdk_plugin/utils/refcount/refcnt.go
+++ b/vmdk_plugin/utils/refcount/refcnt.go
@@ -264,7 +264,7 @@ func (r *RefCountsMap) GetCount(vol string) uint {
 	return rc.count
 }
 
-//GetVolumeNames - return volume names of entries in refmap
+// GetVolumeNames - return fully qualified volume names from refMap
 func (r *RefCountsMap) GetVolumeNames() []string {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()

--- a/vmdk_plugin/utils/refcount/refcnt.go
+++ b/vmdk_plugin/utils/refcount/refcnt.go
@@ -73,8 +73,6 @@ package refcount
 
 import (
 	"fmt"
-	"io/ioutil"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -84,6 +82,7 @@ import (
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
 	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/drivers"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/plugin_utils"
 	"golang.org/x/net/context"
 )
 
@@ -119,9 +118,9 @@ type RefCountsMap struct {
 	refMap map[string]*refCount // Map of refCounts
 	mtx    *sync.RWMutex        // Synchronizes RefCountsMap ops
 
-	refcntInitSuccess bool // save refcounting success
-	isDirty           bool // flag to check reconciling has been interrupted
-	StateMtx *sync.Mutex   // (Exported) Synchronizes refcounting between mount/unmount and refcounting thread
+	refcntInitSuccess bool        // save refcounting success
+	isDirty           bool        // flag to check reconciling has been interrupted
+	StateMtx          *sync.Mutex // (Exported) Synchronizes refcounting between mount/unmount and refcounting thread
 }
 
 var (
@@ -366,6 +365,9 @@ func (r *RefCountsMap) discoverAndSync(c *client.Client, d drivers.VolumeDriver)
 		return err
 	}
 
+	// use same datastore for all volumes with short names
+	datastore := ""
+
 	log.Infof("Found %d running or paused containers", len(containers))
 	for _, ct := range containers {
 
@@ -383,12 +385,20 @@ func (r *RefCountsMap) discoverAndSync(c *client.Client, d drivers.VolumeDriver)
 			return err
 		}
 		log.Debugf("  Mounts for %v", ct.Names)
-
 		for _, mount := range containerJSONInfo.Mounts {
-			// check if the mount location belongs to vsphere plugin
-			if matchNameforVMDK(mount.Source) {
-				r.Incr(mount.Name)
-				log.Infof("  name=%v (driver=%s source=%s) (%v)",
+			// check if the mount location belongs to vmdk plugin
+			if matchNameforVMDK(mount.Source) != true {
+				continue
+			}
+			volname := mount.Name
+			if plugin_utils.IsFullVolumeName(volname) != true {
+				if datastore == "" {
+					volumeMeta, _ := d.GetVolume(volname)
+					datastore = plugin_utils.GetDatastore(volname, volumeMeta)
+				}
+				volname = plugin_utils.GetFullVolumeName(volname, datastore)
+				r.Incr(volname)
+				log.Debugf("name=%v (driver=%s source=%s) (%v)",
 					mount.Name, mount.Driver, mount.Source, mount)
 			}
 		}
@@ -407,7 +417,7 @@ func (r *RefCountsMap) discoverAndSync(c *client.Client, d drivers.VolumeDriver)
 	// Check that refcounts and actual mount info from Linux match
 	// If they don't, unmount unneeded stuff, or yell if something is
 	// not mounted but should be (it's error. we should not get there)
-	r.getMountInfo()
+	r.updateRefMap()
 	r.syncMountsWithRefCounters(d)
 	// mark reconciling success so that further unmounts can instantly be processed
 	r.refcntInitSuccess = true
@@ -479,33 +489,24 @@ func (r *RefCountsMap) syncMountsWithRefCounters(d drivers.VolumeDriver) {
 	}
 }
 
-// scans /proc/mounts and updates refcount map witn mounted volumes
-func (r *RefCountsMap) getMountInfo() error {
+// updates refcount map with mounted volumes using mount info
+func (r *RefCountsMap) updateRefMap() error {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 
-	data, err := ioutil.ReadFile(linuxMountsFile)
+	volumeMap, err := plugin_utils.GetMountInfo(mountRoot)
+
 	if err != nil {
-		log.Errorf("Can't get info from %s (%v)", linuxMountsFile, err)
 		return err
 	}
 
-	for _, line := range strings.Split(string(data), "\n") {
-		field := strings.Fields(line)
-		if len(field) < 2 {
-			continue // skip empty line and lines too short to have our mount
-		}
-		// fields format: [/dev/sdb /mnt/vmdk/vol1 ext2 rw,relatime 0 0]
-		if filepath.Dir(field[1]) != mountRoot {
-			continue
-		}
-		volName := filepath.Base(field[1])
+	for volName, dev := range volumeMap {
 		refInfo := r.refMap[volName]
 		if refInfo == nil {
 			refInfo = newRefCount()
 		}
 		refInfo.mounted = true
-		refInfo.dev = field[0]
+		refInfo.dev = dev
 		r.refMap[volName] = refInfo
 		log.Debugf("Found '%s' in /proc/mount, ref=(%#v)", volName, refInfo)
 	}


### PR DESCRIPTION
1. Convert a short volume name to the long one. If required to a trip to vmdkops service
2. In every mount request, check if the volume is already mounted (info of /proc/mount)
3. refcount test which kills docker and verifies refcounting

Fixes #1220 

Testing:
The refcount test added kills dockerd and verifies refcount (after refcount has been initialized) through logs.

Verified the same manually by forcefully disabling plugin and enabling it.