### PR TITLE
Make configuration DB location survive ESXi reboot

### DIFF
--- a/esx_service/cli/local_sh.py
+++ b/esx_service/cli/local_sh.py
@@ -17,7 +17,7 @@
 """
 Support for adding/removing information about config db link from /etc/rc.local.d/local.sh
 Any config stuff we need and configure in /etc/... will be removed on ESX reboot.
-Anything we need to persist between the reboots, needs to be confugured here.
+Anything we need to persist between the reboots, needs to be configured here.
 """
 
 import sys
@@ -28,10 +28,10 @@ import fileinput
 # We need to insert the content before it.
 END_OF_SCRIPT = "exit 0"
 
-# This is what we use to identify the our content for DB links..
+# This is what we use to identify the content for DB links..
 CONFIG_DB_TAG = "# -- vSphere Docker Volume Service configuration --"
 
-# This is the content tempate for db links. '{}' will be replaced by datastore name
+# This is the content template for db links. '{}' will be replaced by datastore name
 CONFIG_DB_INFO = CONFIG_DB_TAG + \
 """
 #
@@ -42,27 +42,30 @@ CONFIG_DB_INFO = CONFIG_DB_TAG + \
 datastore={}
 
 slink=/etc/vmware/vmdkops/auth-db
-shared_dbn=/vmfs/volumes/$datastore/dockvols/vmdkops_config.db
+shared_db=/vmfs/volumes/$datastore/dockvols/vmdkops_config.db
 
-if [ -d $(basename $slink) ] && [ ! -e $slink  ]
+if [ -d $(dirname $slink) ] && [ ! -e $slink  ]
 then
     ln -s $shared_db $slink
 fi
 
 """ + CONFIG_DB_TAG + "\n"
 
+# full path of local.sh script, used to make things persistent between ESXi reboots
+LOCAL_SH_PATH = '/etc/rc.local.d/local.sh'
+
 
 # open file and scan it.
 #
-# if we reached "exit 0" add the text section, add the rest of the file and be done
-# if we find the tag,  skip to the end of the section
+# if we reach "exit 0", then add the text section, add the rest of the file and be done
+# if we find the tag, then skip to the end of the section
 #
-def update_content(content, tag, add=True, file="/etc/rc.local.d/local.sh"):
+def update_content(content, tag, add=True, file=LOCAL_SH_PATH):
     """
     A generic function to update (add or removes) <content> limited with <tag>s, in a <file>
     """
     if not os.path.exists(file):
-        return # silenty do nothing if the file does not exit
+        return # silently do nothing if the file does not exit
     skip_to_tag = no_more_checks = False
     for line in iter(fileinput.input([file], inplace=True, backup=".bck")):
         if no_more_checks:

--- a/esx_service/cli/local_sh.py
+++ b/esx_service/cli/local_sh.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+#
+#  Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Support for adding/removing information about config db link from /etc/rc.local.d/local.sh
+Any config stuff we need and configure in /etc/... will be removed on ESX reboot.
+Anything we need to persist between the reboots, needs to be confugured here.
+"""
+
+import sys
+import os.path
+import fileinput
+
+# We expect this record at the end of the local.sh.
+# We need to insert the content before it.
+END_OF_SCRIPT = "exit 0"
+
+# This is what we use to identify the our content for DB links..
+CONFIG_DB_TAG = "# -- vSphere Docker Volume Service configuration --"
+
+# This is the content tempate for db links. '{}' will be replaced by datastore name
+CONFIG_DB_INFO = CONFIG_DB_TAG + \
+"""
+#
+# Please do not edit this section manually. It is managed by vmdkops_admin.py config command.
+# Note: the code relies on local.sh having "exit 0" at the end.
+#
+
+datastore={}
+
+slink=/etc/vmware/vmdkops/auth-db
+shared_dbn=/vmfs/volumes/$datastore/dockvols/vmdkops_config.db
+
+if [ -d $(basename $slink) ] && [ ! -e $slink  ]
+then
+    ln -s $shared_db $slink
+fi
+
+""" + CONFIG_DB_TAG + "\n"
+
+
+# open file and scan it.
+#
+# if we reached "exit 0" add the text section, add the rest of the file and be done
+# if we find the tag,  skip to the end of the section
+#
+def update_content(content, tag, add=True, file="/etc/rc.local.d/local.sh"):
+    """
+    A generic function to update (add or removes) <content> limited with <tag>s, in a <file>
+    """
+    if not os.path.exists(file):
+        return # silenty do nothing if the file does not exit
+    skip_to_tag = no_more_checks = False
+    for line in iter(fileinput.input([file], inplace=True, backup=".bck")):
+        if no_more_checks:
+            sys.stdout.write(line)
+            continue
+        if skip_to_tag:
+            if line.startswith(tag):
+                # found the second tag, complete operation.
+                no_more_checks = True
+            continue
+        if line.startswith(tag):
+            # First tag - add the content (if needed) and skip till the next tag
+            if add:
+                sys.stdout.write(content)
+            skip_to_tag = True
+            continue
+        if line.startswith(END_OF_SCRIPT):
+            if add:
+                sys.stdout.write(content)
+            no_more_checks = True
+        sys.stdout.write(line)
+    if not no_more_checks:
+        # for some reason we did not find 'exit 0' nor tag, so let's dump the
+        # requested content just in case.
+        if add:
+            sys.stdout.write(content)
+
+
+def update_symlink_info(ds_name="n/a", add=True):
+    """Convenience wrapper for updating symlink info only"""
+    update_content(CONFIG_DB_INFO.format(ds_name), CONFIG_DB_TAG, add=add)
+

--- a/esx_service/cli/local_sh_test.py
+++ b/esx_service/cli/local_sh_test.py
@@ -27,14 +27,14 @@ import local_sh
 import shutil
 
 class TestLocalShInfo(unittest.TestCase):
-    """ Basic test for saving cofig DB link uising local.sh. The test checks saving
+    """ Basic test for saving config DB link using local.sh. The test checks saving
     data into the sh-like fie """
 
     # Basic test: add new content. Replace it. Remove it.
     # Compare with original content - should be the same.
