### PR TITLE
Pass vm_uuid to createVMDK

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -164,8 +164,8 @@ def RunCommand(cmd):
 # for now we care about size and (maybe) policy
 def createVMDK(vmdk_path, vm_name, vol_name,
                opts={}, vm_uuid=None, tenant_uuid=None, datastore_url=None):
-    logging.info("*** createVMDK: %s opts = %s vm_name=%s tenant_uuid=%s datastore_url=%s",
-                  vmdk_path, opts, vm_name, tenant_uuid, datastore_url)
+    logging.info("*** createVMDK: %s opts = %s vm_name=%s vm_uuid=%s tenant_uuid=%s datastore_url=%s",
+                  vmdk_path, opts, vm_name, vm_uuid, tenant_uuid, datastore_url)
 
     if os.path.isfile(vmdk_path):
         # We are mostly here due to race or Plugin VMCI retry #1076
@@ -941,6 +941,7 @@ def executeRequest(vm_uuid, vm_name, config_path, cmd, full_vol_name, opts):
         elif cmd == "create":
             response = createVMDK(vmdk_path=vmdk_path,
                                   vm_name=vm_name,
+                                  vm_uuid=vm_uuid,
                                   vol_name=vol_name,
                                   opts=opts,
                                   tenant_uuid=tenant_uuid,

--- a/tests/e2e/vmgroups_test.go
+++ b/tests/e2e/vmgroups_test.go
@@ -398,6 +398,34 @@ func (vg *VmGroupTest) TestVmGroupVolumeMobility(c *C) {
 	out, err = adminutils.AddVMToVMgroup(vg.config.EsxHost, vgTestVMgroup1, vg.config.DockerHostNames[0])
 	c.Assert(err, IsNil, Commentf(out))
 
+	// 7. Remove the volume
+	dockercli.DeleteVolume(vg.config.DockerHosts[0], vg.volName1)
+
 	c.Logf("Passed - VM removal from vmgroups, with volume attached")
+	misc.LogTestEnd(c.TestName())
+}
+
+// TestVmGroupVolumeClone - try cloning a volume from a non-default
+// vm group
+// 1. Create a volume in the VM's vmgroup
+// 2. Clone a volume from the volume created in (1)
+// 3. Cleanup and remove the volume
+func (vg *VmGroupTest) TestVmGroupVolumeClone(c *C) {
+	misc.LogTestStart(c.TestName())
+
+	// 1. Create a volume in the VM's vmgroup
+	vg.createVolumes(c, vg.volName1)
+
+	// 2. Clone a volume from the one created in (1)
+	cloneVolOpt :=  "-o clone-from=" + vg.volName1
+	out, err := dockercli.CreateVolumeWithOptions(vg.config.DockerHosts[0], vg.volName2, cloneVolOpt)
+	c.Assert(err, IsNil, Commentf(out))
+
+	// 3. Remove the volume
+	out, err = dockercli.DeleteVolume(vg.config.DockerHosts[0], vg.volName1)
+	c.Assert(err, IsNil, Commentf(out))
+	out, err = dockercli.DeleteVolume(vg.config.DockerHosts[0], vg.volName2)
+	c.Assert(err, IsNil, Commentf(out))
+
 	misc.LogTestEnd(c.TestName())
 }


### PR DESCRIPTION
Pass the vm_uuid to createVMDK() and hence to cloneVMDK(), passing None causes clone op to fail if the VM isn't in the default vmgroup.

Added a test to the vmgroup test group to verify that a VM in a non-default vmgroup can create a volume and then clone it.