### PR TITLE
Handling dockvols symlink on vsanDatastore to update volume status on VM poweroff event

### DIFF
--- a/esx_service/utils/vmdk_utils.py
+++ b/esx_service/utils/vmdk_utils.py
@@ -336,7 +336,7 @@ def get_vm_config_path(vm_name):
 
 def find_dvs_volume(dev):
     """
-    If the @param dev is a dvs managed volume, return its vmdk path
+    If the @param dev (type is vim.vm.device) a vDVS managed volume, return its vmdk path
     """
     # if device is not a virtual disk, skip this device
     if type(dev) != vim.vm.device.VirtualDisk:
@@ -345,20 +345,20 @@ def find_dvs_volume(dev):
     # Filename format is as follows:
     # "[<datastore name>] <parent-directory>/tenant/<vmdk-descriptor-name>"
     # Trim the datastore name and keep disk path.
-    datastore, disk_path = dev.backing.fileName.rsplit("]", 1)
+    datastore_name, disk_path = dev.backing.fileName.rsplit("]", 1)
     logging.info("backing disk name is %s", disk_path)
     # name formatting to remove unwanted characters
-    datastore = datastore[1:]
+    datastore_name = datastore_name[1:]
     disk_path = disk_path.lstrip()
 
     # find the dockvols dir on current datastore and resolve symlinks if any
     dvol_dir_path = os.path.realpath(os.path.join(VOLUME_ROOT,
-                                                  datastore, vmdk_ops.DOCK_VOLS_DIR))
+                                                  datastore_name, vmdk_ops.DOCK_VOLS_DIR))
     dvol_dir = os.path.basename(dvol_dir_path)
 
     if disk_path.startswith(dvol_dir):
         # returning the vmdk path for vDVS volume
-        return os.path.join(VOLUME_ROOT, datastore, disk_path)
+        return os.path.join(VOLUME_ROOT, datastore_name, disk_path)
 
     return None
 

--- a/esx_service/utils/vmdk_utils.py
+++ b/esx_service/utils/vmdk_utils.py
@@ -64,6 +64,9 @@ LSOF_CMD = "/bin/vmkvsitools lsof"
 VMDK_RETRY_COUNT = 5
 VMDK_RETRY_SLEEP = 1
 
+# root for all the volumes
+VOLUME_ROOT = "/vmfs/volumes/"
+
 # For managing resource locks.
 lockManager = threadutils.LockManager()
 
@@ -348,9 +351,14 @@ def find_dvs_volume(dev):
     datastore = datastore[1:]
     disk_path = disk_path.lstrip()
 
-    if disk_path.startswith(vmdk_ops.DOCK_VOLS_DIR):
-        # returning the vmdk path for dvs volume
-        return os.path.join("/vmfs/volumes/", datastore, disk_path)
+    # find the dockvols dir on current datastore and resolve symlinks if any
+    dvol_dir_path = os.path.realpath(os.path.join(VOLUME_ROOT,
+                                                  datastore, vmdk_ops.DOCK_VOLS_DIR))
+    dvol_dir = os.path.basename(dvol_dir_path)
+
+    if disk_path.startswith(dvol_dir):
+        # returning the vmdk path for vDVS volume
+        return os.path.join(VOLUME_ROOT, datastore, disk_path)
 
     return None
 


### PR DESCRIPTION
Resolving the symlinks for dockvols directory for a datastore and using it to decide if it is a vDVS volume.

Fixes #1233 

Testing:

1. Attach a vsan and shared-Vmfs volume to a container.
```
root@sc-rdops-vm02-dhcp-52-237:~# docker volume ls
DRIVER              VOLUME NAME
vsphere:latest      vol1@vsanDatastore
vsphere:latest      vol2@sharedVmfs-0
root@sc-rdops-vm02-dhcp-52-237:~# docker run -it -v vol1@vsanDatastore:/vol1 -v vol2@sharedVmfs-0:/vol2 busybox
/ #
```
```
[root@sc2-rdops-vm03-dhcp-126-220:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py volume ls
Volume  Datastore      VMGroup   Capacity  Used  Filesystem  Policy          Disk Format  Attached-to   Access      Attach-as               Created By    Created Date
------  -------------  --------  --------  ----  ----------  --------------  -----------  ------------  ----------  ----------------------  ------------  ------------------------
vol2    sharedVmfs-0   _DEFAULT  100MB     15MB  ext4        N/A             thin         ubuntu-VM0.0  read-write  independent_persistent  ubuntu-VM0.0  Wed May 10 18:33:22 2017
vol1    vsanDatastore  _DEFAULT  100MB     80MB  ext4        [VSAN default]  thin         ubuntu-VM0.0  read-write  independent_persistent  ubuntu-VM0.0  Wed May 10 18:32:53 2017
```
2. Kill the VM
3. check the status of volumes
```
[root@sc2-rdops-vm03-dhcp-126-220:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py volume ls
Volume  Datastore      VMGroup   Capacity  Used  Filesystem  Policy          Disk Format  Attached-to  Access      Attach-as               Created By    Created Date
------  -------------  --------  --------  ----  ----------  --------------  -----------  -----------  ----------  ----------------------  ------------  ------------------------
vol2    sharedVmfs-0   _DEFAULT  100MB     15MB  ext4        N/A             thin         detached     read-write  independent_persistent  ubuntu-VM0.0  Wed May 10 18:33:22 2017
vol1    vsanDatastore  _DEFAULT  100MB     80MB  ext4        [VSAN default]  thin         detached     read-write  independent_persistent  ubuntu-VM0.0  Wed May 10 18:32:53 2017
```