-    # Also, on neach step check some pattern in the current file
+    # Also, on each step check some pattern in the current file
     def test_fileops(self):
-        """Basic unit test - validates file operaiton on a tmp fake file """
+        """Basic unit test - validates file operation on a tmp fake file """
 
         test_content = """
 #!/bin/bash some
@@ -60,7 +60,7 @@ exit 0
         with open(name) as file_id:
             final_content = file_id.read()
         if final_content != test_content:
-            self.assertEqual("result:\n{}\nexcpected:\n{}\n".format(final_content, test_content),
+            self.assertEqual("result:\n{}\n expected :\n{}\n".format(final_content, test_content),
                              None)
         else:
             print("local.sh update/remove test - All good")

--- a/esx_service/cli/local_sh_test.py
+++ b/esx_service/cli/local_sh_test.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+#  Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit  test invocation for local_sh.py
+"""
+
+import os
+import unittest
+import tempfile
+
+import log_config
+import local_sh
+import shutil
+
+class TestLocalShInfo(unittest.TestCase):
+    """ Basic test for saving cofig DB link uising local.sh. The test checks saving
+    data into the sh-like fie """
+
+    # Basic test: add new content. Replace it. Remove it.
+    # Compare with original content - should be the same.
+    # Also, on neach step check some pattern in the current file
+    def test_fileops(self):
+        """Basic unit test - validates file operaiton on a tmp fake file """
+
+        test_content = """
+#!/bin/bash some
+#stuff for rc.local.d/local.sh
+
+# more
+Some more code() !
+
+exit 0
+
+"""
+
+        name = tempfile.mktemp()
+        with open(name, "w") as f:
+            f.write(test_content)
+        for ds_name in ["DSTest1", "DSTest2", "DSTest3"]:
+            local_sh.update_content(content=local_sh.CONFIG_DB_INFO.format(ds_name),
+                                    tag=local_sh.CONFIG_DB_TAG, file=name)
+            with open(name) as file_id:
+                if file_id.read().find(ds_name) == -1:
+                    self.assertEqual("failed with {}".format(ds_name), None)
+        local_sh.update_content(content=None, tag=local_sh.CONFIG_DB_TAG, file=name, add=False)
+        with open(name) as file_id:
+            final_content = file_id.read()
+        if final_content != test_content:
+            self.assertEqual("result:\n{}\nexcpected:\n{}\n".format(final_content, test_content),
+                             None)
+        else:
+            print("local.sh update/remove test - All good")
+        os.remove(name)
+
+
+if __name__ == "__main__":
+    log_config.configure()
+    unittest.main()

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -45,12 +45,14 @@ from error_code import ErrorCode
 from error_code import error_code_to_message
 from error_code import generate_error_info
 
+# generic strings
 NOT_AVAILABLE = 'N/A'
 UNSET = "Unset"
 
 # Volume attributes
 VOL_SIZE = 'size'
 VOL_ALLOC = 'allocated'
+
 
 def main():
     log_config.configure()
@@ -1288,7 +1290,7 @@ def config_init(args):
     else:
         print("Creating a symlink to {} at {}".format(db_path, link_path))
         create_db_symlink(db_path, link_path)
-        print("Updating /etc/rc.local.d/local.sh")
+        print("Updating {}".format(local_sh.LOCAL_SH_PATH))
         local_sh.update_symlink_info(args.datastore)
 
     return None
@@ -1349,7 +1351,7 @@ def config_rm(args):
                 print("Removed link {}".format(link_path))
             except Exception as ex:
                 print(" Failed to remove {}: {}".format(link_path, ex))
