### PR TITLE
Handle stale attach code

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -1155,7 +1155,7 @@ def getStatusAttached(vmdk_path):
 
 def log_attached_volume(vmdk_path, kv_uuid, vol_name):
        '''
-       Log appropriate message for volume thats already attached
+       Log appropriate message for volume thats already attached.
        '''
        cur_vm = findVmByUuid(kv_uuid)
 

--- a/tests/e2e/basic_test.go
+++ b/tests/e2e/basic_test.go
@@ -72,10 +72,11 @@ var _ = Suite(&BasicTestSuite{})
 // 2. Verify the volume is available
 // 3. Attach the volume
 // 4. Verify volume status is attached
-// 5. Remove the container
-// 6. Verify volume status is detached
-// 7. Remove the volume
-// 8. Verify the volume is unavailable
+// 5. Remove the volume (expect fail)
+// 6. Remove the container
+// 7. Verify volume status is detached
+// 8. Remove the volume
+// 9. Verify the volume is unavailable
 func (s *BasicTestSuite) TestVolumeLifecycle(c *C) {
 	misc.LogTestStart(c.TestName())
 
@@ -91,6 +92,9 @@ func (s *BasicTestSuite) TestVolumeLifecycle(c *C) {
 
 		status := verification.VerifyAttachedStatus(s.volName1, host, s.esx)
 		c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volName1))
+
+		out, err = dockercli.DeleteVolume(host, s.volName1)
+		c.Assert(err, Not(IsNil), Commentf(out))
 
 		out, err = dockercli.RemoveContainer(host, s.containerName)
 		c.Assert(err, IsNil, Commentf(out))


### PR DESCRIPTION
Removed code in handle_stale_attach() to reset KV if the VM is powered off. This code is not relevant any more with the handling of VM events in the service.