### PR TITLE
Made CLI return proper code to shell

### DIFF
--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -53,15 +53,24 @@ UNSET = "Unset"
 VOL_SIZE = 'size'
 VOL_ALLOC = 'allocated'
 
+# Return this to shell
+# note: "1" is returned if a string is passed to sys.exit
+CLI_ERR_ARGS_PARSE = 3
+CLI_ERR_OPERATION_FAILURE = 2
+CLI_SUCCESS = 0
 
 def main():
+    'Main function for Admin CLI'
     log_config.configure()
     kv.init()
     if not vmdk_ops.is_service_available():
-       sys.exit('Unable to connect to the host-agent on this host, ensure the ESXi host agent is running before retrying.')
+        sys.exit('Unable to connect to the host-agent on this host, ensure the ESXi host agent is running before retrying.')
     args = parse_args()
-    if args:
-       args.func(args)
+    if not args:
+        sys.exit(CLI_ERR_ARGS_PARSE)
+    if args.func(args) != None:
+        sys.exit(CLI_ERR_OPERATION_FAILURE)
+    sys.exit(CLI_SUCCESS)  # not really needed, putting here as an eye candy
 
 
 def commands():

--- a/tests/e2e/defaultvmgroup_test.go
+++ b/tests/e2e/defaultvmgroup_test.go
@@ -71,7 +71,7 @@ func (s *DefaultVMGroupTestSuite) TestAddVMToDefaultTenant(c *C) {
 	misc.LogTestStart(c.TestName())
 
 	out, err := admincli.AddVMToVMgroup(s.config.EsxHost, admincliconst.DefaultVMgroup, s.config.DockerHostNames[1])
-	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(err, Not(IsNil), Commentf(out))
 	c.Assert(strings.TrimRight(string(out), "\n"), Equals, vgErrorMsg, Commentf("Unexpected Behavior: "+
 		"We are able to add vm to the _DEFAULT tenant which is NOT allowed as per current spec."))
 
@@ -84,7 +84,7 @@ func (s *DefaultVMGroupTestSuite) TestRemoveDefaultTenantVMs(c *C) {
 	misc.LogTestStart(c.TestName())
 
 	out, err := admincli.RemoveVMFromVMgroup(s.config.EsxHost, admincliconst.DefaultVMgroup, s.config.DockerHostNames[1])
-	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(err, Not(IsNil), Commentf(out))
 	c.Assert(strings.TrimRight(string(out), "\n"), Equals, vgErrorMsg, Commentf("Unexpected Behavior: "+
 		"We are able to remove vm from the _DEFAULT tenant which is NOT allowed as per current spec."))
 
@@ -97,7 +97,7 @@ func (s *DefaultVMGroupTestSuite) TestReplaceDefaultTenantVMs(c *C) {
 	misc.LogTestStart(c.TestName())
 
 	out, err := admincli.ReplaceVMFromVMgroup(s.config.EsxHost, admincliconst.DefaultVMgroup, s.config.DockerHostNames[1])
-	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(err, Not(IsNil), Commentf(out))
 	c.Assert(strings.TrimRight(string(out), "\n"), Equals, vgErrorMsg, Commentf("Unexpected Behavior: "+
 		"We are able to replace vm from the _DEFAULT tenant which is NOT allowed as per current spec."))
 


### PR DESCRIPTION
Partially addresses #1411

CLI code used to print error message and exit, without passing proper code to shell.
This PR fixes that.  
There may still be some functions which do not return proper status , but at least this fixes the framework
 
Functions which do not return proper code: example.
set_vol_opts() should return None on success and return "err msg" on error. Currently it prints stuff and always returns success. A quick review of CLI code is needed to make sure all return proper code. 


Tested: manually (below) plus CI

```
[root@msterin-esx-136:/usr/lib/vmware/vmdkops/bin] ./vmdkops_admin.py config status ; echo $?
DB_Mode: SingleNode (local DB exists)
DB_SharedLocation: N/A
DB_LocalPath: /etc/vmware/vmdkops/auth-db
0
[root@msterin-esx-136:/usr/lib/vmware/vmdkops/bin] ./vmdkops_admin.py volume ls ; echo $?
Volume             Datastore      VMGroup   Capacity  Used  Filesystem  Policy          Disk Format  Attached-to  Access      Attach-as         Created By     Created Date    
-----------------  -------------  --------  --------  ----  ----------  --------------  -----------  -----------  ----------  ----------------  -------------  ----------------
default_tenant_..  vsanDatastore  _DEFAULT  100MB     8MB   ext4        [VSAN default]  thin         detached     read-write  independent_pe..  test-vm_55592  Wed Jun 21 22:..

0
[root@msterin-esx-136:/usr/lib/vmware/vmdkops/bin] ./vmdkops_admin.py volume lsxx ; echo $?
usage: vmdkops_admin.py volume [-h] {set,ls} ...
vmdkops_admin.py volume: error: invalid choice: 'lsxx' (choose from 'set', 'ls')
2
```
