### PR TITLE
Adds npipe server impl for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src/dvolplug/dvolplug
 *~
 .*~
 esx_service/.lint_*
+*.swp

--- a/esx_service/vmci/vmci_client.h
+++ b/esx_service/vmci/vmci_client.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef __VMCI_CLIENT_H__
+#define __VMCI_CLIENT_H__
 
 //
 // VMCI sockets communication - client side.
@@ -69,3 +71,5 @@ Vmci_GetReply(int port, const char* json_request, const char* be_name, be_answer
 //
 void
 Vmci_FreeBuf(be_answer *ans);
+
+#endif /* __VMCI_CLIENT_H__ */

--- a/esx_service/vmci/vmci_client_proxy.c
+++ b/esx_service/vmci/vmci_client_proxy.c
@@ -1,0 +1,21 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// This file serves as proxy for conditionally importing vmci_client.c
+//
+
+#ifndef _WIN32
+   #include "vmci_client.c"
+#endif

--- a/vmdk_plugin/constants.go
+++ b/vmdk_plugin/constants.go
@@ -17,7 +17,7 @@ package main
 const (
 	// vDVS drivers.
 	photonDriver  = "photon"
-	vmdkDriver    = "vmdk"
+	vmdkDriver    = "vmdk" // deprecated
 	vsphereDriver = "vsphere"
 
 	// Default ESX service port.

--- a/vmdk_plugin/constants.go
+++ b/vmdk_plugin/constants.go
@@ -1,0 +1,36 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+const (
+	// vDVS drivers.
+	photonDriver  = "photon"
+	vmdkDriver    = "vmdk"
+	vsphereDriver = "vsphere"
+
+	// Default ESX service port.
+	defaultPort = 1019
+
+	// Docker driver types.
+	volumeDriver = "VolumeDriver"
+
+	// Docker plugin handshake endpoint.
+	// Also see https://docs.docker.com/engine/extend/plugin_api/#handshake-api
+	pluginActivatePath = "/Plugin.Activate"
+
+	// Docker volume plugin endpoints.
+	// Also see https://docs.docker.com/engine/extend/plugins_volume/#volume-plugin-protocol
+	volumeDriverCreatePath = "/VolumeDriver.Create"
+)

--- a/vmdk_plugin/drivers/vmdk/vmdkops/esx_vmdkcmd.go
+++ b/vmdk_plugin/drivers/vmdk/vmdkops/esx_vmdkcmd.go
@@ -35,11 +35,8 @@ import (
 /*
 #cgo CFLAGS: -I ../../../../esx_service/vmci
 #cgo windows LDFLAGS: -L. -lvmci_client
-#ifdef _WIN32
-	#include "vmci_client.h"
-#else
-	#include "vmci_client.c"
-#endif
+#include "vmci_client.h"
+#include "vmci_client_proxy.c"
 */
 import "C"
 

--- a/vmdk_plugin/drivers/vmdk/vmdkops/esx_vmdkcmd.go
+++ b/vmdk_plugin/drivers/vmdk/vmdkops/esx_vmdkcmd.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build linux
+// +build linux windows
 
 // The default (ESX) implementation of the VmdkCmdRunner interface.
 // This implementation sends synchronous commands to and receives responses from ESX.
@@ -34,7 +34,12 @@ import (
 
 /*
 #cgo CFLAGS: -I ../../../../esx_service/vmci
-#include "vmci_client.c"
+#cgo windows LDFLAGS: -L. -lvmci_client
+#ifdef _WIN32
+	#include "vmci_client.h"
+#else
+	#include "vmci_client.c"
+#endif
 */
 import "C"
 

--- a/vmdk_plugin/drivers/vmdk/vmdkops/vmdkops.go
+++ b/vmdk_plugin/drivers/vmdk/vmdkops/vmdkops.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build linux
+// +build linux windows
 
 package vmdkops
 

--- a/vmdk_plugin/main.go
+++ b/vmdk_plugin/main.go
@@ -33,13 +33,6 @@ import (
 	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/config"
 )
 
-const (
-	photonDriver  = "photon"
-	vmdkDriver    = "vmdk"
-	vsphereDriver = "vsphere"
-	defaultPort   = 1019
-)
-
 // PluginServer responds to HTTP requests from Docker.
 type PluginServer interface {
 	// Init initializes the server.

--- a/vmdk_plugin/main.go
+++ b/vmdk_plugin/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/signal"
 	"reflect"
+	"runtime"
 	"syscall"
 
 	log "github.com/Sirupsen/logrus"
@@ -133,6 +134,15 @@ func main() {
 		} else {
 			*driverName = vsphereDriver
 		}
+	}
+
+	// The windows plugin only supports the vsphere driver.
+	if runtime.GOOS == "windows" && *driverName != vsphereDriver {
+		msg := fmt.Sprintf("Plugin only supports the %s driver on Windows, ignoring parameter driver = %s.",
+			vsphereDriver, c.Driver)
+		log.Warning(msg)
+		fmt.Println(msg)
+		*driverName = vsphereDriver
 	}
 
 	log.WithFields(log.Fields{

--- a/vmdk_plugin/main_windows.go
+++ b/vmdk_plugin/main_windows.go
@@ -14,7 +14,7 @@
 
 package main
 
-// A VMDK Docker Data Volume plugin implementation for windows.
+// A VMDK Docker Data Volume plugin implementation for Windows OS.
 
 import (
 	"encoding/json"

--- a/vmdk_plugin/main_windows.go
+++ b/vmdk_plugin/main_windows.go
@@ -1,0 +1,125 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// A VMDK Docker Data Volume plugin implementation for windows.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/Microsoft/go-winio"
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/go-plugins-helpers/volume"
+)
+
+const (
+	volumeDriver = "VolumeDriver"         // Docker volume driver type
+	npipeAddr    = `\\.\pipe\vsphere-dvs` // Plugin's npipe address
+
+	// Docker plugin handshake endpoint.
+	// Also see https://docs.docker.com/engine/extend/plugin_api/#handshake-api
+	pluginActivatePath = "/Plugin.Activate"
+
+	// Docker volume plugin endpoints.
+	// Also see https://docs.docker.com/engine/extend/plugins_volume/#volume-plugin-protocol
+	volumeDriverCreatePath = "/VolumeDriver.Create"
+)
+
+var (
+	mountRoot = filepath.Join(os.Getenv("LOCALAPPDATA"), "docker-volume-vsphere", "mounts") // VMDK volumes are mounted here
+)
+
+// NpipePluginServer serves HTTP requests from Docker over windows npipe.
+type NpipePluginServer struct {
+	PluginServer
+	driver   *volume.Driver // The driver implementation
+	mux      *http.ServeMux // The HTTP mux
+	listener net.Listener   // The npipe listener
+}
+
+// Response for /Plugin.Activate to activate the Docker plugin.
+type PluginActivateResponse struct {
+	Implements []string // Slice of implemented driver types
+}
+
+// NewPluginServer returns a new instance of NpipePluginServer.
+func NewPluginServer(driverName string, driver *volume.Driver) *NpipePluginServer {
+	return &NpipePluginServer{driver: driver, mux: http.NewServeMux()}
+}
+
+// writeJSON writes the JSON encoding of v to w, or returns an
+// error if marshalling fails.
+func writeJSON(v interface{}, w *http.ResponseWriter) error {
+	bytes, err := json.Marshal(v)
+	if err == nil {
+		fmt.Fprintf(*w, string(bytes))
+	}
+	return err
+}
+
+// PluginActivate writes the plugin's handshake response to w.
+func (s *NpipePluginServer) PluginActivate(w http.ResponseWriter, r *http.Request) {
+	resp := &PluginActivateResponse{Implements: []string{volumeDriver}}
+	writeJSON(resp, &w)
+	log.WithFields(log.Fields{"resp": resp}).Info("Plugin activated ")
+}
+
+// VolumeDriverCreate creates a volume and writes the response to w.
+func (s *NpipePluginServer) VolumeDriverCreate(w http.ResponseWriter, r *http.Request) {
+	var volumeReq volume.Request
+	err := json.NewDecoder(r.Body).Decode(&volumeReq)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Error("Failed to service /VolumeDriver.Create request")
+		http.Error(w, err.Error(), 400)
+		return
+	}
+
+	resp := (*s.driver).Create(volumeReq)
+	writeJSON(resp, &w)
+	log.WithFields(log.Fields{"resp": resp}).Info("Serviced /VolumeDriver.Create ")
+}
+
+// registerHttpHandlers registers handlers with the HTTP mux.
+func (s *NpipePluginServer) registerHandlers() {
+	s.mux.HandleFunc(pluginActivatePath, s.PluginActivate)
+	s.mux.HandleFunc(volumeDriverCreatePath, s.VolumeDriverCreate)
+}
+
+// Init initializes the npipe listener which serves HTTP requests
+// from Docker using the HTTP mux.
+func (s *NpipePluginServer) Init() {
+	var err error
+	s.listener, err = winio.ListenPipe(npipeAddr, nil)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to initialize npipe at %s - exiting", npipeAddr)
+		log.WithFields(log.Fields{"err": err}).Error(msg)
+		fmt.Println(msg)
+		os.Exit(1)
+	}
+
+	s.registerHandlers()
+	log.WithFields(log.Fields{"npipe": npipeAddr}).Info("Going into Serve - Listening on npipe ")
+	log.Info(http.Serve(s.listener, s.mux))
+}
+
+// Destroy shuts down the npipe listener.
+func (s *NpipePluginServer) Destroy() {
+	s.listener.Close()
+}

--- a/vmdk_plugin/utils/config/config_windows.go
+++ b/vmdk_plugin/utils/config/config_windows.go
@@ -1,0 +1,27 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var (
+	// DefaultConfigPath is the default location of the config file.
+	DefaultConfigPath = filepath.Join(os.Getenv("PROGRAMDATA"), "docker-volume-vsphere", "docker-volume-vsphere.conf")
+	// DefaultLogPath is the default location of the log (trace) file.
+	DefaultLogPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "docker-volume-vsphere", "logs", "docker-volume-vsphere.log")
+)

--- a/vmdk_plugin/utils/config/config_windows_test.go
+++ b/vmdk_plugin/utils/config/config_windows_test.go
@@ -1,0 +1,26 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/config"
+	"testing"
+)
+
+func TestWindowsPath(t *testing.T) {
+	assert.Equal(t, config.DefaultConfigPath, `C:\ProgramData\docker-volume-vsphere\docker-volume-vsphere.conf`)
+	assert.Equal(t, config.DefaultLogPath, `C:\Users\Administrator\AppData\Local\docker-volume-vsphere\logs\docker-volume-vsphere.log`)
+}

--- a/vmdk_plugin/utils/config/config_windows_test.go
+++ b/vmdk_plugin/utils/config/config_windows_test.go
@@ -17,10 +17,11 @@ package config_test
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/config"
+	"os"
 	"testing"
 )
 
 func TestWindowsPath(t *testing.T) {
-	assert.Equal(t, config.DefaultConfigPath, `C:\ProgramData\docker-volume-vsphere\docker-volume-vsphere.conf`)
-	assert.Equal(t, config.DefaultLogPath, `C:\Users\Administrator\AppData\Local\docker-volume-vsphere\logs\docker-volume-vsphere.log`)
+	assert.Equal(t, config.DefaultConfigPath, os.Getenv("PROGRAMDATA")+`\docker-volume-vsphere\docker-volume-vsphere.conf`)
+	assert.Equal(t, config.DefaultLogPath, os.Getenv("LOCALAPPDATA")+`\docker-volume-vsphere\logs\docker-volume-vsphere.log`)
 }


### PR DESCRIPTION
## Description
This PR adds an `npipe/http` server impl for servicing handshake and create volume APIs, and enables `esx_vmdkcmd` and `vmdkops` usage on Windows environments.

* Adds `NpipePluginServer` impl with handshake and create volume handlers.
* Adds default `config` for windows.
* ~~Adds `_WIN32` conditional to use `vmci_client.dll` in `esx_vmdkcmd.go`.~~
* Enables `vmdkops` usage under windows environments.
* Extracts `main` module constants into `constants.go`.
* Adds `vmci_client_proxy.c` for conditionally importing `vmci_client.c`.

## Test Results
The `test-all` target passes locally with the following output (tail'd):
```
ssh  -kTax -o StrictHostKeyChecking=no root@10.160.205.225 /tmp/docker-volume-vsphere/vmdkops.test -test.v
=== RUN   TestCommands
Detaching loopback device /dev/loop1001
Detaching loopback device /dev/loop1001
Detaching loopback device /dev/loop1001
--- PASS: TestCommands (0.79s)
	cmd_test.go:30: 
		Creating Test Volume with name = [TestVol]...
PASS
coverage: 43.3% of statements
ssh  -kTax -o StrictHostKeyChecking=no root@10.160.205.225 /tmp/docker-volume-vsphere/docker-volume-vsphere.test -test.v \
		-v DefaultTestVol \
		-H1 tcp://10.160.205.225:2375 -H2 tcp://10.160.207.83:2375
=== RUN   TestSanity
2017-06-26T21:03:02-07:00 START: Running TestSanity on  tcp://10.160.205.225:2375 (may take a while)...
2017-06-26T21:03:07-07:00 END: Running TestSanity on  tcp://10.160.205.225:2375 (may take a while)...
--- PASS: TestSanity (5.49s)
	sanity_test.go:201: Successfully connected to tcp://10.160.205.225:2375
	sanity_test.go:201: Successfully connected to tcp://10.160.207.83:2375
	sanity_test.go:219: Creating vol=DefaultTestVol on client tcp://10.160.205.225:2375.
	sanity_test.go:105: Running cmd=&[touch /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.160.205.225:2375
	sanity_test.go:105: Running cmd=&[stat /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.160.205.225:2375
=== RUN   TestConcurrency
2017-06-26T21:03:07-07:00 Running concurrent tests on tcp://10.160.205.225:2375 and tcp://10.160.207.83:2375 (may take a while)...
2017-06-26T21:03:07-07:00 START: Running create/delete multi-host concurrent test ...
2017-06-26T21:03:26-07:00 END: Running create/delete multi-host concurrent test ...
Running same docker host concurrent create/delete test on tcp://10.160.205.225:2375...
2017-06-26T21:03:30-07:00 START: Running clone concurrent test...
2017-06-26T21:03:37-07:00 END: Running clone concurrent test...
--- PASS: TestConcurrency (29.62s)
	sanity_test.go:201: Successfully connected to tcp://10.160.205.225:2375
	sanity_test.go:201: Successfully connected to tcp://10.160.207.83:2375
PASS
coverage: 37.4% of statements
```