### PR TITLE
[Automation] Test cases for volume create, access and vsan 

### DIFF
--- a/tests/constants/admincli/cmd.go
+++ b/tests/constants/admincli/cmd.go
@@ -79,4 +79,10 @@ const (
 
 	//RemoveVolumes option refers to removing all volumes from a vmgroup
 	RemoveVolumes = " --remove-volumes"
+
+	// ReadOnlyAccess read only rights for the volume
+	ReadOnlyAccess = "read-only"
+
+	// ReadWriteAccess read-write rights for the volume
+	ReadWriteAccess = "read-write"
 )

--- a/tests/e2e/volume_access_test.go
+++ b/tests/e2e/volume_access_test.go
@@ -1,0 +1,190 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The goal of this test suite is to verify read/write consistency on volumes
+// in accordance with the access updates on the volume
+
+// +build runalways
+
+package e2e
+
+import (
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	adminconst "github.com/vmware/docker-volume-vsphere/tests/constants/admincli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/admincli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
+)
+
+const (
+	volAccessTest    = "vol_access"
+	errorWriteVolume = "Read-only file system"
+)
+
+type VolumeAccessTestSuite struct {
+	config *inputparams.TestConfig
+
+	volumeName    string
+	containerList [2][]string
+}
+
+func (s *VolumeAccessTestSuite) SetUpSuite(c *C) {
+	s.config = inputparams.GetTestConfig()
+	if s.config == nil {
+		c.Skip("Unable to retrieve test config, skipping volume access tests")
+	}
+}
+
+func (s *VolumeAccessTestSuite) SetUpTest(c *C) {
+	dsName := s.config.Datastores[0]
+	s.volumeName = inputparams.GetVolumeNameWithTimeStamp("vol_access") + "@" + dsName
+}
+
+func (s *VolumeAccessTestSuite) TearDownTest(c *C) {
+	for i := 0; i < 2; i++ {
+		cnameList := strings.Join(s.containerList[i], " ")
+		out, err := dockercli.RemoveContainer(s.config.DockerHosts[i], cnameList)
+		c.Assert(err, IsNil, Commentf(out))
+		s.containerList[i] = s.containerList[i][:0]
+	}
+
+	out, err := dockercli.DeleteVolume(s.config.DockerHosts[0], s.volumeName)
+	c.Assert(err, IsNil, Commentf(out))
+}
+
+var _ = Suite(&VolumeAccessTestSuite{})
+
+func (s *VolumeAccessTestSuite) newCName(i int) string {
+	cname := inputparams.GetContainerNameWithTimeStamp("vol_access")
+	s.containerList[i] = append(s.containerList[i], cname)
+	return cname
+}
+
+// Verify read, write is possible after volume access update
+// 1. Write a message from host1 to a file on the volume
+// 2. Read the content from host2 from same file on the volume
+//    Verify the content is same.
+// 3. Write another message from host2 to the same file on that volume
+// 4. Read from host1 and verify the content is same
+// 5. Update the volume access to read-only
+// 6. Write from host1 to the file on volume should fail
+// 7. Write from host2 should also fail
+// 8. Update the volume access to read-write
+// 9. Write from host1 should succeed
+// 10. Read from host2 to verify the content is same
+// 11. Write from host2 should succeed
+// 12. Read from host1 to verify the content is same
+func (s *VolumeAccessTestSuite) TestAccessUpdate(c *C) {
+	misc.LogTestStart(volAccessTest, "TestAccessUpdate")
+
+	data1 := "message_by_host1"
+	data2 := "message_by_host2"
+	testFile := "test.txt"
+
+	// Create a volume
+	out, err := dockercli.CreateVolume(s.config.DockerHosts[0], s.volumeName)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.WriteToVolume(s.config.DockerHosts[0], s.volumeName, s.newCName(0), testFile, data1)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.ReadFromVolume(s.config.DockerHosts[1], s.volumeName, s.newCName(1), testFile)
+	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(out, Equals, data1)
+
+	out, err = dockercli.WriteToVolume(s.config.DockerHosts[1], s.volumeName, s.newCName(1), testFile, data2)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.ReadFromVolume(s.config.DockerHosts[0], s.volumeName, s.newCName(0), testFile)
+	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(out, Equals, data2)
+
+	out, err = admincli.UpdateVolumeAccess(s.config.EsxHost, s.volumeName, adminconst.DefaultVMgroup, adminconst.ReadOnlyAccess)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.WriteToVolume(s.config.DockerHosts[0], s.volumeName, s.newCName(0), testFile, data1)
+	c.Assert(strings.Contains(out, errorWriteVolume), Equals, true, Commentf(out))
+
+	out, err = dockercli.WriteToVolume(s.config.DockerHosts[1], s.volumeName, s.newCName(1), testFile, data2)
+	c.Assert(strings.Contains(out, errorWriteVolume), Equals, true, Commentf(out))
+
+	out, err = admincli.UpdateVolumeAccess(s.config.EsxHost, s.volumeName, adminconst.DefaultVMgroup, adminconst.ReadWriteAccess)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.WriteToVolume(s.config.DockerHosts[0], s.volumeName, s.newCName(0), testFile, data1)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.ReadFromVolume(s.config.DockerHosts[1], s.volumeName, s.newCName(1), testFile)
+	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(out, Equals, data1)
+
+	out, err = dockercli.WriteToVolume(s.config.DockerHosts[1], s.volumeName, s.newCName(1), testFile, data2)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.ReadFromVolume(s.config.DockerHosts[0], s.volumeName, s.newCName(0), testFile)
+	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(out, Equals, data2)
+
+	misc.LogTestEnd(volAccessTest, "TestAccessUpdate")
+}
+
+// Verify read, write is possible after volume access update
+// 1. Create a volume with read-only access
+// 2. Write from host1 to the file on volume should fail
+// 3. Write from host2 should also fail
+// 4. Update the volume access to read-write
+// 5. Write from host1 should succeed
+// 6. Read from host2 to verify the content is same
+// 7. Write from host2 should succeed
+// 8. Read from host1 to verify the content is same
+func (s *VolumeAccessTestSuite) TestAccessUpdate_R_RW(c *C) {
+	misc.LogTestStart(volAccessTest, "TestAccessUpdate_R_RW")
+
+	data1 := "message_by_host1"
+	data2 := "message_by_host2"
+	testFile := "test.txt"
+
+	// Create a volume
+	out, err := dockercli.CreateVolumeWithOptions(s.config.DockerHosts[0], s.volumeName, " -o access="+adminconst.ReadOnlyAccess)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.WriteToVolume(s.config.DockerHosts[0], s.volumeName, s.newCName(0), testFile, data1)
+	c.Assert(strings.Contains(out, errorWriteVolume), Equals, true, Commentf(out))
+
+	out, err = dockercli.WriteToVolume(s.config.DockerHosts[1], s.volumeName, s.newCName(1), testFile, data2)
+	c.Assert(strings.Contains(out, errorWriteVolume), Equals, true, Commentf(out))
+
+	out, err = admincli.UpdateVolumeAccess(s.config.EsxHost, s.volumeName, adminconst.DefaultVMgroup, adminconst.ReadWriteAccess)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.WriteToVolume(s.config.DockerHosts[0], s.volumeName, s.newCName(0), testFile, data1)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.ReadFromVolume(s.config.DockerHosts[1], s.volumeName, s.newCName(1), testFile)
+	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(out, Equals, data1)
+
+	out, err = dockercli.WriteToVolume(s.config.DockerHosts[1], s.volumeName, s.newCName(1), testFile, data2)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.ReadFromVolume(s.config.DockerHosts[0], s.volumeName, s.newCName(0), testFile)
+	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(out, Equals, data2)
+
+	misc.LogTestEnd(volAccessTest, "TestAccessUpdate_R_RW")
+}

