### PR TITLE
[DO NOT REVIEW] Refactors vmci_client C library

### DIFF
--- a/esx_service/vmci/vmci_client.def
+++ b/esx_service/vmci/vmci_client.def
@@ -1,0 +1,20 @@
+; Copyright 2017 VMware, Inc. All Rights Reserved.
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;    http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+;
+; This file defines the APIs exported by the vmci_client.dll.
+; Only Vmci_GetReply and Vmci_FreeBuf functions are exported.
+
+EXPORTS
+    Vmci_GetReply
+    Vmci_FreeBuf

--- a/esx_service/vmci/vmci_client.h
+++ b/esx_service/vmci/vmci_client.h
@@ -1,0 +1,73 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+//
+// VMCI sockets communication - client side.
+//
+// Called mainly from Go code.
+//
+// API: Exposes Vmci_GetReply and Vmci_FreeBuf.
+//
+
+#include <stdlib.h>
+#include <errno.h>
+#include <stdint.h>
+
+#include "vmci_sockets.h"
+#include "connection_types.h"
+
+#define ERR_BUF_LEN 512
+#define MAXBUF 1024 * 1024 // Safety limit. We do not expect json string > 1M
+#define MAX_CLIENT_PORT 1023 // Last privileged port
+#define START_CLIENT_PORT 100 // Where to start client port
+#define BIND_RETRY_COUNT (MAX_CLIENT_PORT - START_CLIENT_PORT) // Retry entire range on bind failures
+
+// Operations status. 0 is OK
+typedef int be_sock_status;
+
+//
+// Booking structure for opened VMCI / vSocket
+//
+typedef struct {
+   int sock_id; // socket id for socket APIs
+   struct sockaddr_vm addr; // held here for bookkeeping and reporting
+} be_sock_id;
+
+//
+// Protocol message structure: request and reply
+//
+typedef struct be_request {
+   uint32_t mlen;   // length of message (including trailing \0)
+   const char *msg; // null-terminated immutable JSON string.
+} be_request;
+
+typedef struct be_answer {
+   char *buf;                  // response buffer
+   char errBuf[ERR_BUF_LEN];   // error response buffer
+} be_answer;
+
+//
+// Entry point for vsocket requests.
+// Returns NULL for success, -1 for err, and sets errno if needed
+// <ans> is allocated upstairs
+//
+const be_sock_status
+Vmci_GetReply(int port, const char* json_request, const char* be_name, be_answer* ans);
+
+//
+// Frees a be_answer instance.
+//
+void
+Vmci_FreeBuf(be_answer *ans);


### PR DESCRIPTION
## Description
This PR serves as a preparatory step towards the implementation of vDVS Docker plugin for Windows. The goal of this change is to enable building of vmci_client.dll, which will be later used on Windows for communicating with the VMDK Ops Service. The following changes were made in this PR.

* Extracted `vmci_client.h` from `vmci_client.c`.
* Updated `vmci_client.c` to support `Winsock`.
* Added `vmci_client.def` for Windows DLL export.

## Testing Done
This PR doesn't make any behavioral change. I have verified that the build is created successfully. Please find the logs below.

```
Successfully created ../build/vmware-esx-vmdkops-0.14.d618f53.vib.
Successfully created ../build/vmware-esx-vmdkops-0.14.d618f53.zip.
...
{:timestamp=>"2017-06-12T22:22:37.155147+0000", :message=>"Created package", :path=>"../build/docker-volume-vsphere_0.14.d618f53_amd64.deb"}
...
{:timestamp=>"2017-06-12T22:22:41.658924+0000", :message=>"Created package", :path=>"../build/docker-volume-vsphere-0.14.d618f53-1.x86_64.rpm"}
...
Pushing vnoronha/docker-volume-vsphere:0.15-dev to dockerhub.io...
The push refers to a repository [docker.io/vnoronha/docker-volume-vsphere]
4267062181ef: Pushed
...
```

P.S. This PR has already been reviewed by @pshahzeb and @shaominchen.