### PR TITLE
Creates platform specific config, main modules

### DIFF
--- a/vmdk_plugin/main.go
+++ b/vmdk_plugin/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,14 +15,12 @@
 package main
 
 // A VMDK Docker Data Volume plugin - main
-// relies on docker/go-plugins-helpers/volume API
 
 import (
 	"flag"
 	"fmt"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"reflect"
 	"syscall"
 
@@ -35,22 +33,16 @@ import (
 )
 
 const (
-	pluginSockDir = "/run/docker/plugins"
-	mountRoot     = "/mnt/vmdk" // VMDK and photon volumes are mounted here
 	photonDriver  = "photon"
 	vmdkDriver    = "vmdk"
 	vsphereDriver = "vsphere"
 	defaultPort   = 1019
 )
 
-// An equivalent function is not exported from the SDK.
-// API supports passing a full address instead of just name.
-// Using the full path during creation and deletion. The path
-// is the same as the one generated internally. Ideally SDK
-// should have ability to clean up sock file instead of replicating
-// it here.
-func fullSocketAddress(pluginName string) string {
-	return filepath.Join(pluginSockDir, pluginName+".sock")
+// Server responds to HTTP requests from docker.
+type Server interface {
+	Init()
+	Destroy()
 }
 
 // init log with passed logLevel (and get config from configFile if it's present)
@@ -98,7 +90,7 @@ func logInit(logLevel *string, logFile *string, configFile *string) bool {
 }
 
 // main for docker-volume-vsphere
-// Parses flags, initializes and mounts refcounters and finally services Docker requests
+// Parses flags, initializes and mounts refcounters and finally initializes the server.
 func main() {
 	var driver volume.Driver
 
@@ -189,20 +181,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	server := NewServer(*driverName, &driver)
+
 	sigChannel := make(chan os.Signal, 1)
 	signal.Notify(sigChannel, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		sig := <-sigChannel
 		log.WithFields(log.Fields{"signal": sig}).Warning("Received signal ")
-		os.Remove(fullSocketAddress(*driverName))
+		server.Destroy()
 		os.Exit(0)
 	}()
 
-	handler := volume.NewHandler(driver)
-
-	log.WithFields(log.Fields{
-		"address": fullSocketAddress(*driverName),
-	}).Info("Going into ServeUnix - Listening on Unix socket ")
-
-	log.Info(handler.ServeUnix("root", fullSocketAddress(*driverName)))
+	server.Init()
 }

--- a/vmdk_plugin/main_linux.go
+++ b/vmdk_plugin/main_linux.go
@@ -1,0 +1,69 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// A VMDK Docker Data Volume plugin implementation for linux.
+// relies on docker/go-plugins-helpers/volume API
+
+import (
+	"os"
+	"path/filepath"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/go-plugins-helpers/volume"
+)
+
+const (
+	mountRoot     = "/mnt/vmdk" // VMDK and photon volumes are mounted here
+	pluginSockDir = "/run/docker/plugins"
+)
+
+// SockServer serves HTTP requests over unix sock.
+type SockServer struct {
+	Server
+	driverName string
+	driver     *volume.Driver
+}
+
+// An equivalent function is not exported from the SDK.
+// API supports passing a full address instead of just name.
+// Using the full path during creation and deletion. The path
+// is the same as the one generated internally. Ideally SDK
+// should have ability to clean up sock file instead of replicating
+// it here.
+func fullSocketAddress(pluginName string) string {
+	return filepath.Join(pluginSockDir, pluginName+".sock")
+}
+
+// NewServer creates a new instance of SockServer.
+func NewServer(driverName string, driver *volume.Driver) *SockServer {
+	return &SockServer{driverName: driverName, driver: driver}
+}
+
+// Init initializes a handler to service Docker requests using the driver.
+func (s *SockServer) Init() {
+	handler := volume.NewHandler(*s.driver)
+
+	log.WithFields(log.Fields{
+		"address": fullSocketAddress(s.driverName),
+	}).Info("Going into ServeUnix - Listening on Unix socket ")
+
+	log.Info(handler.ServeUnix("root", fullSocketAddress(s.driverName)))
+}
+
+// Destroy removes the Docker plugin socket.
+func (s *SockServer) Destroy() {
+	os.Remove(fullSocketAddress(s.driverName))
+}

--- a/vmdk_plugin/utils/config/config.go
+++ b/vmdk_plugin/utils/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,13 +23,6 @@ import (
 )
 
 const (
-	// Default paths - used in log init in main() and test:
-
-	// DefaultConfigPath is the default location of Log configuration file
-	DefaultConfigPath = "/etc/docker-volume-vsphere.conf"
-	// DefaultLogPath is the default location of log (trace) file
-	DefaultLogPath = "/var/log/docker-volume-vsphere.log"
-
 	// Local constants
 	defaultMaxLogSizeMb  = 100
 	defaultMaxLogAgeDays = 28

--- a/vmdk_plugin/utils/config/config_linux.go
+++ b/vmdk_plugin/utils/config/config_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config_test
+package config
 
-// Test Loading JSON config files
+const (
+	// Default paths - used in log init in main() and test:
 
-import (
-	"github.com/stretchr/testify/assert"
-	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/config"
-	"testing"
+	// DefaultConfigPath is the default location of Log configuration file
+	DefaultConfigPath = "/etc/docker-volume-vsphere.conf"
+	// DefaultLogPath is the default location of log (trace) file
+	DefaultLogPath = "/var/log/docker-volume-vsphere.log"
 )
-
-func TestLoad(t *testing.T) {
-	conf, err := config.Load("../../default-config.json")
-	assert.Nil(t, err)
-	assert.Equal(t, conf.MaxLogSizeMb, 100)
-	assert.Equal(t, conf.MaxLogAgeDays, 28)
-	assert.Equal(t, conf.LogPath, "/var/log/docker-volume-vsphere.log")
-}

--- a/vmdk_plugin/utils/config/config_linux_test.go
+++ b/vmdk_plugin/utils/config/config_linux_test.go
@@ -1,0 +1,31 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+// Test Loading JSON config files
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/config"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	conf, err := config.Load("../../default-config.json")
+	assert.Nil(t, err)
+	assert.Equal(t, conf.MaxLogSizeMb, 100)
+	assert.Equal(t, conf.MaxLogAgeDays, 28)
+	assert.Equal(t, conf.LogPath, "/var/log/docker-volume-vsphere.log")
+}


### PR DESCRIPTION
## Description
This commit separates platform specific config and plugin serving code
from the generic one. It will aid the development of the Windows plugin.

* Extracts linux config from config.go into config_linux.go file.
* Extracts unix sock service from main.go into main_linux.go.

## Test Results
The `test-all` target passes locally, and following is the tail'd log.

```
	refcnt_test.go:76: 2017-06-22T11:28:39-07:00 Found: ""
	refcnt_test.go:76: 2017-06-22T11:28:39-07:00 Expected pattern: "count=5 mounted=true"
	refcnt_test.go:76: 2017-06-22T11:28:40-07:00 Found: ""
	refcnt_test.go:76: 2017-06-22T11:28:40-07:00 Expected pattern: "count=5 mounted=true"
	refcnt_test.go:76: 2017-06-22T11:28:41-07:00 Found: ""
	refcnt_test.go:76: 2017-06-22T11:28:41-07:00 Expected pattern: "count=5 mounted=true"
	refcnt_test.go:76: 2017-06-22T11:28:42-07:00 Found: ""
	refcnt_test.go:76: 2017-06-22T11:28:42-07:00 Expected pattern: "count=5 mounted=true"
	refcnt_test.go:76: 2017-06-22T11:28:43-07:00 Found: ""
	refcnt_test.go:76: 2017-06-22T11:28:43-07:00 Expected pattern: "count=5 mounted=true"
	refcnt_test.go:76: 2017-06-22T11:28:44-07:00 Cleaning up containers
	refcnt_test.go:76: 2017-06-22T11:28:45-07:00 Checking that the volume is unmounted and can be removed
	refcnt_test.go:76: 2017-06-22T11:28:45-07:00 refCountTestVol
	refcnt_test.go:76: 2017-06-22T11:28:45-07:00 TEST PASSED.
=== RUN   TestSanity
2017-06-22T11:28:45-07:00 START: Running TestSanity on  tcp://10.160.195.145:2375 (may take a while)...
2017-06-22T11:28:52-07:00 END: Running TestSanity on  tcp://10.160.195.145:2375 (may take a while)...
--- PASS: TestSanity (6.36s)
	sanity_test.go:201: Successfully connected to tcp://10.160.195.145:2375
	sanity_test.go:201: Successfully connected to tcp://10.160.214.77:2375
	sanity_test.go:219: Creating vol=DefaultTestVol on client tcp://10.160.195.145:2375.
	sanity_test.go:105: Running cmd=&[touch /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.160.195.145:2375
	sanity_test.go:105: Running cmd=&[stat /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.160.195.145:2375
=== RUN   TestConcurrency
2017-06-22T11:28:52-07:00 Running concurrent tests on tcp://10.160.195.145:2375 and tcp://10.160.214.77:2375 (may take a while)...
2017-06-22T11:28:52-07:00 START: Running create/delete multi-host concurrent test ...
2017-06-22T11:29:00-07:00 END: Running create/delete multi-host concurrent test ...
Running same docker host concurrent create/delete test on tcp://10.160.195.145:2375...
2017-06-22T11:29:05-07:00 START: Running clone concurrent test...
2017-06-22T11:29:13-07:00 END: Running clone concurrent test...
--- PASS: TestConcurrency (21.44s)
	sanity_test.go:201: Successfully connected to tcp://10.160.195.145:2375
	sanity_test.go:201: Successfully connected to tcp://10.160.214.77:2375
PASS
coverage: 39.1% of statements
```