### PR TITLE
[TRIVIAL] Fixed 'ssh: not found' in Makefile and simplied coverage target

### DIFF
--- a/esx_service/Makefile
+++ b/esx_service/Makefile
@@ -213,14 +213,13 @@ COVERAGE := coverage
 VMDKOPSD := /etc/init.d/vmdk-opsd
 
 # check if coverage package exists on ESX
-COV_EXIST := $(shell $(SSH) root@$(ESX) '$(COVERAGE) 2> /dev/null')
-
 # This target is invoked from drone script on CI to capture coverage after the tests end.
 coverage:
 	$(log_target)
-ifdef COV_EXIST
-		@echo "python coverage package exists."
-		$(SSH) root@$(ESX) '$(VMDKOPSD) stop ; $(COVERAGE) combine .coverage* ; $(COVERAGE) report ; rm .coverage*'
-else
-		@echo "python coverage package doesn't exist."
-endif
+	@$(SSH) root@$(ESX) \
+		-C 'if which $(COVERAGE) > /dev/null \
+			; then \
+				echo Running coverage reports; $(VMDKOPSD) stop ; $(COVERAGE) combine .coverage* ; $(COVERAGE) report ; rm .coverage* \
+			; else \
+				echo Python coverage package does not exist \
+			; fi'


### PR DESCRIPTION
Coverage target used SSH to set a Makefile var and this causes "SSH not
found" error message from dockerized build. False positives distract
attention, so fixed it and cleaned up the code too.

Test: before there was a "ssh not found" message, now there is not.
Also tested manually and got the following results:

1) replace 'coverage' with 'ls' and added echo to all to check positive:

> make coverage
Running coverage reports
/etc/init.d/vmdk-opsd stop
coverage combine .coverage*
coverage report
rm .coverage*

2) actual code, to check negative (no coverage on my test box)

> make coverage
Python coverage package does not exist