### PR TITLE
Log cleanup for VMListener : VM object not found

### DIFF
--- a/esx_service/utils/vm_listener.py
+++ b/esx_service/utils/vm_listener.py
@@ -179,6 +179,9 @@ def listen_vm_propertychange(pc):
         except vmodl.fault.RequestCanceled as e:
             return e
 
+        except vmodl.fault.ManagedObjectNotFound as e:
+            # Log this info if required by admin just in case
+            logging.info("VMChangeListener: VM was powered down and then deleted right away. Fault msg: %s", e.msg)
         except Exception as e:
             # Do we need to alert the admin? how?
             logging.error("VMChangeListener: error %s", str(e))


### PR DESCRIPTION
This PR cleanups up messy log described in #1457
Logging the exception as INFO with only logging fault message (since that's the main part).

The log now looks something like
```
06/27/17 17:20:23 276972 [VMChangeListener] [INFO   ] VMChangeListener: VM was powered down and then deleted right away.
Fault msg: The object 'vim.VirtualMachine:101' has already been deleted or has not been completely created
```
Fixes #1457 

Testing:
test-esx passes locally 
```
Ran 5 tests in 1.221s

OK
# ssh  -kTax -o StrictHostKeyChecking=no root@10.192.248.54 rm -rf /tmp/vmdk_ops_unittest643
```

// CC @msterin 