### PR TITLE
Add tests to restart the docker and verify volume refcounts are restored

### DIFF
--- a/tests/constants/admincli/cmd.go
+++ b/tests/constants/admincli/cmd.go
@@ -95,6 +95,12 @@ const (
 	// VMlist VM of the vmgroup
 	VMlist = " --vm-list="
 
+	// AddDatastoreAccess adds datastore to vmgroup
+	AddDatastoreAccess = vmdkopsAdmin + "vmgroup access add --name="
+
+	// RemoveDatastoreAccess removes a datastore from a vmgroup
+	RemoveDatastoreAccess = vmdkopsAdmin + "vmgroup access rm --name %s --datastore %s"
+
 	// GetDBMode get current DB config
 	GetDBMode = vmdkopsAdmin + "config status"
 )

--- a/tests/constants/dockercli/cmd.go
+++ b/tests/constants/dockercli/cmd.go
@@ -121,3 +121,6 @@ const (
 	// ErrorVolumeCreate Error string prefix when volume creation fails
 	ErrorVolumeCreate = "Error response from daemon: create"
 )
+
+// Volume properties returned for a volume by inspecting it
+var VolumeStatusFields = []string{"access", "attach_as", "allocated", "used", "cloned_from", "created_by_VM", "datastore", "diskformat", "fstype", "disk_status", "attached_vm"}

--- a/tests/e2e/restart_test.go
+++ b/tests/e2e/restart_test.go
@@ -87,10 +87,6 @@ func (s *RestartTestData) TearDownSuite(c *C) {
 		out, err := dockercli.DeleteVolume(s.config.DockerHosts[1], s.volumeName)
 		c.Assert(err, IsNil, Commentf(out))
 
-		// Cleanup volume on the second datastore
-		out, err = dockercli.DeleteVolume(s.config.DockerHosts[1], s.volumeName + "@" + ds2)
-		c.Assert(err, IsNil, Commentf(out))
-
 		// Remove access for second datastore from the default vmgroup
 		out, err = adminutil.RemoveDatastoreFromVmgroup(s.config.EsxHost, adminconst.DefaultVMgroup, s.config.Datastores[1])
 		c.Assert(err, IsNil, Commentf(out))
@@ -330,6 +326,10 @@ func (s *RestartTestData) TestDuplicateVolumeName(c *C) {
 
 	// 5. Stop the three containers
 	out, err = dockercli.RemoveContainer(s.config.DockerHosts[1], strings.Join(s.containerNameList, " "))
+	c.Assert(err, IsNil, Commentf(out))
+
+	// Cleanup volume on the second datastore
+	out, err = dockercli.DeleteVolume(s.config.DockerHosts[1], s.volumeName + "@" + ds2)
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 6. Run container on other host to verify the volume is detached after stopping the containers

--- a/tests/e2e/restart_test.go
+++ b/tests/e2e/restart_test.go
@@ -21,39 +21,59 @@ package e2e
 
 import (
 	. "gopkg.in/check.v1"
+	"strings"
+	"log"
 
 	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/verification"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
+	adminconst "github.com/vmware/docker-volume-vsphere/tests/constants/admincli"
+	adminutil "github.com/vmware/docker-volume-vsphere/tests/utils/admincli"
 )
 
 type RestartTestData struct {
 	config        *inputparams.TestConfig
 	volumeName    string
-	containerName string
+	containerName []string
 }
 
 func (s *RestartTestData) SetUpSuite(c *C) {
 	s.config = inputparams.GetTestConfig()
 	if s.config == nil {
+		log.Printf("Setup skipped")
 		c.Skip("Unable to retrieve test config, skipping docker/plugin restart tests")
 	}
 
 	s.volumeName = inputparams.GetUniqueVolumeName("restart_test")
-	s.containerName = inputparams.GetUniqueContainerName("restart_test")
+	s.containerName = []string{inputparams.GetUniqueContainerName("restart_test"),
+				inputparams.GetUniqueContainerName("restart_test"),
+				inputparams.GetUniqueContainerName("restart_test")}
 
 	// ensure there are no remanants from an earlier run
-	out, err := dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerName)
+	out, err := dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerName[0])
 
 	// Create a volume
 	out, err = dockercli.CreateVolume(s.config.DockerHosts[1], s.volumeName)
 	c.Assert(err, IsNil, Commentf(out))
+
+	// Add access for the second datastore to the VM's vmgroup
+	out, err = adminutil.AddDatastoreToVmgroup(s.config.EsxHost, adminconst.DefaultVMgroup, s.config.Datastores[1])
+	c.Assert(err, IsNil, Commentf(out))
+
+	log.Printf("Restart tests setup complete")
 }
 
 func (s *RestartTestData) TearDownSuite(c *C) {
-	out, err := dockercli.DeleteVolume(s.config.DockerHosts[1], s.volumeName)
-	c.Assert(err, IsNil, Commentf(out))
+	if s.config != nil {
+		out, err := dockercli.DeleteVolume(s.config.DockerHosts[1], s.volumeName)
+		c.Assert(err, IsNil, Commentf(out))
+
+		// Remove access for second datastore from the default vmgroup
+		out, err = adminutil.RemoveDatastoreFromVmgroup(s.config.EsxHost, adminconst.DefaultVMgroup, s.config.Datastores[1])
+		c.Assert(err, IsNil, Commentf(out))
+	}
+	log.Printf("Restart tests teardown complete")
 }
 
 var _ = Suite(&RestartTestData{})