--- a/tests/e2e/volume_access_test.go
+++ b/tests/e2e/volume_access_test.go
@@ -15,7 +15,7 @@
 // The goal of this test suite is to verify read/write consistency on volumes
 // in accordance with the access updates on the volume
 
-// +build runalways
+// +build runonce
 
 package e2e
 

--- a/tests/e2e/volumecreate_test.go
+++ b/tests/e2e/volumecreate_test.go
@@ -1,0 +1,237 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This test is going to cover various volume creation test cases
+
+// +build runonce
+
+package e2e
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/verification"
+
+	. "gopkg.in/check.v1"
+)
+
+const (
+	volCreateTest     = "vol_create"
+	ErrorVolumeCreate = "Error response from daemon: create"
+)
+
+type VolumeCreateTestSuite struct {
+	config     *inputparams.TestConfig
+	volumeList []string
+}
+
+func (s *VolumeCreateTestSuite) SetUpSuite(c *C) {
+	s.config = inputparams.GetTestConfig()
+	if s.config == nil {
+		c.Skip("Unable to retrieve test config, skipping volume create tests")
+	}
+}
+
+func (s *VolumeCreateTestSuite) TearDownTest(c *C) {
+	volList := strings.Join(s.volumeList, " ")
+
+	if volList != "" {
+		out, err := dockercli.DeleteVolume(s.config.DockerHosts[0], volList)
+		c.Assert(err, IsNil, Commentf(out))
+	}
+
+	// clean the list of volumes created
+	s.volumeList = s.volumeList[:0]
+}
+
+var _ = Suite(&VolumeCreateTestSuite{})
+
+// create volume and do valid/invalid assertion
+func (s *VolumeCreateTestSuite) createVolCheck(name, option string, valid bool, c *C) {
+	var out string
+	var err error
+
+	if option == "" {
+		out, err = dockercli.CreateVolume(s.config.DockerHosts[0], name)
+	} else {
+		out, err = dockercli.CreateVolumeWithOptions(s.config.DockerHosts[0], name, option)
+	}
+
+	// if creation is successful, add it to the list so that it gets cleaned later
+	if err == nil {
+		s.volumeList = append(s.volumeList, name)
+	}
+
+	if valid {
+		// positive test case
+		c.Assert(err, IsNil, Commentf(out))
+	} else {
+		// negative test case
+		c.Assert(err, Not(IsNil), Commentf(out))
+		c.Assert(strings.HasPrefix(out, ErrorVolumeCreate), Equals, true)
+	}
+}
+
+// loop over volume names to parallely create volumes
+func (s *VolumeCreateTestSuite) parallelCreateByName(names []string, valid bool, c *C) {
+	var wg sync.WaitGroup
+	for _, volName := range names {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			s.createVolCheck(name, "", valid, c)
+		}(volName)
+	}
+	wg.Wait()
+}
+
+// loop over volume options to parallely create volumes
+func (s *VolumeCreateTestSuite) parallelCreateByOption(options []string, valid bool, c *C) {
+	var wg sync.WaitGroup
+	for _, volOption := range options {
+		wg.Add(1)
+		go func(option string) {
+			defer wg.Done()
+			volName := inputparams.GetUniqueVolumeName("option")
+			s.createVolCheck(volName, option, valid, c)
+		}(volOption)
+	}
+	wg.Wait()
+}
+
+func (s *VolumeCreateTestSuite) accessCheck(hostIP string, volList []string, c *C) {
+	isAvailable := verification.CheckVolumeListAvailability(hostIP, volList)
+	c.Assert(isAvailable, Equals, true, Commentf("Volume %s is not available after creation", volList))
+}
+
+// Valid volume names test
+// 1. having 100 chars
+// 2. having various chars including alphanumerics
+// 3. ending in 5Ns
+// 4. ending in 7Ns
+// 5. contains @datastore (valid name)
+// 6. contains multiple '@'
+// 7. contains unicode character
+// 8. contains space
+func (s *VolumeCreateTestSuite) TestValidName(c *C) {
+	misc.LogTestStart(volCreateTest, "TestValidName")
+
+	volNameList := []string{
+		inputparams.GetVolumeNameOfSize(100),
+		"Volume-0000000-****-###",
+		"Volume-00000",
+		"Volume-0000000",
+		inputparams.GetUniqueVolumeName("abc") + "@" + s.config.Datastores[0],
+		inputparams.GetUniqueVolumeName("abc") + "@@@@" + s.config.Datastores[0],
+		inputparams.GetUniqueVolumeName("Volume-你"),
+		"\"Volume Space\"",
+	}
+
+	s.parallelCreateByName(volNameList, true, c)
+	s.accessCheck(s.config.DockerHosts[0], s.volumeList, c)
+
+	misc.LogTestEnd(volCreateTest, "TestValidName")
+}
+
+// Invalid volume names test
+// 1. having more than 100 chars
+// 2. ending -NNNNNN (6Ns)
+// 3. contains @invalid datastore name
+func (s *VolumeCreateTestSuite) TestInvalidName(c *C) {
+	misc.LogTestStart(volCreateTest, "TestInvalidName")
+
+	invalidVolList := []string{
+		inputparams.GetVolumeNameOfSize(101),
+		"Volume-000000",
+		inputparams.GetUniqueVolumeName("Volume") + "@invalidDatastore",
+	}
+
+	s.parallelCreateByName(invalidVolList, false, c)
+
+	misc.LogTestEnd(volCreateTest, "TestInvalidName")
+}
+
+// Valid volume creation options
+// 1. size 10gb
+// 2. disk format (thin, zeroedthick, eagerzeroedthick)
+// 3. attach-as (persistent, independent_persistent)
+// 4. fstype ext4
+// 5. access (read-write, read-only)
+// 6. clone-from valid volume
+// 7. fstype xfs
+func (s *VolumeCreateTestSuite) TestValidOptions(c *C) {
+	misc.LogTestStart(volCreateTest, "TestValidOptions")
+
+	// Need a valid volume source to test clone-from option
+	cloneSrcVol := inputparams.GetUniqueVolumeName("clone_src")
+	s.volumeList = append(s.volumeList, cloneSrcVol)
+	out, err := dockercli.CreateVolume(s.config.DockerHosts[0], cloneSrcVol)
+	c.Assert(err, IsNil, Commentf(out))
+
+	validVolOpts := []string{
+		" -o size=10gb",
+		" -o diskformat=zeroedthick",
+		" -o diskformat=thin",
+		" -o diskformat=eagerzeroedthick",
+		" -o attach-as=independent_persistent",
+		" -o attach-as=persistent",
+		" -o fstype=ext4",
+		" -o access=read-only",
+		" -o access=read-write",
+		" -o clone-from=" + cloneSrcVol,
+	}
+
+	s.parallelCreateByOption(validVolOpts, true, c)
+
+	// xfs file system needs volume name upto than 12 characters
+	xfsVolName := inputparams.GetVolumeNameOfSize(12)
+	out, err = dockercli.CreateVolumeWithOptions(s.config.DockerHosts[0], xfsVolName, " -o fstype=xfs")
+	c.Assert(err, IsNil, Commentf(out))
+	s.volumeList = append(s.volumeList, xfsVolName)
+
+	s.accessCheck(s.config.DockerHosts[0], s.volumeList, c)
+
+	misc.LogTestEnd(volCreateTest, "TestValidOptions")
+}
+
+// Invalid volume create operations
+// 1. Wrong disk formats
+// 2. Wrong volume sizes
+// 3. Wrong fs types
+// 4. Wrong access types
+// 5. Unavailable clone source
+func (s *VolumeCreateTestSuite) TestInvalidOptions(c *C) {
+	misc.LogTestStart(volCreateTest, "TestInvalidOptions")
+
+	invalidVolOpts := []string{
+		" -o diskformat=zeroedthickk",
+		" -o diskformat=zeroedthick,thin",
+		" -o size=100mbb",
+		" -o size=100gbEE",
+		" -o sizes=100mb",
+		" -o fstype=xfs_ext",
+		" -o access=read-write-both",
+		" -o access=write-only",
+		" -o access=read-write-both",
+		" -o clone-from=IDontExist",
+	}
+
+	s.parallelCreateByOption(invalidVolOpts, false, c)
+
+	misc.LogTestEnd(volCreateTest, "TestInvalidOptions")
+}

