### PR TITLE
Reduce log noise [SKIP CI]

### DIFF
--- a/esx_service/utils/auth.py
+++ b/esx_service/utils/auth.py
@@ -456,8 +456,8 @@ def authorize(vm_uuid, datastore_url, cmd, opts):
                       tenant_name, datastore_url, privileges, result)
 
         if result is None:
-            logging.info("cmd=%s opts=%s vmgroup=%s datastore_url=%s is allowed to execute",
-                         cmd, opts, tenant_name, datastore_url)
+            logging.info("db_mode='%s' cmd=%s opts=%s vmgroup=%s datastore_url=%s is allowed to execute",
+                         _auth_mgr.mode, cmd, opts, tenant_name, datastore_url)
 
         return result, tenant_uuid, tenant_name
 

--- a/esx_service/utils/auth_data.py
+++ b/esx_service/utils/auth_data.py
@@ -678,10 +678,10 @@ class AuthorizationDataManager:
         """
 
 
-        logging.info("Checking DB mode for %s...", self.db_path)
+        logging.debug("Checking DB mode for %s...", self.db_path)
         # check if the path exists (without following symlinks)
         if not os.path.lexists(self.db_path):
-            logging.info(DB_REF + "does not exist. mode NotConfigured")
+            logging.debug(DB_REF + "does not exist. mode NotConfigured")
             return DBMode.NotConfigured
 
         if not os.path.exists(self.db_path):
@@ -693,7 +693,7 @@ class AuthorizationDataManager:
 
         # it's a single node config file. Check if the DB is empty so we can drop it.
         if not os.path.islink(self.db_path):
-            logging.info(DB_REF + "exists and has modifications, mode SingleNode")
+            logging.debug(DB_REF + "exists and has modifications, mode SingleNode")
             return DBMode.SingleNode
 
         # let's check if the db content seems good
@@ -702,7 +702,7 @@ class AuthorizationDataManager:
             logging.error(DB_REF + "Location {}, error: {}".format(self.db_path, err))
             return DBMode.BrokenLink
 
-        logging.info(DB_REF + "found. maj_ver={} min_ver={} mode MultiNode".format(major, minor))
+        logging.debug(DB_REF + "found. maj_ver={} min_ver={} mode MultiNode".format(major, minor))
         return DBMode.MultiNode
 
     def allow_all_access(self):


### PR DESCRIPTION
Changed DB discovery logs from INFO to Debug. Otherwise, seeing following log messages for every incoming request;

```
09/20/16 03:18:27 1150265 [MainThread] [INFO   ] Started new thread : 92556144 with target <function execRequestThread at 0x3bdeb684> and args (11, 252313, '{"cmd":"detach","details":{"Name":"pg_data"},"version":"2"}')
09/20/16 03:18:27 1150265 [Thread-63] [INFO   ] Checking DB mode for /etc/vmware/vmdkops/auth-db...
09/20/16 03:18:27 1150265 [Thread-63] [INFO   ] Config DB exists and has modifications, mode SingleNode
09/20/16 03:18:27 1150265 [Thread-63] [INFO   ] cmd=detach opts={} vmgroup=_DEFAULT datastore_url=/vmfs/volumes/57473702-8b550986-70c0-000c290799f4 is allowed to execute
```