@@ -72,7 +92,7 @@ func (s *RestartTestData) TestVolumeDetached(c *C) {
 	misc.LogTestStart(c.TestName())
 
 	// 1. Attach a volume to a container on a host
-	out, err := dockercli.AttachVolume(s.config.DockerHosts[1], s.volumeName, s.containerName)
+	out, err := dockercli.AttachVolume(s.config.DockerHosts[1], s.volumeName, s.containerName[0])
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 2. Verify attached status
@@ -87,11 +107,11 @@ func (s *RestartTestData) TestVolumeDetached(c *C) {
 	status = verification.VerifyDetachedStatus(s.volumeName, s.config.DockerHosts[1], s.config.EsxHost)
 	c.Assert(status, Equals, true, Commentf("Volume %s is still attached", s.volumeName))
 
-	out, err = dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerName)
+	out, err = dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerName[0])
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 5. Verify a container can be started to use the same volume on another host
-	out, err = dockercli.AttachVolume(s.config.DockerHosts[0], s.volumeName, s.containerName)
+	out, err = dockercli.AttachVolume(s.config.DockerHosts[0], s.volumeName, s.containerName[0])
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 6. Restart the docker daemon on the other host
@@ -99,7 +119,7 @@ func (s *RestartTestData) TestVolumeDetached(c *C) {
 	c.Assert(err, IsNil, Commentf(out))
 
 	// Clean up the container on host0
-	out, err = dockercli.RemoveContainer(s.config.DockerHosts[0], s.containerName)
+	out, err = dockercli.RemoveContainer(s.config.DockerHosts[0], s.containerName[0])
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 7. Verify detached status for the volume
@@ -107,7 +127,7 @@ func (s *RestartTestData) TestVolumeDetached(c *C) {
 	c.Assert(status, Equals, true, Commentf("Volume %s is still attached", s.volumeName))
 
 	// 8. Verify a container can be started to use the same volume on the original host
-	out, err = dockercli.ExecContainer(s.config.DockerHosts[1], s.volumeName, s.containerName)
+	out, err = dockercli.ExecContainer(s.config.DockerHosts[1], s.volumeName, s.containerName[0])
 	c.Assert(err, IsNil, Commentf(out))
 
 	misc.LogTestEnd(c.TestName())
@@ -125,7 +145,7 @@ func (s *RestartTestData) TestPluginKill(c *C) {
 	misc.LogTestStart(c.TestName())
 
 	// 1. Attach a volume with restart=always flag
-	out, err := dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName, s.containerName)
+	out, err := dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName, s.containerName[0])
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 2. Verify volume attached status
@@ -137,15 +157,15 @@ func (s *RestartTestData) TestPluginKill(c *C) {
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 4. Stop the container
-	out, err = dockercli.StopContainer(s.config.DockerHosts[1], s.containerName)
+	out, err = dockercli.StopContainer(s.config.DockerHosts[1], s.containerName[0])
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 5. Start the same container
-	out, err = dockercli.StartContainer(s.config.DockerHosts[1], s.containerName)
+	out, err = dockercli.StartContainer(s.config.DockerHosts[1], s.containerName[0])
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 6. Stop the container
-	out, err = dockercli.StopContainer(s.config.DockerHosts[1], s.containerName)
+	out, err = dockercli.StopContainer(s.config.DockerHosts[1], s.containerName[0])
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 7. Verify volume detached status
@@ -153,7 +173,163 @@ func (s *RestartTestData) TestPluginKill(c *C) {
 	c.Assert(status, Equals, true, Commentf("Volume %s is still attached", s.volumeName))
 
 	// Cleanup container
-	out, err = dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerName)
+	out, err = dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerName[0])
+	c.Assert(err, IsNil, Commentf(out))
+
+	misc.LogTestEnd(c.TestName())
+}
+
+// TestRecoverMountsAfterRestart  - Verify that volume mounts are recovered after
+// docker is restarted and volume is usable by any VM.
+// 1. Start 2 containers using same volume with restart=always
+// 2. Restart docker and wait for containers to start and reference counts to be initialized.
+// 3. Verify volume is attached to the VM
+// 4. Start 1 container using same volume
+// 5. Stop all 3 containers and confirm disk is detached
+// 6. Run container on other host to verify the volume is detached after stopping the containers
+func (s *RestartTestData) TestRecoverMountsAfterRestart(c *C) {
+	misc.LogTestStart(c.TestName())
+
+	c.Skip("Skipping verification of attached status after docker restart")
+	// 1. Run containers with restart-always flag
+	out, err := dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName, s.containerName[0])
+	c.Assert(err, IsNil, Commentf(out))
+
+	// Run second container 
+	out, err = dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName, s.containerName[1])
+	c.Assert(err, IsNil, Commentf(out))
+
+	// 2. Restart docker
+	out, err = dockercli.RestartDocker(s.config.DockerHosts[1])
+	c.Assert(err, IsNil, Commentf(out))
+
+	misc.SleepForSec(60)
+
+	// 3. Verify the volume is attached to the VM
+	status, err := dockercli.GetVolumeStatus(s.config.DockerHosts[1], s.volumeName)
+	c.Assert(err, IsNil, Commentf("Failed to fetch status for volume %s", s.volumeName))
+	c.Assert(s.config.DockerHostNames[0], Equals, status["attached_vm"], Commentf("Volume is not attached to VM %s, attached to %s",
+		s.config.DockerHostNames[0], status["attached_vm"]))
+
+	// 4. Run third container
+	out, err = dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName, s.containerName[2])
+	c.Assert(err, IsNil, Commentf(out))
+
+	// 5. Stop the three containers
+	out, err = dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerName[0])
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerName[1])
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerName[2])
+	c.Assert(err, IsNil, Commentf(out))
+
+	// 6. Run container on other host to verify the volume is detached after stopping the containers
+	out, err = dockercli.ExecContainer(s.config.DockerHosts[0], s.volumeName, s.containerName[0])
+	c.Assert(err, IsNil, Commentf(out))
+
+	misc.LogTestEnd(c.TestName())
+}
+
+// TestLongVolumeName - Verifies volumes can be created on the default
+// datastore by long and short names.
+// 1. Start container with restart flag and use short name for volume (vol1)
+// 2. Restart docker
+// 3. Start another instance of container with short name for volume (vol1)
+// 4. Get the volume properties and figure the datastore of the volume
+// 4. Start another instance of container with long name for volume (vol1@<datastore-name>)
+// 5. Stop all 3 containers and confirm disk is detached (verify by exec'ing a container on another host).
+func (s *RestartTestData) TestLongVolumeName(c *C) {
+	misc.LogTestStart(c.TestName())
+
+	// 1. Run container with restart-always flag
+	out, err := dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName, s.containerName[0])
+	c.Assert(err, IsNil, Commentf(out))
+
+	// 2. Restart docker
+	out, err = dockercli.RestartDocker(s.config.DockerHosts[1])
+	c.Assert(err, IsNil, Commentf(out))
+
+	// 3. Run second container 
+	out, err = dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName, s.containerName[1])
+	c.Assert(err, IsNil, Commentf(out))
+
+	// 3. Get volume status
+	status, err := dockercli.GetVolumeStatus(s.config.DockerHosts[1], s.volumeName)
+	c.Assert(err, IsNil, Commentf("Failed to fetch status for volume %s", s.volumeName))
+
+	// 4. Run third container with long volume name
+	out, err = dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName + "@" + status["datastore"], s.containerName[2])
+	c.Assert(err, IsNil, Commentf(out))
+
+	// 5. Stop the three containers
+	out, err = dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerName[0])
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerName[1])
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerName[2])
+	c.Assert(err, IsNil, Commentf(out))
+
+	// 6. Run container on other host to verify the volume is detached after stopping the containers
+	out, err = dockercli.ExecContainer(s.config.DockerHosts[0], s.volumeName, s.containerName[0])
+	c.Assert(err, IsNil, Commentf(out))
+	misc.LogTestEnd(c.TestName())
+}
+
+// TestDuplicateVolumeName - Verifies volumes with same same can be created on the default
+// datastore and non-default datastores
+// 1. Start container with restart flag and short name "vol1" (assuming vol1@ds1)
+// 2. Start container with restart flag with same volume name on another ds: vol1@ds2
+// 3. Restart docker
+// 4. Start container with long name: vol1@ds1
+// 5. Stop all 3 containers and make sure both vol1@ds1 ad vol1@ds2 are detached.
+func (s *RestartTestData) TestDuplicateVolumeName(c *C) {
+	misc.LogTestStart(c.TestName())
+
+	// 1. Run container with restart-always flag
+	out, err := dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName, s.containerName[0])
+	c.Assert(err, IsNil, Commentf(out))
+
+	// Get volume status
+	status, err := dockercli.GetVolumeStatus(s.config.DockerHosts[1], s.volumeName)
+	c.Assert(err, IsNil, Commentf("Failed to fetch status for volume %s", s.volumeName))
+	
+	ds2 := s.config.Datastores[0]
+	if strings.Compare(status["datastore"], s.config.Datastores[0]) == 0 {
+		ds2 = s.config.Datastores[1]
+	}
+
+	// 2. Run second container with same volume name on the other datastore 
+	out, err = dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName + "@" + ds2, s.containerName[1])
+	c.Assert(err, IsNil, Commentf(out))
+
+	// 3. Restart docker
+	out, err = dockercli.RestartDocker(s.config.DockerHosts[1])
+	c.Assert(err, IsNil, Commentf(out))
+
+	// 4. Run third container with same volume as the first container
+	out, err = dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName + "@" + status["datastore"], s.containerName[2])
+	c.Assert(err, IsNil, Commentf(out))
+
+	// 5. Stop the three containers
+	out, err = dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerName[0])
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerName[1])
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerName[2])
+	c.Assert(err, IsNil, Commentf(out))
+
+	// 6. Run container on other host to verify the volume is detached after stopping the containers
+	out, err = dockercli.ExecContainer(s.config.DockerHosts[0], s.volumeName, s.containerName[0])
+	c.Assert(err, IsNil, Commentf(out))
+
+	// 7. Cleanup volume on the second datastore
+	out, err = dockercli.DeleteVolume(s.config.DockerHosts[1], s.volumeName + "@" + ds2)
 	c.Assert(err, IsNil, Commentf(out))
 
 	misc.LogTestEnd(c.TestName())