--- a/tests/e2e/vsan_test.go
+++ b/tests/e2e/vsan_test.go
@@ -1,0 +1,103 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This test is going to create volume on the fresh testbed very first time.
+// After installing vmdk volume plugin/driver, volume creation should not be
+// failed very first time.
+
+// This test is going to cover various vsan related test cases
+
+// +build runonce
+
+package e2e
+
+import (
+	"strings"
+
+	"github.com/vmware/docker-volume-vsphere/tests/utils/admincli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/govc"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/verification"
+
+	. "gopkg.in/check.v1"
+)
+
+const (
+	vsanVolumeTest = "vsan_vol"
+	vsanPolicyFlag = "vsan-policy-name"
+)
+
+type VsanTestSuite struct {
+	config *inputparams.TestConfig
+
+	vsanDSName string
+	volumeName string
+}
+
+func (s *VsanTestSuite) SetUpSuite(c *C) {
+	s.config = inputparams.GetTestConfig()
+	if s.config == nil {
+		c.Skip("Unable to retrieve test config, skipping vsan tests")
+	}
+
+	s.vsanDSName = govc.GetDatastoreByType("vsan")
+	if s.vsanDSName == "" {
+		c.Skip("Vsan datastore unavailable")
+	}
+}
+
+func (s *VsanTestSuite) TearDownTest(c *C) {
+	out, err := dockercli.DeleteVolume(s.config.DockerHosts[0], s.volumeName)
+	c.Assert(err, IsNil, Commentf(out))
+}
+
+var _ = Suite(&VsanTestSuite{})
+
+// Vsan related test
+// 1. Create a valid vsan policy
+// 2. Create an invalid vsan policy (wrong content)
+// 3. Volume creation with valid policy should pass
+// 4. Valid volume should be accessible
+// 5. Volume creation with non existing policy should fail
+// 6. Volume creation with invalid policy should fail
+func (s *VsanTestSuite) TestVSANPolicy(c *C) {
+	misc.LogTestStart(volCreateTest, "TestVSANPolicy")
+
+	policyName := "validPolicy"
+	out, err := admincli.CreatePolicy(s.config.EsxHost, policyName, "'((\"proportionalCapacity\" i50)''(\"hostFailuresToTolerate\" i0))'")
+	c.Assert(err, IsNil, Commentf(out))
+
+	invalidContentPolicyName := "invalidPolicy"
+	out, err = admincli.CreatePolicy(s.config.EsxHost, invalidContentPolicyName, "'((\"wrongKey\" i50)'")
+	c.Assert(err, IsNil, Commentf(out))
+
+	s.volumeName = inputparams.GetVolumeNameWithTimeStamp("vsanVol") + "@" + s.vsanDSName
+	vsanOpts := " -o " + vsanPolicyFlag + "=" + policyName
+
+	out, err = dockercli.CreateVolumeWithOptions(s.config.DockerHosts[0], s.volumeName, vsanOpts)
+	c.Assert(err, IsNil, Commentf(out))
+	isAvailable := verification.CheckVolumeAvailability(s.config.DockerHosts[0], s.volumeName)
+	c.Assert(isAvailable, Equals, true, Commentf("Volume %s is not available after creation", s.volumeName))
+
+	invalidVsanOpts := [2]string{"-o " + vsanPolicyFlag + "=IDontExist", "-o " + vsanPolicyFlag + "=" + invalidContentPolicyName}
+	for _, option := range invalidVsanOpts {
+		invalidVolName := inputparams.GetVolumeNameWithTimeStamp("vsanVol") + "@" + s.vsanDSName
+		out, _ = dockercli.CreateVolumeWithOptions(s.config.DockerHosts[0], invalidVolName, option)
+		c.Assert(strings.HasPrefix(out, ErrorVolumeCreate), Equals, true)
+	}
+
+	misc.LogTestStart(volCreateTest, "TestVSANPolicy")
+}

