### PR TITLE
Support shared volumes with NFS [SKIP CI]

### DIFF
--- a/plugin/Dockerfile
+++ b/plugin/Dockerfile
@@ -9,7 +9,7 @@
 
 FROM alpine:3.5
 
-RUN apk update ; apk add e2fsprogs xfsprogs
+RUN apk update ; apk add e2fsprogs xfsprogs; apk add nfs-utils
 RUN mkdir -p /mnt/vmdk
 COPY docker-volume-vsphere /usr/bin
 CMD ["/usr/bin/docker-volume-vsphere"]

--- a/vmdk_plugin/Makefile
+++ b/vmdk_plugin/Makefile
@@ -97,7 +97,7 @@ VMDKOPS_MODULE_SRC = $(VMDKOPS_MODULE)/*.go $(VMCI_SRC)
 # All sources. We rebuild if anything changes here
 SRC = main.go log_formatter.go utils/refcount/refcnt.go \
 	utils/fs/fs.go utils/config/config.go utils/plugin_utils/plugin_utils.go\
-	drivers/photon/photon_driver.go drivers/vmdk/vmdk_driver.go
+	drivers/photon/photon_driver.go drivers/vmdk/vmdk_driver.go drivers/vsphere/vsphere_driver.go
 
 TEST_SRC = ../tests/utils/inputparams/TestInputParamsUtil.go \
 	../tests/utils/dockercli/VolumeCreationTestUtil.go \

--- a/vmdk_plugin/drivers/network/network_driver.go
+++ b/vmdk_plugin/drivers/network/network_driver.go
@@ -1,0 +1,380 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+//
+// NFS backed  VolumeImpl Driver.
+//
+// Provide support for NFS based file backed volumes.
+//
+
+import (
+	"errors"
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/go-plugins-helpers/volume"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/drivers"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/config"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/fs"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/plugin_utils"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	fsType      = "nfs"
+	networkRoot = "remote/dockvols/"
+	defaultPerm = 0775
+	// Vol stats
+	stat_size  = "Size(bytes)"
+	stat_mtime = "ModifiedTime"
+	stat_mode  = "Mode"
+	stat_path  = "Path"
+	stat_ctime = "CreateTime"
+	stat_atime = "AccessTime"
+	stat_ucnt  = "Current user count"
+)
+
+type mountedDir struct {
+	volsDir    string
+	remotePath string
+}
+
+// VolumeImplDriver - NFS based volume driver meta-data
+type VolumeImplDriver struct {
+	config       config.Config
+	mountRoot    string
+	volDriver    drivers.VolumeDriver
+	defaultLabel string
+	//mountedRdirs []mountedDir // TBD for unmount on cleanup
+}
+
+// NewVolumeImplDriver creates Driver which to real ESX (useMockEsx=False) or a mock
+func Init(vdriver drivers.VolumeDriver, mountDir string, config config.Config) (*VolumeImplDriver, error) {
+	var d *VolumeImplDriver
+
+	// Init all known backends - VMDK and network volume drivers
+	d = new(VolumeImplDriver)
+	d.config = config
+	d.defaultLabel = config.RemoteDirs.Default
+	d.mountRoot = filepath.Join(mountDir, networkRoot)
+	d.volDriver = vdriver
+	return d, nil
+}
+
+// Get info about a single volume
+func (d *VolumeImplDriver) Get(r volume.Request) volume.Response {
+	status, err := d.GetVolume(r.Name)
+	if err != nil {
+		return volume.Response{Err: err.Error()}
+	}
+	mountpoint := d.GetMountPoint(r.Name)
+	return volume.Response{Volume: &volume.Volume{Name: r.Name,
+		Mountpoint: mountpoint,
+		Status:     status}}
+}
+
+func (d *VolumeImplDriver) getVolumeList() ([]string, error) {
+	var volumes []string
+
+	msg := "Failed list volume "
+	for dslabel := range d.config.RemoteDirs.RemoteDirTbl {
+		rdir := d.config.RemoteDirs.RemoteDirTbl[dslabel]
+		if strings.Compare(rdir.FSType, fsType) != 0 {
+			continue
+		}
+
+		// Returns the path under which the named volume is created
+		path, err := d.checkLabelIsMounted(rdir, dslabel)
+		if err != nil {
+			mountErrMsg := msg + " remote dir not accessible " + dslabel + "- "
+			return nil, errors.New(mountErrMsg + err.Error())
+		}
+
+		chkLabel := "@" + dslabel
+		err = filepath.Walk(path, func(wpath string, finfo os.FileInfo, err error) error {
+			if finfo.IsDir() && strings.Contains(finfo.Name(), chkLabel) {
+				volumes = append(volumes, finfo.Name())
+			}
+			return err
+		})
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return volumes, nil
+}
+
+// List volumes known to the driver
+func (d *VolumeImplDriver) List(r volume.Request) ([]*volume.Volume, error) {
+	volumes, err := d.getVolumeList()
+	if err != nil {
+		return nil, err
+	}
+	responseVolumes := make([]*volume.Volume, 0, len(volumes))
+	for _, vol := range volumes {
+		mountpoint := d.GetMountPoint(vol)
+		responseVol := volume.Volume{Name: vol, Mountpoint: mountpoint}
+		responseVolumes = append(responseVolumes, &responseVol)
+	}
+	return responseVolumes, nil
+}
+
+// mountRDirAndGetVolPath - For a given name (volname@label) resolve the remote dir
+// label, mount the remote dir if needed and return the path to the volume folder.
+// Note: volume folder may not be created yet.
+func (d *VolumeImplDriver) mountRDirAndGetVolPath(name string, msg string) (string, error) {
+	dslabel := d.getDSLabel(name)
+
+	if dslabel == "" {
+		return "", errors.New(msg + " unknown label or FS type.")
+	}
+
+	rdir := d.config.RemoteDirs.RemoteDirTbl[dslabel]
+
+	// Returns the path under which the named volume is created
+	path, err := d.checkLabelIsMounted(rdir, dslabel)
+	if err != nil {
+		mountErrMsg := msg + " remote dir not accessible " + dslabel + "- "
+		return "", errors.New(mountErrMsg + err.Error())
+	}
+
+	volpath := filepath.Join(path, strings.Split(name, "@")[0])
+	return volpath, nil
+}
+
+// GetVolume - return volume meta-data, name is like volname@label.
+func (d *VolumeImplDriver) GetVolume(name string) (map[string]interface{}, error) {
+	var volStat map[string]interface{}
+	var size int64
+	var stats syscall.Stat_t
+
+	msg := "Failed Get volume  - " + name
+	volpath, err := d.mountRDirAndGetVolPath(name, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	err = syscall.Lstat(volpath, &stats)
+	if err != nil {
+		return nil, err
+	}
+
+	err = filepath.Walk(volpath, func(wpath string, finfo os.FileInfo, err error) error {
+		if !finfo.IsDir() {
+			size += finfo.Size()
+		}
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Create volume status map
+	volStat[stat_path] = volpath
+	volStat[stat_size] = size
+	volStat[stat_mode] = stats.Mode
+	stat_time := time.Unix(stats.Mtim.Sec, stats.Mtim.Nsec)
+	volStat[stat_mtime] = stat_time.Format(time.UnixDate)
+
+	stat_time = time.Unix(stats.Atim.Sec, stats.Atim.Nsec)
+	volStat[stat_atime] = stat_time.Format(time.UnixDate)
+
+	stat_time = time.Unix(stats.Ctim.Sec, stats.Ctim.Nsec)
+	volStat[stat_ctime] = stat_time.Format(time.UnixDate)
+
+	volStat[stat_ucnt] = d.volDriver.GetRefCount(name)
+
+	return volStat, nil
+}
+
+// MountVolume- name is like volname@label, return the mount path for the volume
+func (d *VolumeImplDriver) MountVolume(name string, fstype string, id string, isReadOnly bool, skipAttach bool) (string, error) {
+	msg := "Failed mount volume  - " + name
+	volpath, err := d.mountRDirAndGetVolPath(name, msg)
+
+	if err != nil {
+		return "", err
+	}
+
+	return volpath, err
+}
+
+// UnmountVolume - nothing to do
+func (d *VolumeImplDriver) UnmountVolume(name string) error {
+	return nil
+}
+
+// getPathsForRDir - resolves the remote dir to a path on the host
+// returns the path to create volumes and the remote path to mount
+func (d *VolumeImplDriver) getPathsForRDir(rdir config.RemoteDir, dslabel string) mountedDir {
+	var vdir, rpath string
+	var pdir *config.RemoteDir
+	var tmpdir config.RemoteDir
+
+	mpath := filepath.Join(d.mountRoot, dslabel)
+
+	// If rdir has a redirect to a parent then use the parent
+	if rdir.Src != "" {
+		// Use the remote dir that the Src references
+		tmpdir = d.config.RemoteDirs.RemoteDirTbl[rdir.Src]
+		pdir = &tmpdir
+	}
+
+	if pdir != nil {
+		// If a parent dir must be used then the volumes are placed
+		// within the volpath of the parent + the volpath for the
+		// label provided
+		vdir = filepath.Join(mpath, pdir.VolPath, rdir.VolPath)
+		rpath = pdir.Path
+	} else {
+		vdir = filepath.Join(mpath, rdir.VolPath)
+		rpath = rdir.Path
+	}
+	return mountedDir{volsDir: vdir, remotePath: rpath}
+}
+
+// checkLabel - resolve label to mount params used to mount remote dir,
+// mount remote dir and create vol-path relative to that.
+func (d *VolumeImplDriver) checkLabelIsMounted(rdir config.RemoteDir, dslabel string) (string, error) {
+	dirPaths := d.getPathsForRDir(rdir, dslabel)
+
+	// Check and mount mountPath
+	mountPath := filepath.Join(d.mountRoot, dslabel)
+	if !plugin_utils.IsMounted(mountPath, d.mountRoot) {
+		err := fs.DoNFSMountCmd(mountPath, rdir.FSType, dirPaths.remotePath, rdir.Args)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// Check and create the vol path under mountPath
+	err := makeVolumeDir(dirPaths.volsDir)
+
+	if err != nil {
+		return "", err
+	}
+
+	return dirPaths.volsDir, err
+}
+
+func makeVolumeDir(path string) error {
+	err := os.MkdirAll(path, defaultPerm)
+	if os.IsExist(err) {
+		return nil
+	}
+	return err
+}
+
+// getDSLabel - return the label for the remote dir from
+// the given name (volname@label), using the default if
+// no label was specified. Check the FS type matches the
+// type supported.
+func (d *VolumeImplDriver) getDSLabel(name string) string {
+	dslabel := plugin_utils.GetDSLabel(name)
+
+	if dslabel == "" {
+		// Use the default label else error
+		dslabel = d.defaultLabel
+	}
+
+	if dslabel == "" {
+		return ""
+	} else {
+		rdir := d.config.RemoteDirs.RemoteDirTbl[dslabel]
+		// TBD - handle Src setting for a remote dir
+		if strings.Compare(rdir.FSType, fsType) != 0 {
+			return ""
+		}
+		return dslabel
+	}
+}
+
+// Create - create a volume.
+func (d *VolumeImplDriver) Create(r volume.Request) volume.Response {
+	// Check if the default label is to be used or pick the
+	// specified label and mount that if not already mounted
+	msg := "Failed create volume  - " + r.Name
+	volpath, err := d.mountRDirAndGetVolPath(r.Name, msg)
+	if err != nil {
+		return volume.Response{Err: err.Error()}
+	}
+	err = makeVolumeDir(volpath)
+	if err != nil {
+		// The remote dir is left mounted there may be other users
+		// already using volumes on this rdir. Or another create or
+		// mount may come by and we don't want to repeat all the
+		// actions again.
+		return volume.Response{Err: err.Error()}
+	}
+
+	return volume.Response{Err: ""}
+}
+
+// Remove - removes individual volume. Docker would call it only if is not using it anymore
+func (d *VolumeImplDriver) Remove(r volume.Request) volume.Response {
+	log.WithFields(log.Fields{"name": r.Name}).Info("Removing volume ")
+	msg := "Failed remove volume  - " + r.Name
+	volpath, err := d.mountRDirAndGetVolPath(r.Name, msg)
+	if err != nil {
+		return volume.Response{Err: err.Error()}
+	}
+	err = os.RemoveAll(volpath)
+	return volume.Response{Err: err.Error()}
+}
+
+// Path - give docker a reminder of the volume mount path
+func (d *VolumeImplDriver) Path(r volume.Request) volume.Response {
+	return volume.Response{Mountpoint: d.GetMountPoint(r.Name)}
+}
+
+// Mount - Provide a volume to docker container - called once per container start.
+func (d *VolumeImplDriver) Mount(r volume.MountRequest, volumeInfo *plugin_utils.VolumeInfo) volume.Response {
+	log.WithFields(log.Fields{"name": r.Name}).Info("Mounting volume ")
+	path, err := d.MountVolume(r.Name, "", "", true, true)
+
+	if err != nil {
+		return volume.Response{Err: err.Error()}
+	}
+	return volume.Response{Mountpoint: path}
+}
+
+// Unmount request from Docker. If mount refcount is drop to 0.
+// Unmount and detach from VM
+func (d *VolumeImplDriver) Unmount(r volume.UnmountRequest) volume.Response {
+	log.WithFields(log.Fields{"name": r.Name}).Info("Unmounting Volume ")
+	return volume.Response{Err: ""}
+}
+
+func (d *VolumeImplDriver) GetMountPoint(name string) string {
+	dslabel := d.getDSLabel(name)
+	rdir := d.config.RemoteDirs.RemoteDirTbl[dslabel]
+	rpath := d.getPathsForRDir(rdir, dslabel)
+	return filepath.Join(rpath.volsDir, strings.Split(name, "@")[0])
+}
+
+// IsMounted - return true if the remote dir hosting the named volume
+// is mounted, name is like (volname@label).
+func (d *VolumeImplDriver) IsMounted(name string) bool {
+	// Check if the label for the given name is mounted
+	if label := plugin_utils.GetDSLabel(name); label != "" {
+		return plugin_utils.IsMounted(label, d.mountRoot)
+	}
+	return false
+}

--- a/vmdk_plugin/drivers/vsphere/volumeimpl.go
+++ b/vmdk_plugin/drivers/vsphere/volumeimpl.go
@@ -12,13 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package drivers
+package vsphere
+
+import (
+	"github.com/docker/go-plugins-helpers/volume"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/plugin_utils"
+)
 
 // VolumeDriver interface used by the refcountedVolume module to handle
 // recovery mounts/unmounts.
-type VolumeDriver interface {
+type VolumeImpl interface {
+	Create(volume.Request) volume.Response
+	Mount(volume.MountRequest, *plugin_utils.VolumeInfo) volume.Response
+	Unmount(volume.UnmountRequest) volume.Response
+	Get(volume.Request) volume.Response
+	Remove(volume.Request) volume.Response
+	Path(volume.Request) volume.Response
+	List(volume.Request) ([]*volume.Volume, error)
+	GetMountPoint(string) string
+	IsMounted(string) bool
 	MountVolume(string, string, string, bool, bool) (string, error)
 	UnmountVolume(string) error
 	GetVolume(string) (map[string]interface{}, error)
-	GetRefCount(string) uint
 }

--- a/vmdk_plugin/drivers/vsphere/vsphere_driver.go
+++ b/vmdk_plugin/drivers/vsphere/vsphere_driver.go
@@ -1,0 +1,332 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphere
+
+//
+// VMWare vSphere Docker Data Volume plugin.
+//
+// Provide support for --driver=vsphere in Docker, when Docker VM is running under ESX.
+//
+// Serves requests from Docker Engine related to VMDK volume operations.
+// Depends on vmdk-opsd service to be running on hosting ESX
+// (see ./esx_service)
+///
+
+import (
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/go-plugins-helpers/volume"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/drivers/network"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/drivers/vmdk"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/config"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/plugin_utils"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/refcount"
+	"strings"
+)
+
+const (
+	version  = "vSphere Volume Driver v0.4"
+	volType  = "type"
+	vmdkImpl = "vmdk"
+	nfsImpl  = "nfs"
+)
+
+// VolumeDriver - vSphere driver struct
+type VolumeDriver struct {
+	refCounts      *refcount.RefCountsMap
+	mountedVolumes map[string]string
+	mountIDToName  map[string]string
+	config         config.Config
+}
+
+// volumeBackingMap - Maps FS type to implementing driver object
+var volumeBackingMap map[string]VolumeImpl
+
+func (d *VolumeDriver) getVolImplWithType(name string) (VolumeImpl, string) {
+	// If the volume is mounted then get the backing for
+	// it from the mounted volumes map.
+	if fstype, ok := d.mountedVolumes[name]; ok {
+		return volumeBackingMap[fstype], fstype
+	}
+
+	// Else figure the FS type for the label and use the
+	// volume impl for that.
+	dslabel := plugin_utils.GetDSLabel(name)
+	if dslabel != "" && len(d.config.RemoteDirs.RemoteDirTbl) > 0 {
+		if rdir, ok := d.config.RemoteDirs.RemoteDirTbl[dslabel]; ok {
+			return volumeBackingMap[rdir.FSType], rdir.FSType
+		}
+	}
+	// Default to a VMDK type volume
+	return volumeBackingMap[vmdkImpl], vmdkImpl
+}
+
+// NewVolumeDriver creates Driver which to real ESX (useMockEsx=False) or a mock
+func NewVolumeDriver(port int, useMockEsx bool, mountDir string, driverName string, configFile string) *VolumeDriver {
+	var d *VolumeDriver
+
+	d = new(VolumeDriver)
+	c, err := config.Load(configFile)
+	if err != nil {
+		log.Warning("Failed to load config file - ", configFile)
+		return nil
+	}
+	d.config = c
+
+	// Init all known backends - VMDK and network volume drivers
+	d.mountedVolumes = make(map[string]string)
+	d.mountIDToName = make(map[string]string)
+	vimpl, err := vmdk.Init(port, useMockEsx, mountDir)
+	if err != nil {
+		return nil
+	}
+	volumeBackingMap[vmdkImpl] = vimpl
+
+	nimpl, err := network.Init(d, mountDir, d.config)
+	if err != nil {
+		return nil
+	}
+	volumeBackingMap[nfsImpl] = nimpl
+
+	d.refCounts = refcount.NewRefCountsMap()
+	d.refCounts.Init(d, mountDir, driverName)
+
+	return d
+}
+
+// Return the number of references for the given volume
+func (d *VolumeDriver) GetRefCount(vol string) uint { return d.refCounts.GetCount(vol) }
+
+// Increment the reference count for the given volume
+func (d *VolumeDriver) incrRefCount(vol string) uint { return d.refCounts.Incr(vol) }
+
+// Decrement the reference count for the given volume
+func (d *VolumeDriver) decrRefCount(vol string) (uint, error) { return d.refCounts.Decr(vol) }
+
+// Get info about a single volume
+func (d *VolumeDriver) Get(r volume.Request) volume.Response {
+	volImpl, _ := d.getVolImplWithType(r.Name)
+	return volImpl.Get(r)
+}
+
+// List volumes known to the driver
+func (d *VolumeDriver) List(r volume.Request) volume.Response {
+	// Get and append volumes from the two backing types
+	responseVolumes, err := volumeBackingMap[vmdkImpl].List(r)
+	if err != nil {
+		return volume.Response{Err: err.Error()}
+	}
+	filVols, err := volumeBackingMap[nfsImpl].List(r)
+	if err != nil {
+		return volume.Response{Err: err.Error()}
+	}
+
+	responseVolumes = append(responseVolumes, filVols...)
+	return volume.Response{Volumes: responseVolumes}
+}
+
+// Create - create a volume.
+func (d *VolumeDriver) Create(r volume.Request) volume.Response {
+	// For file type volume the network driver handles any
+	// addition opts that specify the exported fs to create
+	// the volume. Later change this to match against the known
+	// volume backing types to figure which one to use. For now
+	// the only two types are "nfs" and "vmdk".
+	if ftype, ok := r.Options[volType]; ok == true && strings.Contains(ftype, nfsImpl) {
+		return volumeBackingMap[nfsImpl].Create(r)
+	}
+
+	// If a DS label was specified the use the volume impl
+	// for the type associated with DS label.
+	dslabel := plugin_utils.GetDSLabel(r.Name)
+	if dslabel != "" && len(d.config.RemoteDirs.RemoteDirTbl) > 0 {
+		// Default to the one remote FS type thats supported now
+		rdir, ok := d.config.RemoteDirs.RemoteDirTbl[dslabel]
+		if ok && strings.Contains(rdir.FSType, nfsImpl) {
+			return volumeBackingMap[nfsImpl].Create(r)
+		}
+	}
+	// If volume doesn't have a label or not a remote dir.
+	return volumeBackingMap[vmdkImpl].Create(r)
+}
+
+// Remove - removes individual volume. Docker would call it only if is not using it anymore
+func (d *VolumeDriver) Remove(r volume.Request) volume.Response {
+	log.WithFields(log.Fields{"name": r.Name}).Info("Removing volume ")
+	// Docker is supposed to block 'remove' command if the volume is used. Verify.
+	if d.GetRefCount(r.Name) != 0 {
+		msg := fmt.Sprintf("Remove failure - volume is still in use, "+
+			" volume=%s, refcount=%d", r.Name, d.GetRefCount(r.Name))
+		log.Error(msg)
+		return volume.Response{Err: msg}
+	}
+	volImpl, _ := d.getVolImplWithType(r.Name)
+	return volImpl.Remove(r)
+}
+
+// Path - give docker a reminder of the volume mount path
+func (d *VolumeDriver) Path(r volume.Request) volume.Response {
+	volImpl, _ := d.getVolImplWithType(r.Name)
+	return volImpl.Path(r)
+}
+
+// Mount - Provide a volume to docker container - called once per container start.
+func (d *VolumeDriver) Mount(r volume.MountRequest) volume.Response {
+	log.WithFields(log.Fields{"name": r.Name}).Info("Mounting volume ")
+
+	volImpl, fstype := d.getVolImplWithType(r.Name)
+
+	// lock the state
+	d.refCounts.LockStateLock()
+	defer d.refCounts.UnlockStateLock()
+
+	// Checked by refcounting thread until refmap initialized
+	d.refCounts.SetDirty()
+
+	// Get the full name for the named volume
+	volInfo, err := plugin_utils.GetVolumeInfo(r.Name, "", d)
+	if err != nil {
+		log.Errorf("Unable to get volume info for volume %s. err:%v", r.Name, err)
+		return volume.Response{Err: err.Error()}
+	}
+
+	fname := volInfo.VolumeName
+
+	// If the volume is already mounted , increase the refcount.
+	// Note: for new keys, GO maps return zero value, so no need for if_exists.
+	refcnt := d.incrRefCount(fname) // save map traversal
+	log.Debugf("volume name=%s refcnt=%d", fname, refcnt)
+
+	if refcnt > 1 || volImpl.IsMounted(fname) {
+		log.WithFields(
+			log.Fields{"name": fname, "refcount": refcnt},
+		).Info("Already mounted, skipping mount. ")
+		return volume.Response{Mountpoint: volImpl.GetMountPoint(fname)}
+	}
+
+	response := volImpl.Mount(r, volInfo)
+	if response.Err != "" {
+		d.decrRefCount(fname)
+		d.refCounts.ClearDirty()
+		delete(d.mountedVolumes, fname)
+	} else {
+		// Add to the mounted volumes map
+		d.mountedVolumes[fname] = fstype
+		d.mountIDToName[r.ID] = fname
+
+	}
+
+	return response
+}
+
+// Unmount request from Docker. If mount refcount is drop to 0.
+// Unmount and detach from VM
+func (d *VolumeDriver) Unmount(r volume.UnmountRequest) volume.Response {
+	var fname string
+
+	log.WithFields(log.Fields{"name": r.Name}).Info("Unmounting Volume ")
+	volImpl, _ := d.getVolImplWithType(r.Name)
+
+	// lock the state
+	d.refCounts.LockStateLock()
+	defer d.refCounts.UnlockStateLock()
+
+	// Get the fully qualified name of the volume, the mount
+	// may have happened before the plugin restarted, so check its
+	// ok to use, else fetch volume meta-data and the full name
+	fname, ok := d.mountIDToName[r.ID]
+	if !ok {
+		// Get the full name for the named volume
+		volInfo, err := plugin_utils.GetVolumeInfo(r.Name, "", d)
+		if err != nil {
+			log.Errorf("Unable to get volume info for volume %s. err:%v", r.Name, err)
+			return volume.Response{Err: err.Error()}
+		}
+
+		fname = volInfo.VolumeName
+	} else {
+		delete(d.mountIDToName, r.ID)
+	}
+
+	if d.refCounts.GetInitSuccess() != true {
+		// If refcounting hasn't been succesful,
+		// no refcounting, no unmount. All unmounts are delayed
+		// until we succesfully populate the refcount map
+		d.refCounts.SetDirty()
+		delete(d.mountedVolumes, fname)
+
+		return volume.Response{Err: ""}
+	}
+
+	// if refcount has been succcessful, Normal flow
+	// if the volume is still used by other containers, just return OK
+	refcnt, err := d.decrRefCount(fname)
+	if err != nil {
+		// something went wrong - yell, but still try to unmount
+		log.WithFields(
+			log.Fields{"name": fname, "refcount": refcnt},
+		).Error("Refcount error - still trying to unmount...")
+	}
+
+	log.Debugf("volume name=%s refcnt=%d", fname, refcnt)
+	if refcnt >= 1 {
+		log.WithFields(
+			log.Fields{"name": fname, "refcount": refcnt},
+		).Info("Still in use, skipping unmount request. ")
+		return volume.Response{Err: ""}
+	}
+
+	// Remove from the mounted volumes map
+	delete(d.mountedVolumes, fname)
+	return volImpl.Unmount(volume.UnmountRequest{Name: fname})
+}
+
+// Capabilities - Report plugin scope to Docker
+func (d *VolumeDriver) Capabilities(r volume.Request) volume.Response {
+	return volume.Response{Capabilities: volume.Capability{Scope: "global"}}
+}
+
+// MountVolume - mount a volume without reference counting, name
+// is the fully qualified name of the volume (volume@ds).
+func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isReadOnly bool, skipAttach bool) (string, error) {
+	volImpl, fs := d.getVolImplWithType(name)
+
+	// If mounting via the refcounter then create the entry in the
+	// mountedVolumes map so the next mount to the same volume finds it
+	d.mountedVolumes[name] = fs
+
+	res, err := volImpl.MountVolume(name, fstype, id, isReadOnly, skipAttach)
+	return res, err
+}
+
+// UnmountVolume - unmount a volume without reference counting, name
+// is the fully qualified name of the volume (volume@ds).
+func (d *VolumeDriver) UnmountVolume(name string) error {
+	volImpl, _ := d.getVolImplWithType(name)
+
+	// Remove from the map as no one is using the volume
+	if name, exist := d.mountedVolumes[name]; exist {
+		delete(d.mountedVolumes, name)
+	}
+
+	return volImpl.UnmountVolume(name)
+
+}
+
+// GetVolume - get volume data.
+func (d *VolumeDriver) GetVolume(name string) (map[string]interface{}, error) {
+	volImpl, _ := d.getVolImplWithType(name)
+	return volImpl.GetVolume(name)
+}

--- a/vmdk_plugin/main.go
+++ b/vmdk_plugin/main.go
@@ -30,7 +30,7 @@ import (
 	"github.com/docker/go-plugins-helpers/volume"
 	"github.com/natefinch/lumberjack"
 	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/drivers/photon"
-	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/drivers/vmdk"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/drivers/vsphere"
 	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/config"
 )
 
@@ -178,7 +178,11 @@ func main() {
 		}
 		log.WithFields(log.Fields{"port": *port}).Info("Plugin options - ")
 
-		driver = vmdk.NewVolumeDriver(*port, *useMockEsx, mountRoot, *driverName)
+		driver = vsphere.NewVolumeDriver(*port, *useMockEsx, mountRoot, *driverName, *configFile)
+		if driver == nil {
+			log.Warning("Failed to initialize driver, exiting - ", *driverName)
+			os.Exit(1)
+		}
 	} else {
 		log.Warning("Unknown driver or invalid/missing driver options, exiting - ", *driverName)
 		os.Exit(1)

--- a/vmdk_plugin/utils/config/config.go
+++ b/vmdk_plugin/utils/config/config.go
@@ -36,16 +36,33 @@ const (
 	defaultLogLevel      = "info"
 )
 
+// RemoteDir describes a network shared folder.
+type RemoteDir struct {
+	Path    string `json:",omitempty"`
+	Args    string `json:",omitempty"`
+	FSType  string `json:",omitempty"`
+	VolPath string `json:",omitempty"`
+	Src     string `json:",omitempty"`
+}
+
+// RemoteDirTable - table of remote dirs and the default table entry
+// to use to place volumes.
+type RemoteDirTable struct {
+	Default      string               `json:",omitempty"`
+	RemoteDirTbl map[string]RemoteDir `json:",omitempty"`
+}
+
 // Config stores the configuration for the plugin
 type Config struct {
-	Driver        string `json:",omitempty"`
-	LogPath       string `json:",omitempty"`
-	MaxLogSizeMb  int    `json:",omitempty"`
-	MaxLogAgeDays int    `json:",omitempty"`
-	LogLevel      string `json:",omitempty"`
-	Target        string `json:",omitempty"`
-	Project       string `json:",omitempty"`
-	Host          string `json:",omitempty"`
+	Driver        string         `json:",omitempty"`
+	LogPath       string         `json:",omitempty"`
+	MaxLogSizeMb  int            `json:",omitempty"`
+	MaxLogAgeDays int            `json:",omitempty"`
+	LogLevel      string         `json:",omitempty"`
+	Target        string         `json:",omitempty"`
+	Project       string         `json:",omitempty"`
+	Host          string         `json:",omitempty"`
+	RemoteDirs    RemoteDirTable `json:",omitempty"`
 }
 
 // Load the configuration from a file and return a Config.

--- a/vmdk_plugin/utils/fs/fs.go
+++ b/vmdk_plugin/utils/fs/fs.go
@@ -43,6 +43,7 @@ const (
 	bdevPath        = "/sys/block/"
 	deleteFile      = "/device/delete"
 	watchPath       = "/dev/disk/by-id"
+	mountPrefix     = "/sbin/mount."
 )
 
 // FstypeDefault contains the default FS when not specified by the user
@@ -308,4 +309,12 @@ func GetDevicePath(str []byte) (string, error) {
 	}
 	return fmt.Sprintf("/dev/disk/by-path/pci-%s.0-scsi-0:0:%s:0", string(buf), volDev.Unit), nil
 
+}
+
+// DoNFSMount - Run a mount command to mount a remote dir via nfs/nfs4, syscall Mount()
+// can't be used for nfs mounts owing to the mount protocol involved
+func DoNFSMountCmd(mountPath string, fstype string, remotePath string, args string) error {
+	mountCmd := mountPrefix + fstype
+	_, err := exec.Command(mountCmd, remotePath, mountPath, args).CombinedOutput()
+	return err
 }


### PR DESCRIPTION
Changes to support NFS volumes. Changes are only compiled at this point and I'll first verify VMDK volume support and then the NFS volumes. Please see #1217 for a description of the proposed support (from user perspective).

Changes are not tested yet and will be done thru this week, along with test cases addition.

Authentication with nfs4 isn't supported yet and will be a separate change once these are in.

Changes are large and I'm also reviewing.

Changes:
1.  New VolumeImpl interface is defined to support the current (vmdk), new (nfs) and future(efs, CIFS, etc) volume types.
2. The existing VMDK driver is now implementing the interface in (1), plus a new network driver thats supporting shared volumes with NFS.
3. Parts of the VMDK driver (Volume interface functions and ref counting) are abstracted into a generic vsphere driver that frontends all volume types on vsphere platform.
4. Refactored changes in plugin_utils, refcount modules to simplify the use of fully qualified names for volumes (as volume@dslabel) for all volume types.
5. The vsphere module now keeps the maps to map mount/unmount IDs to qualified volume names and those names to the backing volume type.
6. At run time on each command, the vsphere driver figures out which backing to use based on the config of remote dirs in the plugin config file and invokes the appropriate (vmdk/nfs) drivers.

Have shared the block diagram of the modules and interfaces in the plugin with the proposed changes.
