### PR TITLE
Fix tenant_add_vm

### DIFF
--- a/esx_service/utils/auth_api.py
+++ b/esx_service/utils/auth_api.py
@@ -695,7 +695,7 @@ def _tenant_vm_add(name, vm_list):
     if error_info:
         error_info.msg = "Cannot add VM to vmgroup " + error_info.msg
         logging.error(error_info.msg)
-        return error_info, None
+        return error_info
 
     error_info, auth_mgr = get_auth_mgr_object()
 


### PR DESCRIPTION
Minor error in return from _tenant_vm_add when checking for attached volumes to the VM being added to the vmgroup.

The code is using two functions to do the same work in auth_api.py - _tenant_vm_add() and _tenant_vm_replace() both are about the same in functionality - the former is moving the VM from default to a named tenant and the latter from a named tenant to another named tenant. These need to be refactored into a single function so code isn't duplicated.