### PR TITLE
uncomment check to verify vm name is same on esx/docker host as reported by govc

### DIFF
--- a/tests/e2e/swarm_test.go
+++ b/tests/e2e/swarm_test.go
@@ -15,7 +15,7 @@
 // This test suite includes test cases to verify basic vDVS functionality
 // in docker swarm mode.
 
-// +build runonce
+// +build unstable
 
 package e2e
 

--- a/tests/utils/verification/volumeproperties.go
+++ b/tests/utils/verification/volumeproperties.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vmware/docker-volume-vsphere/tests/constants/admincli"
 	"github.com/vmware/docker-volume-vsphere/tests/constants/dockercli"
 	"github.com/vmware/docker-volume-vsphere/tests/constants/properties"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/esx"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/ssh"
 )
@@ -106,13 +107,12 @@ func VerifyAttachedStatus(name, hostName, esxName string) bool {
 
 	vmAttachedHost := GetVMAttachedToVolUsingDockerCli(name, hostName)
 	vmAttachedESX := GetVMAttachedToVolUsingAdminCli(name, esxName)
-	//expectedVMName := esx.RetrieveVMNameFromIP(hostName)
+	expectedVMName := esx.RetrieveVMNameFromIP(hostName)
 
-	//isMatching := ((vmAttachedHost == expectedVMName) && (vmAttachedHost == vmAttachedESX))
-	isMatching := (vmAttachedHost == vmAttachedESX)
+	isMatching := ((vmAttachedHost == expectedVMName) && (vmAttachedHost == vmAttachedESX))
 
 	if !isMatching {
-		//log.Printf("Expected Attached VM name is [%s]", expectedVMName)
+		log.Printf("Expected Attached VM name is [%s]", expectedVMName)
 		log.Printf("Attached VM name from Docker CLI is [%s]", vmAttachedHost)
 		log.Printf("Attached VM name from Admin CLI is [%s]", vmAttachedESX)
 	}


### PR DESCRIPTION
Uncomment the code to verify vm name is same on esx and docker host as reported by govc
https://github.com/vmware/docker-volume-vsphere/issues/1284#issuecomment-311200955

Ran all the e2e-tests and all tests passed other than swarm test. Swarm tests failed because I wasn't having swarm setup.

```
=> Running target test-e2e-runalways
OK: 6 passed
--- PASS: Test (111.40s)
PASS
ok  	github.com/vmware/docker-volume-vsphere/tests/e2e	111.401s

=> Running target test-e2e-runonce
OOPS: 21 passed, 3 skipped, 2 FAILED, 1 MISSED
--- FAIL: Test (401.19s)
FAIL
exit status 1
FAIL	github.com/vmware/docker-volume-vsphere/tests/e2e	401.198s
```