### PR TITLE
Fixes admin cli logging failure

### DIFF
--- a/esx_service/utils/kvESX.py
+++ b/esx_service/utils/kvESX.py
@@ -321,7 +321,7 @@ def get_info(volpath):
     dhandle = vol_open_path(volpath, VMDK_OPEN_DISKCHAIN_NOIO)
 
     if not disk_is_valid(dhandle):
-        logging.warning("Failed to open disk - %x", volpath)
+        logging.warning("Failed to open disk - %s", volpath)
         return None
 
     sinfo = disk_info()


### PR DESCRIPTION
This PR fixes the bug related to logging that occurs while listing invalid disk handles.

Fixes #1072. Testing done.

I was able to reproduce the issue with just 10 volumes. Following is the new output generated from executing the admin CLI command simultaneously while removing volumes.

```
[root@sc2-rdops-vm03-dhcp-112-247:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py volume ls
Volume      Datastore     VMGroup   Capacity  Used  Filesystem  Policy  Disk Format  Attached-to  Access      Attach-as               Created By    Created Date              
----------  ------------  --------  --------  ----  ----------  ------  -----------  -----------  ----------  ----------------------  ------------  ------------------------  
MyVolume-9  sharedVmfs-0  _DEFAULT  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  ubuntu-VM1.2  Tue May 16 21:44:35 2017  
MyVolume-8  sharedVmfs-0  _DEFAULT  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  ubuntu-VM1.2  Tue May 16 21:44:33 2017  
MyVolume-7  sharedVmfs-0  _DEFAULT  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  ubuntu-VM1.2  Tue May 16 21:44:30 2017  
MyVolume-4  sharedVmfs-0  _DEFAULT  N/A       N/A   N/A         N/A     N/A          detached     read-write  independent_persistent  N/A           N/A                       
MyVolume-5  sharedVmfs-0  _DEFAULT  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  ubuntu-VM1.2  Tue May 16 21:44:26 2017  
MyVolume-6  sharedVmfs-0  _DEFAULT  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  ubuntu-VM1.2  Tue May 16 21:44:28 2017
```

Please review and merge.

Thanks,
Venil