### PR TITLE
Introducing common e2e test utils

### DIFF
--- a/tests/constants/admincli/cmd.go
+++ b/tests/constants/admincli/cmd.go
@@ -26,6 +26,12 @@ const (
 	// ListVolumes referring to vmdkops_admin volume ls
 	ListVolumes = vmdkopsAdminVolume + "ls "
 
+	// CreatePolicy Create a policy
+	CreatePolicy = vmdkopsAdmin + " policy create "
+
+	// SetVolumeAccess set volume access
+	SetVolumeAccess = vmdkopsAdminVolume + " set "
+
 	// CreateVMgroup referring to create vmgroup
 	// where --name will be name of the vmgroup
 	CreateVMgroup = vmdkopsAdmin + "vmgroup create --name="

--- a/tests/constants/dockercli/cmd.go
+++ b/tests/constants/dockercli/cmd.go
@@ -71,8 +71,11 @@ const (
 	// RemoveContainer remove the container
 	RemoveContainer = docker + "rm -f "
 
+	// ContainerImage busybox container image
+	ContainerImage = " busybox "
+
 	// TestContainer test busybox container that keeps running
-	TestContainer = " busybox tail -f /dev/null "
+	TestContainer = ContainerImage + " tail -f /dev/null "
 
 	// QueryContainer checks whether container exists or not
 	QueryContainer = docker + "ps -aq --filter name="

--- a/tests/constants/govc/cli.go
+++ b/tests/constants/govc/cli.go
@@ -25,6 +25,12 @@ const (
 	// VMInfoByIP refers to govc query to grab VM IP from VM info object
 	VMInfoByIP = VMInfo + "-vm.ip="
 
+	// DatastoreInfo get datastore info from govc
+	DatastoreInfo = govcCmd + "datastore.info "
+
+	// DatastoreList get the list of datastore names from govc output
+	DatastoreList = ".Datastores[].Name "
+
 	// JSONTypeOutput sets govc response type
 	JSONTypeOutput = " -json "
 

--- a/tests/utils/admincli/cmd.go
+++ b/tests/utils/admincli/cmd.go
@@ -1,0 +1,37 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This util is holding misc small functions for operations to be done using admincli on esx
+
+package admincli
+
+import (
+	"log"
+
+	"github.com/vmware/docker-volume-vsphere/tests/constants/admincli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/ssh"
+)
+
+// CreatePolicy creates a policy
+func CreatePolicy(ip, name, content string) (string, error) {
+	log.Printf("Creating policy [%s] with content [%s] on ESX [%s]\n", name, content, ip)
+	return ssh.InvokeCommand(ip, admincli.CreatePolicy+" --name "+name+" --content "+content)
+}
+
+// UpdateVolumeAccess update the volume access as per params
+func UpdateVolumeAccess(ip, volName, vmgroup, access string) (string, error) {
+	log.Printf("Updating access to [%s] for volume [%s] ", access, volName)
+	return ssh.InvokeCommand(ip, admincli.SetVolumeAccess+" --vmgroup="+vmgroup+
+		" --volume="+volName+" --options=\"access="+access+"\"")
+}

--- a/tests/utils/dockercli/volumelifecycle.go
+++ b/tests/utils/dockercli/volumelifecycle.go
@@ -33,6 +33,12 @@ func CreateVolume(ip, name string) (string, error) {
 	return ssh.InvokeCommand(ip, dockercli.CreateVolume+"--name="+name)
 }
 
+// CreateVolumeWithOptions is going to create vsphere docker volume with given name.
+func CreateVolumeWithOptions(ip, name, options string) (string, error) {
+	log.Printf("Creating volume [%s] with options [%s] on VM [%s]\n", name, options, ip)
+	return ssh.InvokeCommand(ip, dockercli.CreateVolume+"--name="+name+" "+options)
+}
+
 // AttachVolume - attach volume to container on given host
 func AttachVolume(ip, volName, containerName string) (string, error) {
 	log.Printf("Attaching volume [%s] on VM [%s]\n", volName, ip)
@@ -49,6 +55,26 @@ func AttachVolumeWithRestart(ip, volName, containerName string) (string, error) 
 	return ssh.InvokeCommand(ip, dockercli.RunContainer+" --restart=always -d -v "+volName+
 		":/vol1 --name "+containerName+
 		dockercli.TestContainer)
+}
+
+// WriteToVolume write data to a given file on given volume
+func WriteToVolume(ip, volName, containerName, fileName, data string) (string, error) {
+	log.Printf("Writing %s to file %s on volume [%s] from VM[%s]\n", data, fileName, volName, ip)
+
+	writeCmd := " /bin/sh -c 'echo \"" + data + "\" > /vol1/test.txt'"
+	return ssh.InvokeCommand(ip, dockercli.RunContainer+" -v "+volName+
+		":/vol1 --name "+containerName+dockercli.ContainerImage+
+		writeCmd)
+}
+
+// ReadFromVolume read content of given file on a given volume
+func ReadFromVolume(ip, volName, containerName, fileName string) (string, error) {
+	log.Printf("Reading from file %s on volume [%s] from VM[%s]\n", fileName, volName, ip)
+
+	readCmd := " /bin/sh -c 'cat /vol1/" + fileName + "'"
+	return ssh.InvokeCommand(ip, dockercli.RunContainer+" -v "+volName+
+		":/vol1 --name "+containerName+dockercli.ContainerImage+
+		readCmd)
 }
 
 // DeleteVolume helper deletes the created volume as per passed volume name.

--- a/tests/utils/govc/cmd.go
+++ b/tests/utils/govc/cmd.go
@@ -22,6 +22,7 @@ package govc
 
 import (
 	"log"
+	"strings"
 
 	"github.com/vmware/docker-volume-vsphere/tests/constants/govc"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/ssh"
@@ -48,5 +49,19 @@ func GetVMPowerState(vmName string) string {
 func PowerOnVM(vmName string) string {
 	log.Printf("Powering on VM [%s]\n", vmName)
 	cmd := govc.PowerOnVM + vmName
+	return ssh.InvokeCommandLocally(cmd)
+}
+
+// GetDatastoreList returns a list of datastore names available
+func GetDatastoreList() []string {
+	log.Printf("Finding Datastores available on ESX")
+	cmd := govc.DatastoreInfo + govc.JSONTypeOutput + "| " + govc.JSONParser + govc.DatastoreList
+	out := ssh.InvokeCommandLocally(cmd)
+	return strings.Fields(out)
+}
+
+// GetDatastoreByType returns the datastore name of type specified
+func GetDatastoreByType(typeName string) string {
+	cmd := govc.DatastoreInfo + govc.JSONTypeOutput + "| " + govc.JSONParser + " '.Datastores[].Summary | select(.Type==\"" + typeName + "\") | .Name'"
 	return ssh.InvokeCommandLocally(cmd)
 }

--- a/tests/utils/inputparams/testparams.go
+++ b/tests/utils/inputparams/testparams.go
@@ -19,6 +19,7 @@ package inputparams
 
 import (
 	"flag"
+	"math/rand"
 	"os"
 	"strconv"
 	"time"
@@ -51,6 +52,16 @@ func GetVolumeNameWithTimeStamp(volumeName string) string {
 // GetContainerNameWithTimeStamp prepares unique container name by appending current time-stamp value
 func GetContainerNameWithTimeStamp(containerName string) string {
 	return containerName + "_container_" + strconv.FormatInt(time.Now().Unix(), 10)
+}
+
+// GetVolumeNameOfSize returns a random volume name of required length
+func GetVolumeNameOfSize(size int) string {
+	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	result := make([]byte, size)
+	for i := range result {
+		result[i] = chars[rand.Intn(len(chars))]
+	}
+	return string(result)
 }
 
 // GetEndPoint1 returns first VM endpoint supplied through CLI


### PR DESCRIPTION
This PR is a subset of PR #1299. This only includes changes for common test utils.

1. govc utils for datastores and related constants
2. volume read/write utils
3. volume create with options util
4. admincli util to create a policy and update volume access

Testing: e2e-test target passes locally.