### PR TITLE
Updates in-use volume removal error message

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -606,8 +606,7 @@ def removeVMDK(vmdk_path, vol_name=None, vm_name=None, tenant_uuid=None, datasto
                 vol_name = vmdk_utils.get_volname_from_vmdk_path(vmdk_path)
             logging.info("*** removeVMDK: %s is in use, volume = %s VM = %s VM-uuid = %s (%s)",
                 vmdk_path, vol_name, attached_vm_name, kv_uuid, ret)
-            return err("Failed to remove volume {0}, in use by VM = {1} VM-uuid = {2}.".format(
-                vol_name, attached_vm_name, kv_uuid))
+            return err("Failed to remove volume {0}, in use by VM = {1}.".format(vol_name, attached_vm_name))
 
     # Cleaning .vmdk file
     clean_err = cleanVMDK(vmdk_path, vol_name)

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -288,7 +288,7 @@ def cloneVMDK(vm_name, vmdk_path, opts={}, vm_uuid=None, datastore_url=None):
     lockname = "{}.{}.{}".format(src_datastore, tenant_name, src_volume)
     with lockManager.get_lock(lockname):
         # Verify if the source volume is in use.
-        attached, uuid, attach_as = getStatusAttached(src_vmdk_path)
+        attached, uuid, attach_as, _ = getStatusAttached(src_vmdk_path)
         if attached:
             if handle_stale_attach(vmdk_path, uuid):
                 return err("Source volume cannot be in use when cloning")
@@ -598,13 +598,16 @@ def removeVMDK(vmdk_path, vol_name=None, vm_name=None, tenant_uuid=None, datasto
     logging.info("*** removeVMDK: %s", vmdk_path)
 
     # Check the current volume status
-    kv_status_attached, kv_uuid, attach_mode = getStatusAttached(vmdk_path)
+    kv_status_attached, kv_uuid, attach_mode, attached_vm_name = getStatusAttached(vmdk_path)
     if kv_status_attached:
         ret = handle_stale_attach(vmdk_path, kv_uuid)
         if ret:
-            logging.info("*** removeVMDK: %s is in use, VM uuid = %s (%s)", vmdk_path, kv_uuid, ret)
-            return err("Failed to remove volume {0}, in use by VM uuid = {1}.".format(
-                vmdk_path, kv_uuid))
+            if vol_name is None:
+                vol_name = vmdk_utils.get_volname_from_vmdk_path(vmdk_path)
+            logging.info("*** removeVMDK: %s is in use, volume = %s VM = %s VM-uuid = %s (%s)",
+                vmdk_path, vol_name, attached_vm_name, kv_uuid, ret)
+            return err("Failed to remove volume {0}, in use by VM = {1} VM-uuid = {2}.".format(
+                vol_name, attached_vm_name, kv_uuid))
 
     # Cleaning .vmdk file
     clean_err = cleanVMDK(vmdk_path, vol_name)
@@ -1117,7 +1120,7 @@ def setStatusDetached(vmdk_path):
 
 
 def getStatusAttached(vmdk_path):
-    '''Returns (attached, uuid, attach_as) tuple. For 'detached' status uuid is None'''
+    '''Returns (attached, uuid, attach_as, vm_name) tuple. For 'detached' status uuid is None'''
 
     vol_meta = kv.getAll(vmdk_path)
     try:
@@ -1126,14 +1129,20 @@ def getStatusAttached(vmdk_path):
         attach_as = kv.DEFAULT_ATTACH_AS
 
     if not vol_meta or kv.STATUS not in vol_meta:
-        return False, None, attach_as
+        return False, None, attach_as, None
 
     attached = (vol_meta[kv.STATUS] == kv.ATTACHED)
     try:
         uuid = vol_meta[kv.ATTACHED_VM_UUID]
     except:
         uuid = None
-    return attached, uuid, attach_as
+
+    try:
+        vm_name = vol_meta[kv.ATTACHED_VM_NAME]
+    except:
+        vm_name = None
+
+    return attached, uuid, attach_as, vm_name
 
 def handle_stale_attach(vmdk_path, kv_uuid):
        '''
@@ -1250,7 +1259,7 @@ def disk_attach(vmdk_path, vm):
     return error or unit:bus numbers of newly attached disk.
     '''
 
-    kv_status_attached, kv_uuid, attach_mode = getStatusAttached(vmdk_path)
+    kv_status_attached, kv_uuid, attach_mode, _ = getStatusAttached(vmdk_path)
     logging.info("Attaching {0} as {1}".format(vmdk_path, attach_mode))
 
     # If the volume is attached then check if the attach is stale (VM is powered off).

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -1119,7 +1119,10 @@ def setStatusDetached(vmdk_path):
 
 
 def getStatusAttached(vmdk_path):
-    '''Returns (attached, uuid, attach_as, vm_name) tuple. For 'detached' status uuid is None'''
+    '''
+    Returns (attached, uuid, attach_as, vm_name) tuple. For 'detached' status
+    uuid and vm_name are None.
+    '''
 
     vol_meta = kv.getAll(vmdk_path)
     try:


### PR DESCRIPTION
## Description
This PR updates the error message that's printed on removal of in-use volumes. Changes to the error message are as follows. Fixes #1208.

1. Replaced VMDK path with Volume name.
2. Added VM name.
3. Removed VM uuid.

Signature of the `getStatusAttached(..)` function was modified to return a 4th value i.e. `vm_name`, which is needed for building the error message in `removeVMDK(..)`.

## Test

`docker volume rm v2` now displays:
```
Error response from daemon: unable to remove volume: remove v2: VolumeDriver.Remove: Failed to remove volume v2, in use by VM = ubuntu-VM1.2.
```

ESX Plugin log at `/var/log/vmware/vmdk_ops.log` displays:
```
05/17/17 21:39:41 1835942 [ubuntu-VM0.2-sharedVmfs-0._DEFAULT.v2] [INFO   ] *** removeVMDK: /vmfs/volumes/sharedVmfs-0/dockvols/11111111-1111-1111-1111-111111111111/v2.vmdk
05/17/17 21:39:41 1835942 [ubuntu-VM0.2-sharedVmfs-0._DEFAULT.v2] [WARNING] Disk /vmfs/volumes/sharedVmfs-0/dockvols/11111111-1111-1111-1111-111111111111/v2.vmdk already attached to VM=ubuntu-VM1.2
05/17/17 21:39:41 1835942 [ubuntu-VM0.2-sharedVmfs-0._DEFAULT.v2] [INFO   ] *** removeVMDK: /vmfs/volumes/sharedVmfs-0/dockvols/11111111-1111-1111-1111-111111111111/v2.vmdk is in use, volume = v2 VM = ubuntu-VM1.2 VM-uuid = 564ddf99-d58f-db6e-bf3e-d4afd3377873 ({'Error': 'Disk /vmfs/volumes/sharedVmfs-0/dockvols/11111111-1111-1111-1111-111111111111/v2.vmdk already attached to VM=ubuntu-VM1.2'})
05/17/17 21:39:41 1835942 [ubuntu-VM0.2-sharedVmfs-0._DEFAULT.v2] [INFO   ] executeRequest 'remove' completed with ret={'Error': 'Failed to remove volume v2, in use by VM = ubuntu-VM1.2.'}
```

Please review and merge.

Thanks,
Venil