### PR TITLE
Improving error message in plugin state where the refcounting hasn't been successful

### DIFF
--- a/vmdk_plugin/drivers/photon/photon_driver.go
+++ b/vmdk_plugin/drivers/photon/photon_driver.go
@@ -114,7 +114,7 @@ func NewVolumeDriver(targetURL string, projectID string, hostID string, mountDir
 
 // Return the number of references for the given volume
 func (d *VolumeDriver) getRefCount(vol string) uint {
-	if d.refCounts.GetInitSuccess() != true {
+	if d.refCounts.IsInitialized() != true {
 		return 1
 	}
 	return d.refCounts.GetCount(vol)
@@ -122,7 +122,7 @@ func (d *VolumeDriver) getRefCount(vol string) uint {
 
 // Increment the reference count for the given volume
 func (d *VolumeDriver) incrRefCount(vol string) uint {
-	if d.refCounts.GetInitSuccess() != true {
+	if d.refCounts.IsInitialized() != true {
 		return 1
 	}
 	return d.refCounts.Incr(vol)
@@ -130,7 +130,7 @@ func (d *VolumeDriver) incrRefCount(vol string) uint {
 
 // Decrement the reference count for the given volume
 func (d *VolumeDriver) decrRefCount(vol string) (uint, error) {
-	if d.refCounts.GetInitSuccess() != true {
+	if d.refCounts.IsInitialized() != true {
 		return 1, nil
 	}
 	return d.refCounts.Decr(vol)
@@ -560,8 +560,10 @@ func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 func (d *VolumeDriver) Remove(r volume.Request) volume.Response {
 	log.WithFields(log.Fields{"name": r.Name}).Info("Removing volume ")
 
-	if d.refCounts.GetInitSuccess() != true {
-		msg := fmt.Sprintf(plugin_utils.ErrorPluginInit+" Cannot remove volume=%s", r.Name)
+	// Cannot remove volumes till plugin completely initializes (refcounting is complete)
+	// because we don't know if it is being used or not
+	if d.refCounts.IsInitialized() != true {
+		msg := fmt.Sprintf(plugin_utils.PluginInitError+" Cannot remove volume=%s", r.Name)
 		log.Error(msg)
 		return volume.Response{Err: msg}
 	}
@@ -639,7 +641,7 @@ func (d *VolumeDriver) Unmount(r volume.UnmountRequest) volume.Response {
 	d.refCounts.StateMtx.Lock()
 	defer d.refCounts.StateMtx.Unlock()
 
-	if d.refCounts.GetInitSuccess() != true {
+	if d.refCounts.IsInitialized() != true {
 		// if refcounting hasn't been succesful,
 		// no refcounting, no unmount. All unmounts are delayed
 		// until we succesfully populate the refcount map

--- a/vmdk_plugin/drivers/photon/photon_driver.go
+++ b/vmdk_plugin/drivers/photon/photon_driver.go
@@ -560,7 +560,13 @@ func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 func (d *VolumeDriver) Remove(r volume.Request) volume.Response {
 	log.WithFields(log.Fields{"name": r.Name}).Info("Removing volume ")
 
-	// Docker is supposed to block 'remove' command if the volume is used. Verify.
+	if d.refCounts.GetInitSuccess() != true {
+		msg := fmt.Sprintf(plugin_utils.ErrorPluginInit+" Cannot remove volume=%s", r.Name)
+		log.Error(msg)
+		return volume.Response{Err: msg}
+	}
+
+	// Docker is supposed to block 'remove' command if the volume is used.
 	if d.getRefCount(r.Name) != 0 {
 		msg := fmt.Sprintf("Remove failure - volume is still mounted. "+
 			" volume=%s, refcount=%d", r.Name, d.getRefCount(r.Name))

--- a/vmdk_plugin/drivers/vmdk/vmdk_driver.go
+++ b/vmdk_plugin/drivers/vmdk/vmdk_driver.go
@@ -422,7 +422,13 @@ func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 func (d *VolumeDriver) Remove(r volume.Request) volume.Response {
 	log.WithFields(log.Fields{"name": r.Name}).Info("Removing volume ")
 
-	// Docker is supposed to block 'remove' command if the volume is used. Verify.
+	if d.refCounts.GetInitSuccess() != true {
+		msg := fmt.Sprintf(plugin_utils.ErrorPluginInit+" Cannot remove volume=%s", r.Name)
+		log.Error(msg)
+		return volume.Response{Err: msg}
+	}
+
+	// Docker is supposed to block 'remove' command if the volume is used.
 	if d.getRefCount(r.Name) != 0 {
 		msg := fmt.Sprintf("Remove failure - volume is still mounted. "+
 			" volume=%s, refcount=%d", r.Name, d.getRefCount(r.Name))

--- a/vmdk_plugin/drivers/vmdk/vmdk_driver.go
+++ b/vmdk_plugin/drivers/vmdk/vmdk_driver.go
@@ -103,7 +103,7 @@ func (d *VolumeDriver) VolumesInRefMap() []string {
 
 // Return the number of references for the given volume
 func (d *VolumeDriver) getRefCount(vol string) uint {
-	if d.refCounts.GetInitSuccess() != true {
+	if d.refCounts.IsInitialized() != true {
 		return 1
 	}
 	return d.refCounts.GetCount(vol)
@@ -111,7 +111,7 @@ func (d *VolumeDriver) getRefCount(vol string) uint {
 
 // Increment the reference count for the given volume
 func (d *VolumeDriver) incrRefCount(vol string) uint {
-	if d.refCounts.GetInitSuccess() != true {
+	if d.refCounts.IsInitialized() != true {
 		return 1
 	}
 	return d.refCounts.Incr(vol)
@@ -119,7 +119,7 @@ func (d *VolumeDriver) incrRefCount(vol string) uint {
 
 // Decrement the reference count for the given volume
 func (d *VolumeDriver) decrRefCount(vol string) (uint, error) {
-	if d.refCounts.GetInitSuccess() != true {
+	if d.refCounts.IsInitialized() != true {
 		return 1, nil
 	}
 	return d.refCounts.Decr(vol)
@@ -422,8 +422,10 @@ func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 func (d *VolumeDriver) Remove(r volume.Request) volume.Response {
 	log.WithFields(log.Fields{"name": r.Name}).Info("Removing volume ")
 
-	if d.refCounts.GetInitSuccess() != true {
-		msg := fmt.Sprintf(plugin_utils.ErrorPluginInit+" Cannot remove volume=%s", r.Name)
+	// Cannot remove volumes till plugin completely initializes (refcounting is complete)
+	// because we don't know if it is being used or not
+	if d.refCounts.IsInitialized() != true {
+		msg := fmt.Sprintf(plugin_utils.PluginInitError+" Cannot remove volume=%s", r.Name)
 		log.Error(msg)
 		return volume.Response{Err: msg}
 	}
@@ -483,7 +485,7 @@ func (d *VolumeDriver) Unmount(r volume.UnmountRequest) volume.Response {
 	d.refCounts.StateMtx.Lock()
 	defer d.refCounts.StateMtx.Unlock()
 
-	if d.refCounts.GetInitSuccess() != true {
+	if d.refCounts.IsInitialized() != true {
 		// if refcounting hasn't been succesful,
 		// no refcounting, no unmount. All unmounts are delayed
 		// until we succesfully populate the refcount map

--- a/vmdk_plugin/utils/plugin_utils/plugin_utils.go
+++ b/vmdk_plugin/utils/plugin_utils/plugin_utils.go
@@ -32,6 +32,9 @@ const (
 	// index datastore from volume meta
 	// "datastore" key is defined in vmdkops service
 	datastoreKey = "datastore"
+
+	// ErrorPluginInit message to indicate that plugin initialization(refcounting) is not yet complete
+	ErrorPluginInit = "Plugin initialization in progress."
 )
 
 // VolumeInfo - Volume fullname, datastore and metadata

--- a/vmdk_plugin/utils/plugin_utils/plugin_utils.go
+++ b/vmdk_plugin/utils/plugin_utils/plugin_utils.go
@@ -33,8 +33,8 @@ const (
 	// "datastore" key is defined in vmdkops service
 	datastoreKey = "datastore"
 
-	// ErrorPluginInit message to indicate that plugin initialization(refcounting) is not yet complete
-	ErrorPluginInit = "Plugin initialization in progress."
+	// PluginInitError message to indicate that plugin initialization(refcounting) is not yet complete
+	PluginInitError = "Plugin initialization in progress."
 )
 
 // VolumeInfo - Volume fullname, datastore and metadata

--- a/vmdk_plugin/utils/refcount/refcnt.go
+++ b/vmdk_plugin/utils/refcount/refcnt.go
@@ -158,7 +158,7 @@ func newRefCount() *refCount {
 }
 
 // return if refcount initialization has been successful
-func (r *RefCountsMap) GetInitSuccess() bool {
+func (r *RefCountsMap) IsInitialized() bool {
 	return r.refcntInitSuccess
 }
 


### PR DESCRIPTION
1. refcount get, incr and decr functions return err instead of 1 in state where refcounting hasn't been successful.
2. updating the callers of above functions to make use of this error

Fixes #1348
