### PR TITLE
Silencing e2e test ssh util

### DIFF
--- a/tests/utils/ssh/ssh.go
+++ b/tests/utils/ssh/ssh.go
@@ -39,9 +39,6 @@ func InvokeCommand(ip, cmd string) (string, error) {
 	sshIdentity := []string{sshKeyOpt[0], sshKeyOpt[1], "-q", "-kTax", "-o StrictHostKeyChecking=no"}
 
 	out, err := exec.Command("/usr/bin/ssh", append(sshIdentity, "root@"+ip, cmd)...).CombinedOutput()
-	if err != nil {
-		log.Printf("Failed to invoke command [%s]: %v", cmd, err)
-	}
 	return strings.TrimSpace(string(out[:])), err
 }
 


### PR DESCRIPTION
ssh util to execute a command remotely yells a print  "Failed to invoke command" in case the command failed. But the command is expected to fail in some negative test cases. Such prints become misleading.
removing the print, since all tests handle error prints in test assertion comments (assert Commentf).

Testing: Done locally. e2e-test passes.
Fixes #1389 