### PR TITLE
Updates vmci_client C library for supporting DLL generation

### DIFF
--- a/esx_service/vmci/vmci_client.def
+++ b/esx_service/vmci/vmci_client.def
@@ -1,0 +1,20 @@
+; Copyright 2017 VMware, Inc. All Rights Reserved.
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;    http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+;
+; This file defines the APIs exported by the vmci_client.dll.
+; Only Vmci_GetReply and Vmci_FreeBuf functions are exported.
+
+EXPORTS
+    Vmci_GetReply
+    Vmci_FreeBuf

--- a/esx_service/vmci/vmci_client.h
+++ b/esx_service/vmci/vmci_client.h
@@ -1,0 +1,71 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+//
+// VMCI sockets communication - client side.
+//
+// API: Exposes Vmci_GetReply and Vmci_FreeBuf.
+//
+
+#include <stdlib.h>
+#include <errno.h>
+#include <stdint.h>
+
+#include "vmci_sockets.h"
+#include "connection_types.h"
+
+#define ERR_BUF_LEN 512
+#define MAXBUF 1024 * 1024 // Safety limit. We do not expect json string > 1M
+#define MAX_CLIENT_PORT 1023 // Last privileged port
+#define START_CLIENT_PORT 100 // Where to start client port
+#define BIND_RETRY_COUNT (MAX_CLIENT_PORT - START_CLIENT_PORT) // Retry entire range on bind failures
+
+// Operations status. 0 is OK
+typedef int be_sock_status;
+
+//
+// Booking structure for opened VMCI / vSocket
+//
+typedef struct {
+   int sock_id; // socket id for socket APIs
+   struct sockaddr_vm addr; // held here for bookkeeping and reporting
+} be_sock_id;
+
+//
+// Protocol message structure: request and reply
+//
+typedef struct be_request {
+   uint32_t mlen;   // length of message (including trailing \0)
+   const char *msg; // null-terminated immutable JSON string.
+} be_request;
+
+typedef struct be_answer {
+   char *buf;                  // response buffer
+   char errBuf[ERR_BUF_LEN];   // error response buffer
+} be_answer;
+
+//
+// Entry point for vsocket requests.
+// Returns NULL for success, -1 for err, and sets errno if needed
+// <ans> is allocated upstairs
+//
+const be_sock_status
+Vmci_GetReply(int port, const char* json_request, const char* be_name, be_answer* ans);
+
+//
+// Frees a be_answer instance.
+//
+void
+Vmci_FreeBuf(be_answer *ans);


### PR DESCRIPTION
## Description
This PR serves as a preliminary step for creating the vDVS plugin for Windows Containers.

`esx_vmdkcmd.go` uses `CGO` for making vmci_client calls to communicate with the VMDKOps service on ESXi. By default, `CGO` supports `gcc`, which creates compatibility issues on Windows, because the vmci_client implementation depends on libraries provided by `Microsoft Build Tools`. This PR enables exporting of the vmci_client library as a Windows `DLL`, which can then be used with the regular `MinGW-w64` `gcc` on Windows for making calls via `CGO`.

* Extracted `vmci_client.h` from `vmci_client.c`.
* Updated `vmci_client.c` impl to support `Winsock`.
* Added `vmci_client.def` for DLL export.

## Test Output
`test-all` target passes locally, and following is the tail'd output.
```
	refcnt_test.go:76: 2017-06-20T09:58:49-07:00 Found: ""
	refcnt_test.go:76: 2017-06-20T09:58:49-07:00 Expected pattern: "count=5 mounted=true"
	refcnt_test.go:76: 2017-06-20T09:58:50-07:00 Found: ""
	refcnt_test.go:76: 2017-06-20T09:58:50-07:00 Expected pattern: "count=5 mounted=true"
	refcnt_test.go:76: 2017-06-20T09:58:51-07:00 Found: ""
	refcnt_test.go:76: 2017-06-20T09:58:51-07:00 Expected pattern: "count=5 mounted=true"
	refcnt_test.go:76: 2017-06-20T09:58:52-07:00 Cleaning up containers
	refcnt_test.go:76: 2017-06-20T09:58:53-07:00 Checking that the volume is unmounted and can be removed
	refcnt_test.go:76: 2017-06-20T09:58:54-07:00 refCountTestVol
	refcnt_test.go:76: 2017-06-20T09:58:54-07:00 TEST PASSED.
=== RUN   TestSanity
2017-06-20T09:58:54-07:00 START: Running TestSanity on  tcp://10.192.60.198:2375 (may take a while)...
2017-06-20T09:59:08-07:00 END: Running TestSanity on  tcp://10.192.60.198:2375 (may take a while)...
--- PASS: TestSanity (13.76s)
	sanity_test.go:201: Successfully connected to tcp://10.192.60.198:2375
	sanity_test.go:201: Successfully connected to tcp://10.192.46.211:2375
	sanity_test.go:219: Creating vol=DefaultTestVol on client tcp://10.192.60.198:2375.
	sanity_test.go:105: Running cmd=&[touch /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.192.60.198:2375
	sanity_test.go:105: Running cmd=&[stat /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.192.60.198:2375
=== RUN   TestConcurrency
2017-06-20T09:59:08-07:00 Running concurrent tests on tcp://10.192.60.198:2375 and tcp://10.192.46.211:2375 (may take a while)...
2017-06-20T09:59:08-07:00 START: Running create/delete multi-host concurrent test ...
2017-06-20T09:59:30-07:00 END: Running create/delete multi-host concurrent test ...
Running same docker host concurrent create/delete test on tcp://10.192.60.198:2375...
2017-06-20T09:59:42-07:00 START: Running clone concurrent test...
2017-06-20T09:59:56-07:00 END: Running clone concurrent test...
--- PASS: TestConcurrency (47.74s)
	sanity_test.go:201: Successfully connected to tcp://10.192.60.198:2375
	sanity_test.go:201: Successfully connected to tcp://10.192.46.211:2375
PASS
coverage: 40.6% of statements
```