--- a/tests/utils/inputparams/testparams.go
+++ b/tests/utils/inputparams/testparams.go
@@ -23,16 +23,15 @@ import (
 	"os"
 	"strconv"
 	"time"
-
 	"github.com/vmware/docker-volume-vsphere/tests/utils/govc"
 )
 
 // TestConfig - struct for common test configuration params
 type TestConfig struct {
-	EsxHost         string
-	DockerHosts     []string
+	EsxHost string
+	DockerHosts []string
 	DockerHostNames []string
-	Datastores      []string
+	Datastores []string
 }
 
 var (
@@ -53,7 +52,6 @@ func init() {
 func GetVolumeName() string {
 	return volumeName
 }
-
 // GetVolumeNameWithTimeStamp prepares unique volume name by appending current time-stamp value
 func GetVolumeNameWithTimeStamp(volName string) string {
 	return volName + "_volume_" + strconv.FormatInt(time.Now().Unix(), 10)

--- a/tests/utils/inputparams/testparams.go
+++ b/tests/utils/inputparams/testparams.go
@@ -23,15 +23,16 @@ import (
 	"os"
 	"strconv"
 	"time"
+
 	"github.com/vmware/docker-volume-vsphere/tests/utils/govc"
 )
 
 // TestConfig - struct for common test configuration params
 type TestConfig struct {
-	EsxHost string
-	DockerHosts []string
+	EsxHost         string
+	DockerHosts     []string
 	DockerHostNames []string
-	Datastores []string
+	Datastores      []string
 }
 
 var (
@@ -52,6 +53,7 @@ func init() {
 func GetVolumeName() string {
 	return volumeName
 }
+
 // GetVolumeNameWithTimeStamp prepares unique volume name by appending current time-stamp value
 func GetVolumeNameWithTimeStamp(volName string) string {
 	return volName + "_volume_" + strconv.FormatInt(time.Now().Unix(), 10)


### PR DESCRIPTION
1. Test cases for volume create with valid/invalid volume names
2. Test cases for volume create with valid/invalid volume options
3. Test cases for volume access updates and consistently test read/write operations
4. Test cases for vsan volume

Fixes #1254 

Testing: done locally
test-all target passes
e2-test output
```
=== RUN   Test
2017/05/25 22:48:10 START: basic-test.TestVolumeIsolation
2017/05/25 22:48:10 Creating volume [basic_test_volume_1495752490] on VM [10.192.51.202]
2017/05/25 22:48:13 Checking volume [basic_test_volume_1495752490] availability from VM [10.192.51.202]
2017/05/25 22:48:13 Checking volume [basic_test_volume_1495752490] availability from VM [10.192.51.202]
2017/05/25 22:48:14 Destroying volume [basic_test_volume_1495752490]
2017/05/25 22:48:15 END: basic-test.TestVolumeIsolation
2017/05/25 22:48:15 START: basic-test.TestVolumeLifecycle
2017/05/25 22:48:15 Creating volume [basic_test_volume_1495752495] on VM [10.192.51.202]
2017/05/25 22:48:17 Checking volume [basic_test_volume_1495752495] availability from VM [10.192.51.202]
2017/05/25 22:48:17 Attaching volume [basic_test_volume_1495752495] on VM [10.192.51.202]
2017/05/25 22:48:19 Confirming attached status for volume [basic_test_volume_1495752495]
2017/05/25 22:48:21 Removing container [basic_test_container_1495752495] on VM [10.192.51.202]
2017/05/25 22:48:22 Confirming detached status for volume [basic_test_volume_1495752495]
2017/05/25 22:48:25 Destroying volume [basic_test_volume_1495752495]
2017/05/25 22:48:26 Checking volume [basic_test_volume_1495752495] availability from VM [10.192.51.202]
2017/05/25 22:48:26 Creating volume [basic_test_volume_1495752495] on VM [10.192.51.202]
2017/05/25 22:48:29 Checking volume [basic_test_volume_1495752495] availability from VM [10.192.51.202]
2017/05/25 22:48:29 Attaching volume [basic_test_volume_1495752495] on VM [10.192.51.202]
2017/05/25 22:48:31 Confirming attached status for volume [basic_test_volume_1495752495]
2017/05/25 22:48:33 Removing container [basic_test_container_1495752495] on VM [10.192.51.202]
2017/05/25 22:48:34 Confirming detached status for volume [basic_test_volume_1495752495]
2017/05/25 22:48:37 Destroying volume [basic_test_volume_1495752495]
2017/05/25 22:48:38 Checking volume [basic_test_volume_1495752495] availability from VM [10.192.51.202]
2017/05/25 22:48:38 END: basic-test.TestVolumeLifecycle
2017/05/25 22:48:38 Creating volume [restart_test_volume_1495752518] on VM [10.192.51.202]
2017/05/25 22:48:40 START: restart_test.TestPluginKill
2017/05/25 22:48:40 Attaching volume [restart_test_volume_1495752518] on VM[10.192.51.202]
2017/05/25 22:48:42 Confirming attached status for volume [restart_test_volume_1495752518]
2017/05/25 22:48:44 Killing vDVS plugin on VM [10.192.51.202]
2017/05/25 22:48:45 Sleep for 2 seconds
2017/05/25 22:48:47 Stopping container [restart_test_container_1495752518] on VM [10.192.51.202]
2017/05/25 22:48:59 Starting container [restart_test_container_1495752518] on VM [10.192.51.202]
2017/05/25 22:49:00 Stopping container [restart_test_container_1495752518] on VM [10.192.51.202]
2017/05/25 22:49:11 Confirming detached status for volume [restart_test_volume_1495752518]
2017/05/25 22:49:14 END: restart_test.TestPluginKill
2017/05/25 22:49:14 Removing container [restart_test_container_1495752518] on VM [10.192.51.202]
2017/05/25 22:49:14 Destroying volume [restart_test_volume_1495752518]
2017/05/25 22:49:15 Creating volume [restart_test_volume_1495752555] on VM [10.192.51.202]
2017/05/25 22:49:17 START: restart_test.TestVolumeStaleMount
2017/05/25 22:49:17 Attaching volume [restart_test_volume_1495752555] on VM [10.192.51.202]
2017/05/25 22:49:18 Confirming attached status for volume [restart_test_volume_1495752555]
2017/05/25 22:49:20 Killing docker on VM [10.192.51.202]
2017/05/25 22:49:21 Sleep for 2 seconds
2017/05/25 22:49:23 Confirming detached status for volume [restart_test_volume_1495752555]
2017/05/25 22:49:47 END: restart_test.TestVolumeStaleMount
2017/05/25 22:49:47 Removing container [restart_test_container_1495752555] on VM [10.192.51.202]
2017/05/25 22:49:47 Destroying volume [restart_test_volume_1495752555]
2017/05/25 22:49:48 Finding VM name from IP Address [10.192.51.202]
2017/05/25 22:49:49 START: Test vmdkops service restart + kill vm process
2017/05/25 22:49:49 Creating volume [vmlistener_test_volume_1495752589] on VM [10.192.51.202]
2017/05/25 22:49:51 Attaching volume [vmlistener_test_volume_1495752589] on VM [10.192.51.202]
2017/05/25 22:49:53 Confirming attached status for volume [vmlistener_test_volume_1495752589]
2017/05/25 22:49:54 Restarting vmdkops service on ESX host [10.192.59.225]
2017/05/25 22:49:58 Confirming attached status for volume [vmlistener_test_volume_1495752589]
2017/05/25 22:50:01 Retrieving VM power state for [ubuntu-VM0.2]
2017/05/25 22:50:02 VM[ubuntu-VM0.2]'s current power state is [poweredOn]
2017/05/25 22:50:02 Retrieving World ID for VM [ubuntu-VM0.2] from ESX [10.192.59.225]
2017/05/25 22:50:03 VM's process ID is: 2046140
2017/05/25 22:50:03 Killing VM from ESX [10.192.59.225]
2017/05/25 22:50:04 Sleep for 10 seconds
2017/05/25 22:50:14 Retrieving VM power state for [ubuntu-VM0.2]
2017/05/25 22:50:15 VM[ubuntu-VM0.2]'s current power state is [poweredOff]
2017/05/25 22:50:16 Powering on VM [ubuntu-VM0.2]
2017/05/25 22:50:18 Sleep for 35 seconds
2017/05/25 22:50:53 Retrieving VM power state for [ubuntu-VM0.2]
2017/05/25 22:50:54 VM[ubuntu-VM0.2]'s current power state is [poweredOn]
2017/05/25 22:50:54 Confirming detached status for volume [vmlistener_test_volume_1495752589]
2017/05/25 22:50:58 END: Test vmdkops service restart + kill vm process
2017/05/25 22:50:58 Destroying volume [vmlistener_test_volume_1495752589]
2017/05/25 22:50:58 Finding Datastores available on ESX
2017/05/25 22:50:59 Datastores found are [sharedVmfs-0 sharedVmfs-1 local.2-0 local.2-1 local.2-2 vsanDatastore]
2017/05/25 22:50:59 Creating volume [BpLnfgDsc2WD8F2qNfHK5a84jjJkwzDkh9h2fhfUVuS9jZ8uVbhV3vC5AWX39IVUWSP2NcHciWvqZTa2N95RxRTZHWUsaD6HEdz0T] on VM [10.192.51.202]
2017/05/25 22:51:00 Creating volume [Volume-000000] on VM [10.192.51.202]
2017/05/25 22:51:01 Creating volume [Volume_volume_1495752659@invalidDatastore] on VM [10.192.51.202]
2017/05/25 22:51:01 Creating volume [invalid_opts_volume_1495752661] with options [ -o diskformat=zeroedthickk] on VM [10.192.51.202]
2017/05/25 22:51:02 Creating volume [invalid_opts_volume_1495752662] with options [ -o diskformat=zeroedthick,thin] on VM [10.192.51.202]
2017/05/25 22:51:03 Creating volume [invalid_opts_volume_1495752663] with options [ -o size=100mbb] on VM [10.192.51.202]
2017/05/25 22:51:03 Creating volume [invalid_opts_volume_1495752663] with options [ -o size=100gbEE] on VM [10.192.51.202]
2017/05/25 22:51:04 Creating volume [invalid_opts_volume_1495752664] with options [ -o sizes=100mb] on VM [10.192.51.202]
2017/05/25 22:51:05 Creating volume [invalid_opts_volume_1495752665] with options [ -o fstype=xfs_ext] on VM [10.192.51.202]
2017/05/25 22:51:06 Creating volume [invalid_opts_volume_1495752666] with options [ -o access=read-write-both] on VM [10.192.51.202]
2017/05/25 22:51:06 Creating volume [invalid_opts_volume_1495752666] with options [ -o access=write-only] on VM [10.192.51.202]
2017/05/25 22:51:07 Creating volume [invalid_opts_volume_1495752667] with options [ -o access=read-write-both] on VM [10.192.51.202]
2017/05/25 22:51:07 Creating volume [invalid_opts_volume_1495752667] with options [ -o clone-from=IDontExist] on VM [10.192.51.202]
2017/05/25 22:51:08 Creating volume [hbXfQ6pYSQ3n267l1VQKGNbSuJE9fQbzONJAAwdCxmM8BIabKERsUhPNmMmdf2eSJyYtqwcFiUILzXv2fcNIrWO7sToFgoilA0U1] on VM [10.192.51.202]
2017/05/25 22:51:10 Checking volume [hbXfQ6pYSQ3n267l1VQKGNbSuJE9fQbzONJAAwdCxmM8BIabKERsUhPNmMmdf2eSJyYtqwcFiUILzXv2fcNIrWO7sToFgoilA0U1] availability from VM [10.192.51.202]
2017/05/25 22:51:11 Creating volume [Volume-0000000-****-###] on VM [10.192.51.202]
2017/05/25 22:51:13 Checking volume [Volume-0000000-****-###] availability from VM [10.192.51.202]
2017/05/25 22:51:14 Creating volume [Volume-00000] on VM [10.192.51.202]
2017/05/25 22:51:16 Checking volume [Volume-00000] availability from VM [10.192.51.202]
2017/05/25 22:51:17 Creating volume [Volume-0000000] on VM [10.192.51.202]
2017/05/25 22:51:19 Checking volume [Volume-0000000] availability from VM [10.192.51.202]
2017/05/25 22:51:20 Creating volume [abc_volume_1495752668@sharedVmfs-0] on VM [10.192.51.202]
2017/05/25 22:51:22 Checking volume [abc_volume_1495752668@sharedVmfs-0] availability from VM [10.192.51.202]
2017/05/25 22:51:22 Creating volume [abc_volume_1495752668@@@@sharedVmfs-0] on VM [10.192.51.202]
2017/05/25 22:51:24 Checking volume [abc_volume_1495752668@@@@sharedVmfs-0] availability from VM [10.192.51.202]
2017/05/25 22:51:25 Creating volume [Volume-你_volume_1495752668] on VM [10.192.51.202]
2017/05/25 22:51:27 Checking volume [Volume-你_volume_1495752668] availability from VM [10.192.51.202]
2017/05/25 22:51:28 Destroying volume [hbXfQ6pYSQ3n267l1VQKGNbSuJE9fQbzONJAAwdCxmM8BIabKERsUhPNmMmdf2eSJyYtqwcFiUILzXv2fcNIrWO7sToFgoilA0U1]
2017/05/25 22:51:29 Destroying volume [Volume-0000000-****-###]
2017/05/25 22:51:29 Destroying volume [Volume-00000]
2017/05/25 22:51:30 Destroying volume [Volume-0000000]
2017/05/25 22:51:31 Destroying volume [abc_volume_1495752668@sharedVmfs-0]
2017/05/25 22:51:32 Destroying volume [abc_volume_1495752668@@@@sharedVmfs-0]
2017/05/25 22:51:33 Destroying volume [Volume-你_volume_1495752668]
2017/05/25 22:51:34 Creating volume [clone_src_volume_1495752694] on VM [10.192.51.202]
2017/05/25 22:51:36 Creating volume [valid_opts_volume_1495752696] with options [ -o size=10gb] on VM [10.192.51.202]
2017/05/25 22:51:40 Checking volume [valid_opts_volume_1495752696] availability from VM [10.192.51.202]
2017/05/25 22:51:41 Creating volume [valid_opts_volume_1495752701] with options [ -o diskformat=zeroedthick] on VM [10.192.51.202]
2017/05/25 22:51:43 Checking volume [valid_opts_volume_1495752701] availability from VM [10.192.51.202]
2017/05/25 22:51:44 Creating volume [valid_opts_volume_1495752704] with options [ -o diskformat=thin] on VM [10.192.51.202]
2017/05/25 22:51:46 Checking volume [valid_opts_volume_1495752704] availability from VM [10.192.51.202]
2017/05/25 22:51:46 Creating volume [valid_opts_volume_1495752706] with options [ -o diskformat=eagerzeroedthick] on VM [10.192.51.202]
2017/05/25 22:51:49 Checking volume [valid_opts_volume_1495752706] availability from VM [10.192.51.202]
2017/05/25 22:51:49 Creating volume [valid_opts_volume_1495752709] with options [ -o attach-as=independent_persistent] on VM [10.192.51.202]
2017/05/25 22:51:51 Checking volume [valid_opts_volume_1495752709] availability from VM [10.192.51.202]
2017/05/25 22:51:52 Creating volume [valid_opts_volume_1495752712] with options [ -o attach-as=persistent] on VM [10.192.51.202]
2017/05/25 22:51:54 Checking volume [valid_opts_volume_1495752712] availability from VM [10.192.51.202]
2017/05/25 22:51:55 Creating volume [valid_opts_volume_1495752715] with options [ -o fstype=ext4] on VM [10.192.51.202]
2017/05/25 22:51:57 Checking volume [valid_opts_volume_1495752715] availability from VM [10.192.51.202]
2017/05/25 22:51:57 Creating volume [valid_opts_volume_1495752717] with options [ -o access=read-only] on VM [10.192.51.202]
2017/05/25 22:51:59 Checking volume [valid_opts_volume_1495752717] availability from VM [10.192.51.202]
2017/05/25 22:52:00 Creating volume [valid_opts_volume_1495752720] with options [ -o access=read-write] on VM [10.192.51.202]
2017/05/25 22:52:02 Checking volume [valid_opts_volume_1495752720] availability from VM [10.192.51.202]
2017/05/25 22:52:03 Creating volume [valid_opts_volume_1495752723] with options [ -o clone-from=clone_src_volume_1495752694] on VM [10.192.51.202]
2017/05/25 22:52:05 Checking volume [valid_opts_volume_1495752723] availability from VM [10.192.51.202]
2017/05/25 22:52:06 Creating volume [WxNeW1gdgUVD] with options [ -o fstype=xfs] on VM [10.192.51.202]
2017/05/25 22:52:08 Checking volume [WxNeW1gdgUVD] availability from VM [10.192.51.202]
2017/05/25 22:52:09 Destroying volume [clone_src_volume_1495752694]
2017/05/25 22:52:10 Destroying volume [valid_opts_volume_1495752696]
2017/05/25 22:52:10 Destroying volume [valid_opts_volume_1495752701]
2017/05/25 22:52:11 Destroying volume [valid_opts_volume_1495752704]
2017/05/25 22:52:12 Destroying volume [valid_opts_volume_1495752706]
2017/05/25 22:52:13 Destroying volume [valid_opts_volume_1495752709]
2017/05/25 22:52:14 Destroying volume [valid_opts_volume_1495752712]
2017/05/25 22:52:14 Destroying volume [valid_opts_volume_1495752715]
2017/05/25 22:52:15 Destroying volume [valid_opts_volume_1495752717]
2017/05/25 22:52:16 Destroying volume [valid_opts_volume_1495752720]
2017/05/25 22:52:17 Destroying volume [valid_opts_volume_1495752723]
2017/05/25 22:52:18 Destroying volume [WxNeW1gdgUVD]
2017/05/25 22:52:18 Finding Datastores available on ESX
2017/05/25 22:52:19 Creating policy [validPolicy] with content ['(("proportionalCapacity" i50)''("hostFailuresToTolerate" i0))'] on ESX [10.192.59.225]
2017/05/25 22:52:20 Creating policy [invalidPolicy] with content ['(("wrongKey" i50)'] on ESX [10.192.59.225]
2017/05/25 22:52:21 Creating volume [vsanVol_volume_1495752741@vsanDatastore] with options [ -o vsan-policy-name=validPolicy] on VM [10.192.51.202]
2017/05/25 22:52:24 Checking volume [vsanVol_volume_1495752741@vsanDatastore] availability from VM [10.192.51.202]
2017/05/25 22:52:25 Creating volume [vsanVol_volume_1495752745@vsanDatastore] with options [-o vsan-policy-name=IDontExist] on VM [10.192.51.202]
2017/05/25 22:52:25 Creating volume [vsanVol_volume_1495752745@vsanDatastore] with options [-o vsan-policy-name=invalidPolicy] on VM [10.192.51.202]
2017/05/25 22:52:27 Destroying volume [vsanVol_volume_1495752741@vsanDatastore]
OK: 10 passed
--- PASS: Test (257.52s)
```