-            print("Updating /etc/rc.local.d/local.sh")
+            print("Updating {}".format(local_sh.LOCAL_SH_PATH))
             local_sh.update_symlink_info(add=False)
             return None
 

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -1331,7 +1331,17 @@ def config_rm(args):
             info = auth.get_info()
             mode = auth.mode # for usage outside of the 'with'
         except auth_data.DbAccessError as ex:
-            return err_out(str(ex))
+            # the DB is broken and is being asked to be removed, so let's oblige
+            print("Received error - removing comfiguration anyways. Err: \"{}\"".format(str(ex)))
+            try:
+                os.remove(auth_data.AUTH_DB_PATH)
+            except:
+                pass
+            return None
+
+    # mode is NotConfigured, path does not exist, nothing to remove
+    if mode == auth_data.DBMode.NotConfigured:
+        return None
 
     # mode is NotConfigured, path does not exist
     if mode == auth_data.DBMode.NotConfigured:


### PR DESCRIPTION
 Fixes #1347

On reboot all changes in /etc are lost, unless they are backed up.
ESXi has a standard backup for /etc/rc.local.d/local.sh - this file is
backed up and run on boot ,so to persist symlink to shared DB we need to
insert the link creation to local.sh. And when we drop the link, we need
to clean up the local.sh

This is exactly what this change is doing.

**Tested - unit test attached. Admin_cli tested manually:** 

**Add**:

```
[root@msterin-esx-136:/usr/lib/vmware/vmdkops/bin] ./vmdkops_admin.py config init --datastore=datastore1 --force                                                                                                                               
Warning: this feature is EXPERIMENTAL                                                                                                                                                                                                          
Creating a symlink to /vmfs/volumes/datastore1/dockvols/vmdkops_config.db at /etc/vmware/vmdkops/auth-db                                                                                                                                       
Updating /etc/rc.local.d/local.sh                                                                                                                                                                                                              
[root@msterin-esx-136:/usr/lib/vmware/vmdkops/bin] cat /etc/rc.local.d/local.sh                                                                                                                                                                
#!/bin/sh                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                               
# local configuration options                                                                                                                                                                                                                  
                                                                                                                                                                                                                                               
# Note: modify at your own risk!  If you do/use anything in this                                                                                                                                                                               
# script that is not part of a stable API (relying on files to be in                                                                                                                                                                           
# specific places, specific tools, specific output, etc) there is a                                                                                                                                                                            
# possibility you will end up with a broken system after patching or                                                                                                                                                                           
# upgrading.  Changes are not supported unless under direction of                                                                                                                                                                              
# VMware support.                                                                                                                                                                                                                              
                                                                                                                                                                                                                                               
# Note: This script will not be run when UEFI secure boot is enabled.                                                                                                                                                                          
                                                                                                                                                                                                                                               
# -- vSphere Docker Volume Service configuration --                                                                                                                                                                                            
#                                                                                                                                                                                                                                              
# Please do not edit this section manually. It is managed by vmdkops_admin.py config command.                                                                                                                                                  
# Note: the code relies on local.sh having "exit 0" at the end.                                                                                                                                                                                
#                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                               
datastore=datastore1                                                                                                                                                                                                                           
                                                                                                                                                                                                                                               
slink=/etc/vmware/vmdkops/auth-db                                                                                                                                                                                                              
shared_dbn=/vmfs/volumes/$datastore/dockvols/vmdkops_config.db                                                                                                                                                                                 
                                                                                                                                                                                                                                               
if [ -d $(basename $slink) ] && [ ! -e $slink  ]                                                                                                                                                                                               
then                                                                                                                                                                                                                                           
    ln -s $shared_db $slink                                                                                                                                                                                                                    
fi                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                               
# -- vSphere Docker Volume Service configuration --                                                                                                                                                                                            
exit 0                                                                                                                                                                                                                                         
[root@msterin-esx-136:/usr/lib/vmware/vmdkops/bin>
```

**remove** : 
```
[root@msterin-esx-136:/usr/lib/vmware/vmdkops/bin] ./vmdkops_admin.py config rm --unlink --confirm
Removed link /etc/vmware/vmdkops/auth-db
Updating /etc/rc.local.d/local.sh
[root@msterin-esx-136:/usr/lib/vmware/vmdkops/bin] cat /etc/rc.local.d/local.sh
#!/bin/sh

# local configuration options

# Note: modify at your own risk!  If you do/use anything in this
# script that is not part of a stable API (relying on files to be in
# specific places, specific tools, specific output, etc) there is a
# possibility you will end up with a broken system after patching or
# upgrading.  Changes are not supported unless under direction of
# VMware support.

# Note: This script will not be run when UEFI secure boot is enabled.

exit 0
[root@msterin-esx-136:/usr/lib/vmware/vmdkops/bin]
```
