### PR TITLE
Creates platform specific config and main modules

### DIFF
--- a/vmdk_plugin/main.go
+++ b/vmdk_plugin/main.go
@@ -39,8 +39,8 @@ const (
 	defaultPort   = 1019
 )
 
-// Server responds to HTTP requests from Docker.
-type Server interface {
+// PluginServer responds to HTTP requests from Docker.
+type PluginServer interface {
 	// Init initializes the server.
 	Init()
 	// Destroy destroys the server.
@@ -183,7 +183,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	server := NewServer(*driverName, &driver)
+	server := NewPluginServer(*driverName, &driver)
 
 	sigChannel := make(chan os.Signal, 1)
 	signal.Notify(sigChannel, syscall.SIGINT, syscall.SIGTERM)

--- a/vmdk_plugin/main.go
+++ b/vmdk_plugin/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,14 +15,12 @@
 package main
 
 // A VMDK Docker Data Volume plugin - main
-// relies on docker/go-plugins-helpers/volume API
 
 import (
 	"flag"
 	"fmt"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"reflect"
 	"syscall"
 
@@ -35,22 +33,18 @@ import (
 )
 
 const (
-	pluginSockDir = "/run/docker/plugins"
-	mountRoot     = "/mnt/vmdk" // VMDK and photon volumes are mounted here
 	photonDriver  = "photon"
 	vmdkDriver    = "vmdk"
 	vsphereDriver = "vsphere"
 	defaultPort   = 1019
 )
 
-// An equivalent function is not exported from the SDK.
-// API supports passing a full address instead of just name.
-// Using the full path during creation and deletion. The path
-// is the same as the one generated internally. Ideally SDK
-// should have ability to clean up sock file instead of replicating
-// it here.
-func fullSocketAddress(pluginName string) string {
-	return filepath.Join(pluginSockDir, pluginName+".sock")
+// Server responds to HTTP requests from Docker.
+type Server interface {
+	// Init initializes the server.
+	Init()
+	// Destroy destroys the server.
+	Destroy()
 }
 
 // init log with passed logLevel (and get config from configFile if it's present)
@@ -98,7 +92,7 @@ func logInit(logLevel *string, logFile *string, configFile *string) bool {
 }
 
 // main for docker-volume-vsphere
-// Parses flags, initializes and mounts refcounters and finally services Docker requests
+// Parses flags, initializes and mounts refcounters and finally initializes the server.
 func main() {
 	var driver volume.Driver
 
@@ -189,20 +183,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	server := NewServer(*driverName, &driver)
+
 	sigChannel := make(chan os.Signal, 1)
 	signal.Notify(sigChannel, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		sig := <-sigChannel
 		log.WithFields(log.Fields{"signal": sig}).Warning("Received signal ")
-		os.Remove(fullSocketAddress(*driverName))
+		server.Destroy()
 		os.Exit(0)
 	}()
 
-	handler := volume.NewHandler(driver)
-
-	log.WithFields(log.Fields{
-		"address": fullSocketAddress(*driverName),
-	}).Info("Going into ServeUnix - Listening on Unix socket ")
-
-	log.Info(handler.ServeUnix("root", fullSocketAddress(*driverName)))
+	server.Init()
 }

--- a/vmdk_plugin/main_linux.go
+++ b/vmdk_plugin/main_linux.go
@@ -1,0 +1,70 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// A VMDK Docker Data Volume plugin implementation for linux that
+// relies on the docker/go-plugins-helpers/volume API.
+
+import (
+	"os"
+	"path/filepath"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/go-plugins-helpers/volume"
+)
+
+const (
+	mountRoot     = "/mnt/vmdk"           // VMDK and photon volumes are mounted here
+	pluginSockDir = "/run/docker/plugins" // Unix sock for the plugin is maintained here
+)
+
+// SockServer serves HTTP requests from Docker over unix sock.
+type SockServer struct {
+	Server
+	sockAddr string         // Server's unix sock address
+	driver   *volume.Driver // The driver implementation
+}
+
+// An equivalent function is not exported from the SDK.
+// API supports passing a full address instead of just name.
+// Using the full path during creation and deletion. The path
+// is the same as the one generated internally. Ideally SDK
+// should have ability to clean up sock file instead of replicating
+// it here.
+func fullSocketAddress(pluginName string) string {
+	return filepath.Join(pluginSockDir, pluginName+".sock")
+}
+
+// NewServer creates a new instance of SockServer.
+func NewServer(driverName string, driver *volume.Driver) *SockServer {
+	return &SockServer{sockAddr: fullSocketAddress(driverName), driver: driver}
+}
+
+// Init registers the volume driver with a handler to service HTTP
+// requests from Docker.
+func (s *SockServer) Init() {
+	handler := volume.NewHandler(*s.driver)
+
+	log.WithFields(log.Fields{
+		"address": s.sockAddr,
+	}).Info("Going into ServeUnix - Listening on Unix socket ")
+
+	log.Info(handler.ServeUnix("root", s.sockAddr))
+}
+
+// Destroy removes the Docker plugin sock.
+func (s *SockServer) Destroy() {
+	os.Remove(s.sockAddr)
+}

--- a/vmdk_plugin/main_linux.go
+++ b/vmdk_plugin/main_linux.go
@@ -30,9 +30,9 @@ const (
 	pluginSockDir = "/run/docker/plugins" // Unix sock for the plugin is maintained here
 )
 
-// SockServer serves HTTP requests from Docker over unix sock.
-type SockServer struct {
-	Server
+// SockPluginServer serves HTTP requests from Docker over unix sock.
+type SockPluginServer struct {
+	PluginServer
 	sockAddr string         // Server's unix sock address
 	driver   *volume.Driver // The driver implementation
 }
@@ -47,14 +47,14 @@ func fullSocketAddress(pluginName string) string {
 	return filepath.Join(pluginSockDir, pluginName+".sock")
 }
 
-// NewServer creates a new instance of SockServer.
-func NewServer(driverName string, driver *volume.Driver) *SockServer {
-	return &SockServer{sockAddr: fullSocketAddress(driverName), driver: driver}
+// NewPluginServer creates a new instance of SockPluginServer.
+func NewPluginServer(driverName string, driver *volume.Driver) *SockPluginServer {
+	return &SockPluginServer{sockAddr: fullSocketAddress(driverName), driver: driver}
 }
 
 // Init registers the volume driver with a handler to service HTTP
 // requests from Docker.
-func (s *SockServer) Init() {
+func (s *SockPluginServer) Init() {
 	handler := volume.NewHandler(*s.driver)
 
 	log.WithFields(log.Fields{
@@ -65,6 +65,6 @@ func (s *SockServer) Init() {
 }
 
 // Destroy removes the Docker plugin sock.
-func (s *SockServer) Destroy() {
+func (s *SockPluginServer) Destroy() {
 	os.Remove(s.sockAddr)
 }

--- a/vmdk_plugin/utils/config/config.go
+++ b/vmdk_plugin/utils/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,13 +23,6 @@ import (
 )
 
 const (
-	// Default paths - used in log init in main() and test:
-
-	// DefaultConfigPath is the default location of Log configuration file
-	DefaultConfigPath = "/etc/docker-volume-vsphere.conf"
-	// DefaultLogPath is the default location of log (trace) file
-	DefaultLogPath = "/var/log/docker-volume-vsphere.log"
-
 	// Local constants
 	defaultMaxLogSizeMb  = 100
 	defaultMaxLogAgeDays = 28

--- a/vmdk_plugin/utils/config/config_linux.go
+++ b/vmdk_plugin/utils/config/config_linux.go
@@ -1,0 +1,24 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+const (
+	// Default paths - used in log init in main() and test:
+
+	// DefaultConfigPath is the default location of Log configuration file
+	DefaultConfigPath = "/etc/docker-volume-vsphere.conf"
+	// DefaultLogPath is the default location of log (trace) file
+	DefaultLogPath = "/var/log/docker-volume-vsphere.log"
+)

--- a/vmdk_plugin/utils/config/config_linux_test.go
+++ b/vmdk_plugin/utils/config/config_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
This commit separates platform specific config and plugin serving code from the generic one. It will aid  to the development of the Windows plugin.

* Extracts unix sock service from `main.go` into `main_linux.go`.
* Moves linux specific config from `config.go` into `config_linux.go`.
* Renames `config_test.go` to `config_linux_test.go`.

## Test Results
The `test-all` target passes locally with the following output (tail'd):
```
ssh  -kTax -o StrictHostKeyChecking=no root@10.160.205.225 /tmp/docker-volume-vsphere/vmdkops.test -test.v
=== RUN   TestCommands
Detaching loopback device /dev/loop1001
Detaching loopback device /dev/loop1001
Detaching loopback device /dev/loop1001
--- PASS: TestCommands (0.65s)
	cmd_test.go:30: 
		Creating Test Volume with name = [TestVol]...
PASS
coverage: 43.3% of statements
ssh  -kTax -o StrictHostKeyChecking=no root@10.160.205.225 /tmp/docker-volume-vsphere/docker-volume-vsphere.test -test.v \
		-v DefaultTestVol \
		-H1 tcp://10.160.205.225:2375 -H2 tcp://10.160.207.83:2375
=== RUN   TestSanity
2017-06-26T10:45:39-07:00 START: Running TestSanity on  tcp://10.160.205.225:2375 (may take a while)...
2017-06-26T10:45:45-07:00 END: Running TestSanity on  tcp://10.160.205.225:2375 (may take a while)...
--- PASS: TestSanity (6.38s)
	sanity_test.go:201: Successfully connected to tcp://10.160.205.225:2375
	sanity_test.go:201: Successfully connected to tcp://10.160.207.83:2375
	sanity_test.go:219: Creating vol=DefaultTestVol on client tcp://10.160.205.225:2375.
	sanity_test.go:105: Running cmd=&[touch /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.160.205.225:2375
	sanity_test.go:105: Running cmd=&[stat /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.160.205.225:2375
=== RUN   TestConcurrency
2017-06-26T10:45:45-07:00 Running concurrent tests on tcp://10.160.205.225:2375 and tcp://10.160.207.83:2375 (may take a while)...
2017-06-26T10:45:45-07:00 START: Running create/delete multi-host concurrent test ...
2017-06-26T10:45:56-07:00 END: Running create/delete multi-host concurrent test ...
Running same docker host concurrent create/delete test on tcp://10.160.205.225:2375...
2017-06-26T10:46:03-07:00 START: Running clone concurrent test...
2017-06-26T10:46:11-07:00 END: Running clone concurrent test...
--- PASS: TestConcurrency (25.70s)
	sanity_test.go:201: Successfully connected to tcp://10.160.205.225:2375
	sanity_test.go:201: Successfully connected to tcp://10.160.207.83:2375
PASS
coverage: 39.1% of statements
```