### PR TITLE
Adds npipe server for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src/dvolplug/dvolplug
 *~
 .*~
 esx_service/.lint_*
+*.swp

--- a/vmdk_plugin/README_WINDOWS.md
+++ b/vmdk_plugin/README_WINDOWS.md
@@ -1,0 +1,58 @@
+# Project Skylight
+
+### Table of contents
+1. Prerequisites
+2. Compiling the `vmci_client.dll`
+3. Running the plugin on Windows
+4. Issues
+
+### Prerequisites
+1. Install the vDVS driver (VIB) on ESXi.
+2. Install a Windows 2016 Server VM on ESXi.
+3. Install [Docker EE](https://docs.docker.com/docker-ee-for-windows/install/) on your Windows 2016 Server VM.
+4. Install [Git](https://git-scm.com/download/win) on your Windows 2016 Server VM.
+5. Install [Go](https://golang.org/dl/)
+6. Install [MSVC Build Tools](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017)
+7. Add relevant bin directories to the `%PATH%` environment variable.
+
+P.S. We can also do similar installation procedure to get the plugin working on a Windows 10 VM.
+
+### Compiling the `vmci_client.dll`
+1. Fire up a command prompt and type `powershell`.
+2. Get the vDVS plugin `go get github.com/venilnoronha/docker-volume-service`
+3. Rename the `venilnoronha` to `vmware` under `$GOPATH/src/github.com/`.
+4. `cd` into the `esx_service/vmci` directory within `docker-volume-service`.
+5. Compile the `vmci_client.dll` with something like:
+```
+cl /D_USRDLL /D_WINDLL .\vmci_client.c -I "C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\ucrt" -I "C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\um" -I "C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\shared" -I "C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\winrt" -I "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\include" /link /defaultlib:ws2_32.lib /libpath:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.15063.0\um\x64" /libpath:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.15063.0\ucrt\x64" /libpath:"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\lib\x64" /DLL /OUT:vmci_client.dll /DEF:vmci_client.def
+```
+
+### Running the plugin on Windows
+1. Copy the generated `vmci_client.dll` to `vmdk_plugin/` and `vmdk_plugin/drivers/vmdk/vmdkops/` directories.
+2. `go get github.com/Microsoft/go-winio` package into the `vendor` directory.
+3. Delete `vmdk_plugin/drivers/vmdk/vmdkops/cmd_test.go`
+4. In `vmdk_plugin/drivers/vmdk/vmdkops/mock_vmdkcmd.go`.
+    - Replace `// +build linux` with `// +build linux windows`.
+    - Comment `syscall.Fallocate` and related code.
+5. In `vmdk_plugin/utils/refcount/refcount.go`.
+    - Replace `// +build linux` with `// +build linux windows`.
+6. In `vmdk_plugin/utils/fs/fs.go`.
+    - Replace `// +build linux` with `// +build linux windows`.
+    - Empty out all function bodies and related imports.
+7. `cd` to the `vmdk_plugin` directory.
+8. In `main.go` comment the line that says `...VmwareFormatter...`.
+9. Do `go run -v main.go` and wait for the `Pipe listening...` message.
+10. Create a `vsphere.json` file under `C:\ProgramData\docker\plugins\` with the following contents.
+```
+{
+    "Name": "vsphere",
+    "Addr": "npipe:////./pipe/vsphere-dvs"
+}
+```
+10. Create volumes using docker cli. Ex: `docker volume create --driver=vsphere mongo-volume`.
+
+
+### Issues
+1. fs.go is linux specific. (inotify can be replaced with fsnotify)
+2. refcount.go is linux specific.
+3. docker on windows doesn't support case sensitive volume names. (needs handling in vmdk_ops.py driver)

--- a/vmdk_plugin/drivers/vmdk/vmdkops/esx_vmdkcmd.go
+++ b/vmdk_plugin/drivers/vmdk/vmdkops/esx_vmdkcmd.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build linux
+// +build linux windows
 
 // The default (ESX) implementation of the VmdkCmdRunner interface.
 // This implementation sends synchronous commands to and receives responses from ESX.
@@ -34,7 +34,12 @@ import (
 
 /*
 #cgo CFLAGS: -I ../../../../esx_service/vmci
-#include "vmci_client.c"
+#cgo windows LDFLAGS: -L. -lvmci_client
+#ifdef _WIN32
+	#include "vmci_client.h"
+#else
+	#include "vmci_client.c"
+#endif
 */
 import "C"
 

--- a/vmdk_plugin/drivers/vmdk/vmdkops/vmdkops.go
+++ b/vmdk_plugin/drivers/vmdk/vmdkops/vmdkops.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build linux
+// +build linux windows
 
 package vmdkops
 

--- a/vmdk_plugin/main.go
+++ b/vmdk_plugin/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/signal"
 	"reflect"
+	"runtime"
 	"syscall"
 
 	log "github.com/Sirupsen/logrus"
@@ -131,6 +132,15 @@ func main() {
 		} else {
 			*driverName = vsphereDriver
 		}
+	}
+
+	// Only the vsphere driver is supported on windows hosts.
+	if runtime.GOOS == "windows" && *driverName != vsphereDriver {
+		msg := fmt.Sprintf("Plugin only supports the %s driver on Windows, ignoring parameter driver = %s.",
+			vsphereDriver, c.Driver)
+		log.Warning(msg)
+		fmt.Println(msg)
+		*driverName = vsphereDriver
 	}
 
 	log.WithFields(log.Fields{

--- a/vmdk_plugin/main_windows.go
+++ b/vmdk_plugin/main_windows.go
@@ -1,0 +1,124 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// A VMDK Docker Data Volume plugin implementation for windows.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/Microsoft/go-winio"
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/go-plugins-helpers/volume"
+)
+
+const (
+	volumeDriver = "VolumeDriver"             // Docker driver type
+	npipeAddr    = "\\\\.\\pipe\\vsphere-dvs" // Plugin's npipe address on windows
+
+	// Docker plugin handshake endpoint
+	// Also see https://docs.docker.com/engine/extend/plugin_api/#handshake-api
+	pluginActivatePath = "/Plugin.Activate"
+
+	// Docker volume plugin endpoints
+	// Also see https://docs.docker.com/engine/extend/plugins_volume/#volume-plugin-protocol
+	volumeDriverCreatePath = "/VolumeDriver.Create"
+)
+
+var (
+	mountRoot = filepath.Join(os.Getenv("LOCALAPPDATA"), "docker-volume-vsphere", "mounts") // VMDK volumes are mounted here
+)
+
+// NpipeListener serves HTTP requests over windows npipe.
+type NpipeServer struct {
+	Server
+	driver   *volume.Driver
+	mux      *http.ServeMux
+	listener net.Listener
+}
+
+// Response for /Plugin.Activate to activate the Docker plugin.
+type PluginActivateResponse struct {
+	Implements []string
+}
+
+// NewServer creates a new instance of NpipeServer.
+func NewServer(driverName string, driver *volume.Driver) *NpipeServer {
+	return &NpipeServer{driver: driver, mux: http.NewServeMux()}
+}
+
+// Marshals v as a JSON string and writes it to w.
+// Returns an error if marshalling fails.
+func marshalAndWrite(v interface{}, w *http.ResponseWriter) error {
+	bytes, err := json.Marshal(v)
+	if err == nil {
+		fmt.Fprintf(*w, string(bytes))
+	}
+	return err
+}
+
+// PluginActivate writes handshake response to w.
+func (s *NpipeServer) PluginActivate(w http.ResponseWriter, r *http.Request) {
+	response := &PluginActivateResponse{Implements: []string{volumeDriver}}
+	marshalAndWrite(response, &w)
+	log.WithFields(log.Fields{"response": response}).Info("Plugin activated ")
+}
+
+// VolumeDriverCreate creates a volume and writes the response to w.
+func (s *NpipeServer) VolumeDriverCreate(w http.ResponseWriter, r *http.Request) {
+	var volumeReq volume.Request
+	err := json.NewDecoder(r.Body).Decode(&volumeReq)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("Failed to service /VolumeDriver.Create request")
+		http.Error(w, err.Error(), 400)
+		return
+	}
+
+	response := (*s.driver).Create(volumeReq)
+	marshalAndWrite(response, &w)
+	log.WithFields(log.Fields{"response": response}).Info("Serviced /VolumeDriver.Create ")
+}
+
+// registerHttpHandlers registers HTTP handlers.
+func (s *NpipeServer) registerHandlers() {
+	s.mux.HandleFunc(pluginActivatePath, s.PluginActivate)
+	s.mux.HandleFunc(volumeDriverCreatePath, s.VolumeDriverCreate)
+}
+
+// Init registers an HTTP service backed by npipe to service requests using the driver.
+func (s *NpipeServer) Init() {
+	var err error
+	s.listener, err = winio.ListenPipe(npipeAddr, nil)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to initialize npipe at %s - exiting", npipeAddr)
+		log.WithFields(log.Fields{"error": err}).Error(msg)
+		fmt.Println(msg)
+		os.Exit(1)
+	}
+
+	s.registerHandlers()
+	log.WithFields(log.Fields{"npipe": npipeAddr}).Info("Going into Serve - Listening on npipe ")
+	log.Info(http.Serve(s.listener, s.mux))
+}
+
+// Destroy shuts down the npipe listener.
+func (s *NpipeServer) Destroy() {
+	s.listener.Close()
+}

--- a/vmdk_plugin/utils/config/config_windows.go
+++ b/vmdk_plugin/utils/config/config_windows.go
@@ -1,0 +1,30 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// Read the plugin configuration file. The file is stored in JSON.
+// See default-config.json at the root of the project.
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var (
+	// DefaultConfigPath is the default location of Log configuration file
+	DefaultConfigPath = filepath.Join(os.Getenv("PROGRAMDATA"), "docker-volume-vsphere", "docker-volume-vsphere.conf")
+	// DefaultLogPath is the default location of log (trace) file
+	DefaultLogPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "docker-volume-vsphere", "logs", "docker-volume-vsphere.log")
+)

--- a/vmdk_plugin/utils/config/config_windows_test.go
+++ b/vmdk_plugin/utils/config/config_windows_test.go
@@ -1,0 +1,26 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/config"
+	"testing"
+)
+
+func TestWindowsPath(t *testing.T) {
+	assert.Equal(t, config.DefaultConfigPath, "C:\\ProgramData\\docker-volume-vsphere\\docker-volume-vsphere.conf")
+	assert.Equal(t, config.DefaultLogPath, "C:\\Users\\Administrator\\AppData\\Local\\docker-volume-vsphere\\logs\\docker-volume-vsphere.log")
+}


### PR DESCRIPTION
## Description
This commit adds an `npipe/http` server impl for servicing handshake and create volume endpoints on windows hosts.

* Adds `NpipeServer` impl for handshake, create volume endpoints.
* Adds `_WIN32` conditional to use `vmci_client.dll` in `esx_vmdkcmd.go`.
* Adds `README_WINDOWS.md` describing windows plugin usage.

## Test Results
The `test-all` target passes locally with the following output.
```
	refcnt_test.go:76: 2017-06-23T09:35:26-07:00 Found: ""
	refcnt_test.go:76: 2017-06-23T09:35:26-07:00 Expected pattern: "count=5 mounted=true"
	refcnt_test.go:76: 2017-06-23T09:35:27-07:00 Found: ""
	refcnt_test.go:76: 2017-06-23T09:35:27-07:00 Expected pattern: "count=5 mounted=true"
	refcnt_test.go:76: 2017-06-23T09:35:28-07:00 Found: ""
	refcnt_test.go:76: 2017-06-23T09:35:28-07:00 Expected pattern: "count=5 mounted=true"
	refcnt_test.go:76: 2017-06-23T09:35:29-07:00 Found: ""
	refcnt_test.go:76: 2017-06-23T09:35:29-07:00 Expected pattern: "count=5 mounted=true"
	refcnt_test.go:76: 2017-06-23T09:35:30-07:00 Cleaning up containers
	refcnt_test.go:76: 2017-06-23T09:35:31-07:00 Checking that the volume is unmounted and can be removed
	refcnt_test.go:76: 2017-06-23T09:35:32-07:00 refCountTestVol
	refcnt_test.go:76: 2017-06-23T09:35:32-07:00 TEST PASSED.
=== RUN   TestSanity
2017-06-23T09:35:32-07:00 START: Running TestSanity on  tcp://10.160.205.225:2375 (may take a while)...
2017-06-23T09:35:38-07:00 END: Running TestSanity on  tcp://10.160.205.225:2375 (may take a while)...
--- PASS: TestSanity (5.73s)
	sanity_test.go:201: Successfully connected to tcp://10.160.205.225:2375
	sanity_test.go:201: Successfully connected to tcp://10.160.207.83:2375
	sanity_test.go:219: Creating vol=DefaultTestVol on client tcp://10.160.205.225:2375.
	sanity_test.go:105: Running cmd=&[touch /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.160.205.225:2375
	sanity_test.go:105: Running cmd=&[stat /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.160.205.225:2375
=== RUN   TestConcurrency
2017-06-23T09:35:38-07:00 Running concurrent tests on tcp://10.160.205.225:2375 and tcp://10.160.207.83:2375 (may take a while)...
2017-06-23T09:35:38-07:00 START: Running create/delete multi-host concurrent test ...
2017-06-23T09:35:45-07:00 END: Running create/delete multi-host concurrent test ...
Running same docker host concurrent create/delete test on tcp://10.160.205.225:2375...
2017-06-23T09:35:50-07:00 START: Running clone concurrent test...
2017-06-23T09:35:56-07:00 END: Running clone concurrent test...
--- PASS: TestConcurrency (18.30s)
	sanity_test.go:201: Successfully connected to tcp://10.160.205.225:2375
	sanity_test.go:201: Successfully connected to tcp://10.160.207.83:2375
PASS
coverage: 37.4% of statements
```