### PR TITLE
Making volume create and access tests unstable

### DIFF
--- a/tests/constants/dockercli/cmd.go
+++ b/tests/constants/dockercli/cmd.go
@@ -105,4 +105,7 @@ const (
 
 	// RemoveAllContainers removing all the containers forcefully
 	RemoveAllContainers = docker + "rm $(docker ps -aq) -f"
+
+	// ErrorVolumeCreate Error string prefix when volume creation fails
+	ErrorVolumeCreate = "Error response from daemon: create"
 )

--- a/tests/e2e/volumecreate_test.go
+++ b/tests/e2e/volumecreate_test.go
@@ -14,7 +14,7 @@
 
 // This test is going to cover various volume creation test cases
 
-// +build runonce
+// +build unstable
 
 package e2e
 
@@ -22,16 +22,13 @@ import (
 	"strings"
 	"sync"
 
+	dockerclicon "github.com/vmware/docker-volume-vsphere/tests/constants/dockercli"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/verification"
 
 	. "gopkg.in/check.v1"
-)
-
-const (
-	ErrorVolumeCreate = "Error response from daemon: create"
 )
 
 type VolumeCreateTestSuite struct {
@@ -82,7 +79,7 @@ func (s *VolumeCreateTestSuite) createVolCheck(name, option string, valid bool, 
 	} else {
 		// negative test case
 		c.Assert(err, Not(IsNil), Commentf(out))
-		c.Assert(strings.HasPrefix(out, ErrorVolumeCreate), Equals, true)
+		c.Assert(strings.HasPrefix(out, dockerclicon.ErrorVolumeCreate), Equals, true)
 	}
 }
 

--- a/tests/e2e/vsan_test.go
+++ b/tests/e2e/vsan_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	adminclicon "github.com/vmware/docker-volume-vsphere/tests/constants/admincli"
+	dockerclicon "github.com/vmware/docker-volume-vsphere/tests/constants/dockercli"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/admincli"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/govc"
@@ -116,7 +117,7 @@ func (s *VsanTestSuite) TestInvalidPolicy(c *C) {
 	for _, option := range invalidVsanOpts {
 		invalidVolName := inputparams.GetUniqueVolumeName("vsanVol") + "@" + s.vsanDSName
 		out, _ = dockercli.CreateVolumeWithOptions(s.config.DockerHosts[0], invalidVolName, option)
-		c.Assert(strings.HasPrefix(out, ErrorVolumeCreate), Equals, true)
+		c.Assert(strings.HasPrefix(out, dockerclicon.ErrorVolumeCreate), Equals, true)
 	}
 
 	misc.LogTestEnd(c.TestName())


### PR DESCRIPTION
Minor fix to paste test error const in common place.

Tested locally.
```
target e2e-test-runalways :
OK: 6 passed
--- PASS: Test (207.20s)
PASS

target e2e-test-runonce:
--- PASS: Test (555.88s)
PASS
OK: 16 passed
```