--- a/tests/utils/admincli/vmgroupmgmt.go
+++ b/tests/utils/admincli/vmgroupmgmt.go
@@ -202,7 +202,7 @@ func GetDBmode(esxIP string) string {
 
 // RemvoeDatastoreAccessFromVmgroup - Remove access for a datastore from a vmgroup
 func RemoveDatastoreFromVmgroup(ip, vmgroup, dsName string) (string, error) {
-	log.Printf("Removing access for %s to vmgroup %s", dsName, vmgroup)
+	log.Printf("Removing access for %s from vmgroup %s", dsName, vmgroup)
 	cmd := fmt.Sprintf(admincli.RemoveDatastoreAccess, vmgroup, dsName)
 	return ssh.InvokeCommand(ip, cmd)
 }

--- a/tests/utils/admincli/vmgroupmgmt.go
+++ b/tests/utils/admincli/vmgroupmgmt.go
@@ -61,7 +61,7 @@ func ReplaceVMFromVMgroup(ip, name, vmName string) (string, error) {
 
 // AddCreateAccessForVMgroup - add allow-create access on the vmgroup
 func AddCreateAccessForVMgroup(ip, name, datastore string) (string, error) {
-	log.Printf("Creating create access for vmgroup %s, datastore %s on esx [%s] \n", name, datastore, ip)
+	log.Printf("Adding create access for vmgroup %s, datastore %s on esx [%s] \n", name, datastore, ip)
 	return ssh.InvokeCommand(ip, admincli.AddAccessForVMgroup+name+" --allow-create --datastore "+datastore)
 }
 

--- a/tests/utils/admincli/vmgroupmgmt.go
+++ b/tests/utils/admincli/vmgroupmgmt.go
@@ -20,7 +20,7 @@ package admincli
 import (
 	"log"
 	"strings"
-
+	"fmt"
 	"github.com/vmware/docker-volume-vsphere/tests/constants/admincli"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/ssh"
 )
@@ -198,4 +198,11 @@ func GetDBmode(esxIP string) string {
 	} else {
 		return ""
 	}
+}
+
+// RemvoeDatastoreAccessFromVmgroup - Remove access for a datastore from a vmgroup
+func RemoveDatastoreFromVmgroup(ip, vmgroup, dsName string) (string, error) {
+	log.Printf("Removing access for %s to vmgroup %s", dsName, vmgroup)
+	cmd := fmt.Sprintf(admincli.RemoveDatastoreAccess, vmgroup, dsName)
+	return ssh.InvokeCommand(ip, cmd)
 }

--- a/tests/utils/dockercli/volumelifecycle.go
+++ b/tests/utils/dockercli/volumelifecycle.go
@@ -50,7 +50,7 @@ func CreateVolumeWithOptions(ip, name, options string) (string, error) {
 // AttachVolume - attach volume to container on given host
 func AttachVolume(ip, volName, containerName string) (string, error) {
 	log.Printf("Attaching volume [%s] on VM [%s]\n", volName, ip)
-	return ssh.InvokeCommand(ip, dockercli.RunContainer+" -d -v "+volName+
+	return ssh.InvokeCommand(ip, dockercli.RunContainer+" --volume-driver vsphere -d -v "+volName+
 		":"+dockercli.ContainerMountPoint+" --name "+containerName+dockercli.TestContainer)
 }
 
@@ -65,7 +65,7 @@ func InspectVolume(ip, volName string) (string, error) {
 // automatically restarts if killed
 func AttachVolumeWithRestart(ip, volName, containerName string) (string, error) {
 	log.Printf("Attaching volume [%s] on VM[%s]\n", volName, ip)
-	return ssh.InvokeCommand(ip, dockercli.RunContainer+" --restart=always -d -v "+volName+
+	return ssh.InvokeCommand(ip, dockercli.RunContainer+" --restart=always --volume-driver vsphere -d -v "+volName+
 		":"+dockercli.ContainerMountPoint+" --name "+containerName+
 		dockercli.TestContainer)
 }

--- a/tests/utils/dockercli/volumelifecycle.go
+++ b/tests/utils/dockercli/volumelifecycle.go
@@ -65,7 +65,6 @@ func InspectVolume(ip, volName string) (string, error) {
 // automatically restarts if killed
 func AttachVolumeWithRestart(ip, volName, containerName string) (string, error) {
 	log.Printf("Attaching volume [%s] on VM[%s]\n", volName, ip)
-	log.Printf(dockercli.RunContainer+" --restart=always --volume-driver vsphere -d -v "+volName+ ":"+dockercli.ContainerMountPoint+" --name "+containerName+ dockercli.TestContainer)
 	return ssh.InvokeCommand(ip, dockercli.RunContainer+" --restart=always --volume-driver vsphere -d -v "+volName+
 		":"+dockercli.ContainerMountPoint+" --name "+containerName+
 		dockercli.TestContainer)

--- a/tests/utils/dockercli/volumelifecycle.go
+++ b/tests/utils/dockercli/volumelifecycle.go
@@ -65,6 +65,7 @@ func InspectVolume(ip, volName string) (string, error) {
 // automatically restarts if killed
 func AttachVolumeWithRestart(ip, volName, containerName string) (string, error) {
 	log.Printf("Attaching volume [%s] on VM[%s]\n", volName, ip)
+	log.Printf(dockercli.RunContainer+" --restart=always --volume-driver vsphere -d -v "+volName+ ":"+dockercli.ContainerMountPoint+" --name "+containerName+ dockercli.TestContainer)
 	return ssh.InvokeCommand(ip, dockercli.RunContainer+" --restart=always --volume-driver vsphere -d -v "+volName+
 		":"+dockercli.ContainerMountPoint+" --name "+containerName+
 		dockercli.TestContainer)


### PR DESCRIPTION
Newly added tests are passing except for the failing scenario of #1499. Most likely #1499 is happening in each of the newly added tests  that are restarting containers post docker restart.

Test result is shown below and the failure for which #1499 is created. This branch can be used to repro #1499 as needed.

Test result:
2017/06/28 09:25:50 Removing container [restart_test_container_499262] on VM [10.161.250.171]
2017/06/28 09:25:51 Creating volume [restart_test_volume_602275] on VM [10.161.250.171]
2017/06/28 09:25:54 Adding access for sharedVmfs-1 to vmgroup _DEFAULT  with max-size 1gb, total-size 100gb
2017/06/28 09:25:55 Restart tests setup complete
2017/06/28 09:25:55 START: RestartTestData.TestDuplicateVolumeName
2017/06/28 09:25:55 Attaching volume [restart_test_volume_602275] on VM[10.161.250.171]
2017/06/28 09:25:57 Attaching volume [restart_test_volume_602275@sharedVmfs-1] on VM[10.161.250.171]
2017/06/28 09:26:03 Restarting docker ....
2017/06/28 09:26:37 Attaching volume [restart_test_volume_602275@sharedVmfs-0] on VM[10.161.250.171]
2017/06/28 09:26:45 Removing container [restart_test_container_499262] on VM [10.161.250.171]
2017/06/28 09:26:46 Removing container [restart_test_container_901653] on VM [10.161.250.171]
2017/06/28 09:26:46 Removing container [restart_test_container_578687] on VM [10.161.250.171]
2017/06/28 09:26:47 Attaching volume [restart_test_volume_602275] on VM [10.161.248.164]
2017/06/28 09:27:19 Destroying volume [restart_test_volume_602275@sharedVmfs-1]
2017/06/28 09:27:20 END: RestartTestData.TestDuplicateVolumeName
2017/06/28 09:27:20 START: RestartTestData.TestLongVolumeName
2017/06/28 09:27:20 Attaching volume [restart_test_volume_602275] on VM[10.161.250.171]
2017/06/28 09:27:21 Restarting docker ....
2017/06/28 09:27:37 Attaching volume [restart_test_volume_602275] on VM[10.161.250.171]
2017/06/28 09:27:45 Attaching volume [restart_test_volume_602275@sharedVmfs-0] on VM[10.161.250.171]
2017/06/28 09:27:45 Removing container [restart_test_container_499262] on VM [10.161.250.171]
2017/06/28 09:27:45 Removing container [restart_test_container_901653] on VM [10.161.250.171]
2017/06/28 09:27:46 Removing container [restart_test_container_578687] on VM [10.161.250.171]
2017/06/28 09:27:47 Attaching volume [restart_test_volume_602275] on VM [10.161.248.164]
2017/06/28 09:27:49 END: RestartTestData.TestLongVolumeName
2017/06/28 09:27:49 START: RestartTestData.TestPluginKill
2017/06/28 09:27:49 Attaching volume [restart_test_volume_602275] on VM[10.161.250.171]
2017/06/28 09:27:50 Confirming attached status for volume [restart_test_volume_602275]
2017/06/28 09:27:53 Killing vDVS plugin on VM [10.161.250.171]
2017/06/28 09:27:54 Sleep for 2 seconds
2017/06/28 09:27:56 Stopping container [restart_test_container_499262] on VM [10.161.250.171]
2017/06/28 09:28:07 Starting container [restart_test_container_499262] on VM [10.161.250.171]
2017/06/28 09:28:08 Stopping container [restart_test_container_499262] on VM [10.161.250.171]
2017/06/28 09:28:19 Confirming detached status for volume [restart_test_volume_602275]
2017/06/28 09:28:19 Sleep for 2 seconds
2017/06/28 09:28:23 Removing container [restart_test_container_499262] on VM [10.161.250.171]
2017/06/28 09:28:23 END: RestartTestData.TestPluginKill
2017/06/28 09:28:23 START: RestartTestData.TestRecoverMountsAfterRestart
2017/06/28 09:28:23 Attaching volume [restart_test_volume_602275] on VM[10.161.250.171]
2017/06/28 09:28:24 Attaching volume [restart_test_volume_602275] on VM[10.161.250.171]
2017/06/28 09:28:25 Restarting docker ....
2017/06/28 09:28:41 Sleep for 60 seconds

----------------------------------------------------------------------
FAIL: restart_test.go:190: RestartTestData.TestRecoverMountsAfterRestart

restart_test.go:210:
    c.Assert(s.config.DockerHostNames[0], Equals, status["attached_vm"], Commentf("Volume is not attached to VM %s, attached to %s",
        s.config.DockerHostNames[0], status["attached_vm"]))
... obtained string = "worker1-VM1.0"
... expected string = "<no"
... Volume is not attached to VM worker1-VM1.0, attached to <no

2017/06/28 09:29:42 START: RestartTestData.TestVolumeDetached
2017/06/28 09:29:42 Attaching volume [restart_test_volume_602275] on VM [10.161.250.171]

