### PR TITLE
Refactors fs and mock_vmdkcmd modules

### DIFF
--- a/vmdk_plugin/drivers/photon/photon_driver.go
+++ b/vmdk_plugin/drivers/photon/photon_driver.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -140,7 +140,8 @@ func (d *VolumeDriver) getMountPoint(volName string) string {
 	return filepath.Join(d.mountRoot, volName)
 }
 
-func validateCreateOptions(r volume.Request, fsMap map[string]string) error {
+// validateCreateOptions validates the volume create request.
+func validateCreateOptions(r volume.Request) error {
 	// Clone isn't supported
 	if _, result := r.Options["clone-from"]; result == true {
 		return fmt.Errorf("Unrecognized option - clone-from")
@@ -156,22 +157,12 @@ func validateCreateOptions(r volume.Request, fsMap map[string]string) error {
 		r.Options[fsTypeTag] = fs.FstypeDefault
 	}
 
-	// Verify the existence of fstype mkfs
-	_, result := fsMap[r.Options[fsTypeTag]]
-	if result == false {
-		msg := "Not found mkfs for " + r.Options[fsTypeTag]
-		msg += "\nSupported filesystems found: "
-		validfs := ""
-		for fs := range fsMap {
-			if validfs != "" {
-				validfs += ", " + fs
-			} else {
-				validfs += fs
-			}
-		}
+	// Check whether the fstype filesystem is supported.
+	errFstype := fs.AssertFsSupport(r.Options[fsTypeTag])
+	if errFstype != nil {
 		log.WithFields(log.Fields{"name": r.Name,
 			"fstype": r.Options[fsTypeTag]}).Error("Not found ")
-		return fmt.Errorf(msg + validfs)
+		return errFstype
 	}
 	return nil
 }
@@ -464,10 +455,7 @@ func (d *VolumeDriver) UnmountVolume(name string) error {
 func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 	log.WithFields(log.Fields{"name": r.Name, "option": r.Options}).Info("Creating volume ")
 
-	// Get existent filesystem tools, for now only ext4
-	supportedFs := fs.MkfsLookup()
-
-	err := validateCreateOptions(r, supportedFs)
+	err := validateCreateOptions(r)
 	if err != nil {
 		return volume.Response{Err: err.Error()}
 	}
@@ -532,7 +520,7 @@ func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 		return volume.Response{Err: errGetDevicePath.Error()}
 	}
 
-	errMkfs := fs.Mkfs(supportedFs[r.Options[fsTypeTag]], r.Name, device)
+	errMkfs := fs.MkfsByDevicePath(r.Options[fsTypeTag], r.Name, device)
 	if errMkfs != nil {
 		log.WithFields(log.Fields{"name": r.Name, "error": errMkfs}).Error("Create filesystem failed, removing the volume ")
 		err = d.detachVolume(r.Name, createTask.Entity.ID)

--- a/vmdk_plugin/drivers/photon/photon_driver.go
+++ b/vmdk_plugin/drivers/photon/photon_driver.go
@@ -158,7 +158,7 @@ func validateCreateOptions(r volume.Request) error {
 	}
 
 	// Check whether the fstype filesystem is supported.
-	errFstype := fs.AssertFsSupport(r.Options[fsTypeTag])
+	errFstype := fs.VerifyFSSupport(r.Options[fsTypeTag])
 	if errFstype != nil {
 		log.WithFields(log.Fields{"name": r.Name,
 			"fstype": r.Options[fsTypeTag]}).Error("Not found ")

--- a/vmdk_plugin/drivers/photon/photon_driver.go
+++ b/vmdk_plugin/drivers/photon/photon_driver.go
@@ -161,7 +161,7 @@ func validateCreateOptions(r volume.Request) error {
 	errFstype := fs.VerifyFSSupport(r.Options[fsTypeTag])
 	if errFstype != nil {
 		log.WithFields(log.Fields{"name": r.Name,
-			"fstype": r.Options[fsTypeTag]}).Error("Not found ")
+			"fstype": r.Options[fsTypeTag]}).Error("Not supported ")
 		return errFstype
 	}
 	return nil

--- a/vmdk_plugin/drivers/vmdk/vmdk_driver.go
+++ b/vmdk_plugin/drivers/vmdk/vmdk_driver.go
@@ -393,9 +393,7 @@ func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 	if errAttach != nil {
 		log.WithFields(log.Fields{"name": r.Name,
 			"error": errAttach}).Error("Attach volume failed, removing the volume ")
-		// An internal error for the attach may have the volume attached to this client,
-		// detach before removing below.
-		d.detachAndRemove(r.Name)
+		d.remove(r.Name)
 		return volume.Response{Err: errAttach.Error()}
 	}
 

--- a/vmdk_plugin/drivers/vmdk/vmdk_driver.go
+++ b/vmdk_plugin/drivers/vmdk/vmdk_driver.go
@@ -38,7 +38,7 @@ import (
 	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/refcount"
 )
 
-const version = "vSphere Volume Driver v0.4"
+const version = "vSphere Volume Driver v0.5"
 
 // VolumeDriver - VMDK driver struct
 type VolumeDriver struct {

--- a/vmdk_plugin/drivers/vmdk/vmdk_driver.go
+++ b/vmdk_plugin/drivers/vmdk/vmdk_driver.go
@@ -38,9 +38,7 @@ import (
 	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/refcount"
 )
 
-const (
-	version = "vSphere Volume Driver v0.4"
-)
+const version = "vSphere Volume Driver v0.4"
 
 // VolumeDriver - VMDK driver struct
 type VolumeDriver struct {
@@ -189,6 +187,7 @@ func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isRead
 
 	volDev, err := d.ops.Attach(name, nil)
 	if err != nil {
+		log.WithFields(log.Fields{"name": name, "error": err}).Error("Attach volume failed ")
 		return mountpoint, err
 	}
 
@@ -356,7 +355,7 @@ func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 	}
 
 	// Check whether the fstype filesystem is supported.
-	errFstype := fs.AssertFsSupport(r.Options["fstype"])
+	errFstype := fs.VerifyFSSupport(r.Options["fstype"])
 	if errFstype != nil {
 		log.WithFields(log.Fields{"name": r.Name, "fstype": r.Options["fstype"]}).Error("Not found ")
 		return volume.Response{Err: errFstype.Error()}

--- a/vmdk_plugin/drivers/vmdk/vmdkops/cmd_linux_test.go
+++ b/vmdk_plugin/drivers/vmdk/vmdkops/cmd_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,14 +25,14 @@ import (
 )
 
 func TestCommands(t *testing.T) {
-	ops := vmdkops.VmdkOps{Cmd: vmdkops.MockVmdkCmd{}}
+	ops := vmdkops.VmdkOps{Cmd: vmdkops.NewMockCmd()}
 	name := testparams.GetVolumeName()
 	t.Logf("\nCreating Test Volume with name = [%s]...\n", name)
 	opts := map[string]string{"size": "2gb"}
 	if assert.Nil(t, ops.Create(name, opts)) {
 
 		opts = map[string]string{}
-		_, err := ops.Attach(name, opts)
+		_, err := ops.RawAttach(name, opts)
 		assert.Nil(t, err)
 		assert.Nil(t, ops.Detach(name, opts))
 		assert.Nil(t, ops.Remove(name, opts))

--- a/vmdk_plugin/drivers/vmdk/vmdkops/mock_vmdkcmd_linux.go
+++ b/vmdk_plugin/drivers/vmdk/vmdkops/mock_vmdkcmd_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-// +build linux
 
 // An implementation of the VmdkCmdRunner interface that mocks ESX. This removes the requirement forunning ESX at all when testing the plugin.
 
@@ -39,6 +37,11 @@ const (
 	backingRoot     = "/tmp/docker-volumes" // Files for loopback device backing stored here
 	fileSizeInBytes = 100 * 1024 * 1024     // file size for loopback block device
 )
+
+// NewMockCmd returns a new instance of MockVmdkCmd.
+func NewMockCmd() MockVmdkCmd {
+	return MockVmdkCmd{}
+}
 
 func getBackingFileName(nameBase string) string {
 	// make unique name - avoid clashes shall we find any garbage in the directory
@@ -142,11 +145,11 @@ func createBlockDevice(label string, opts map[string]string) error {
 	if _, result := opts["fstype"]; result == false {
 		opts["fstype"] = fs.FstypeDefault
 	}
-	mkfscmd, result := fs.MkfsLookup()[opts["fstype"]]
-	if result == false {
+	errFstype := fs.AssertFsSupport(opts["fstype"])
+	if errFstype != nil {
 		return fmt.Errorf("Not found mkfs for %s", opts["fstype"])
 	}
-	return fs.Mkfs(mkfscmd, label, device)
+	return fs.MkfsByDevicePath(opts["fstype"], label, device)
 }
 
 func getBlockDeviceForName(name string) ([]byte, error) {

--- a/vmdk_plugin/drivers/vmdk/vmdkops/mock_vmdkcmd_linux.go
+++ b/vmdk_plugin/drivers/vmdk/vmdkops/mock_vmdkcmd_linux.go
@@ -145,7 +145,7 @@ func createBlockDevice(label string, opts map[string]string) error {
 	if _, result := opts["fstype"]; result == false {
 		opts["fstype"] = fs.FstypeDefault
 	}
-	errFstype := fs.AssertFsSupport(opts["fstype"])
+	errFstype := fs.VerifyFSSupport(opts["fstype"])
 	if errFstype != nil {
 		return fmt.Errorf("Not found mkfs for %s", opts["fstype"])
 	}

--- a/vmdk_plugin/drivers/vmdk/vmdkops/mock_vmdkcmd_unsupported.go
+++ b/vmdk_plugin/drivers/vmdk/vmdkops/mock_vmdkcmd_unsupported.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This is the filesystem interface for mounting volumes on the guest.
+// +build !linux
 
-package fs
+package vmdkops
 
-// VolumeDevSpec - volume spec returned from the server on an attach
-type VolumeDevSpec struct {
-	Unit                    string
-	ControllerPciSlotNumber string
+import (
+	"errors"
+)
+
+// UnsupportedMockCmd struct.
+type UnsupportedMockCmd struct{}
+
+// NewMockCmd returns a new instance of UnsupportedMockCmd.
+func NewMockCmd() UnsupportedMockCmd {
+	return UnsupportedMockCmd{}
+}
+
+// Run returns an error.
+func (u UnsupportedMockCmd) Run(cmd string, name string, opts map[string]string) ([]byte, error) {
+	return nil, errors.New("VmdkCmdRunner mocking is not supported on this platform")
 }

--- a/vmdk_plugin/drivers/vmdk/vmdkops/mock_vmdkcmd_unsupported.go
+++ b/vmdk_plugin/drivers/vmdk/vmdkops/mock_vmdkcmd_unsupported.go
@@ -16,9 +16,7 @@
 
 package vmdkops
 
-import (
-	"errors"
-)
+import "errors"
 
 // UnsupportedMockCmd struct.
 type UnsupportedMockCmd struct{}

--- a/vmdk_plugin/drivers/vmdk/vmdkops/vmdkops.go
+++ b/vmdk_plugin/drivers/vmdk/vmdkops/vmdkops.go
@@ -65,6 +65,7 @@ func (v VmdkOps) RawAttach(name string, opts map[string]string) ([]byte, error) 
 	log.Debugf("vmdkOps.Attach name=%s", name)
 	str, err := v.Cmd.Run("attach", name, opts)
 	if err != nil {
+		log.WithFields(log.Fields{"name": name, "opts": opts, "error": err}).Error("RawAttach failed ")
 		return nil, err
 	}
 	return str, nil
@@ -80,6 +81,8 @@ func (v VmdkOps) Attach(name string, opts map[string]string) (*fs.VolumeDevSpec,
 	var volDev fs.VolumeDevSpec
 	err = json.Unmarshal(str, &volDev)
 	if err != nil {
+		log.WithFields(log.Fields{"name": name, "opts": opts, "bytes": str,
+			"error": err}).Error("Failed to unmarshal ")
 		return nil, err
 	}
 	return &volDev, nil

--- a/vmdk_plugin/drivers/vmdk/vmdkops/vmdkops.go
+++ b/vmdk_plugin/drivers/vmdk/vmdkops/vmdkops.go
@@ -82,7 +82,13 @@ func (v VmdkOps) Attach(name string, opts map[string]string) (*fs.VolumeDevSpec,
 	err = json.Unmarshal(str, &volDev)
 	if err != nil {
 		log.WithFields(log.Fields{"name": name, "opts": opts, "bytes": str,
-			"error": err}).Error("Failed to unmarshal ")
+			"error": err}).Error("Failed to unmarshal, detaching volume ")
+		// RawAttach may have the volume attached to this client, so detach.
+		errDetach := v.Detach(name, nil)
+		if errDetach != nil {
+			log.WithFields(log.Fields{"name": name,
+				"error": errDetach}).Warning("Detach volume failed ")
+		}
 		return nil, err
 	}
 	return &volDev, nil

--- a/vmdk_plugin/drivers/vmdk/vmdkops/vmdkops.go
+++ b/vmdk_plugin/drivers/vmdk/vmdkops/vmdkops.go
@@ -19,6 +19,7 @@ package vmdkops
 import (
 	"encoding/json"
 	log "github.com/Sirupsen/logrus"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/fs"
 )
 
 //
@@ -59,14 +60,29 @@ func (v VmdkOps) Remove(name string, opts map[string]string) error {
 	return err
 }
 
-// Attach a volume
-func (v VmdkOps) Attach(name string, opts map[string]string) ([]byte, error) {
+// RawAttach attaches a volume and returns a raw response.
+func (v VmdkOps) RawAttach(name string, opts map[string]string) ([]byte, error) {
 	log.Debugf("vmdkOps.Attach name=%s", name)
 	str, err := v.Cmd.Run("attach", name, opts)
 	if err != nil {
 		return nil, err
 	}
-	return str, err
+	return str, nil
+}
+
+// Attach attaches a volume and returns the disk's VolumeDevSpec.
+func (v VmdkOps) Attach(name string, opts map[string]string) (*fs.VolumeDevSpec, error) {
+	str, err := v.RawAttach(name, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var volDev fs.VolumeDevSpec
+	err = json.Unmarshal(str, &volDev)
+	if err != nil {
+		return nil, err
+	}
+	return &volDev, nil
 }
 
 // Detach a volume

--- a/vmdk_plugin/drivers/vmdk/vmdkops/vmdkops.go
+++ b/vmdk_plugin/drivers/vmdk/vmdkops/vmdkops.go
@@ -60,7 +60,7 @@ func (v VmdkOps) Remove(name string, opts map[string]string) error {
 	return err
 }
 
-// RawAttach attaches a volume and returns a raw response.
+// RawAttach attaches a volume and returns `[]byte` representing the raw response string.
 func (v VmdkOps) RawAttach(name string, opts map[string]string) ([]byte, error) {
 	log.Debugf("vmdkOps.Attach name=%s", name)
 	str, err := v.Cmd.Run("attach", name, opts)

--- a/vmdk_plugin/utils/fs/fs.go
+++ b/vmdk_plugin/utils/fs/fs.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This is the filesystem interface for mounting volumes on the guest.
-
 package fs
 
 // VolumeDevSpec - volume spec returned from the server on an attach

--- a/vmdk_plugin/utils/fs/fs_linux.go
+++ b/vmdk_plugin/utils/fs/fs_linux.go
@@ -32,21 +32,20 @@ import (
 )
 
 const (
-	// FstypeDefault contains the default FS when not specified by the user.
+	// FstypeDefault contains the default FS to be used when not specified by the user.
 	FstypeDefault = "ext4"
-	// SleepBeforeMount specifies the time to sleep in case of watch failure.
-	SleepBeforeMount = 1 * time.Second
 
-	sysPciDevs      = "/sys/bus/pci/devices"   // All PCI devices on the host
-	sysPciSlots     = "/sys/bus/pci/slots"     // PCI slots on the host
-	pciAddrLen      = 10                       // Length of PCI dev addr
-	diskPathByDevID = "/dev/disk/by-id/wwn-0x" // Path for devices named by ID
-	scsiHostPath    = "/sys/class/scsi_host/"  // Path for scsi hosts
-	devWaitTimeout  = 10 * time.Second         // give it plenty of time to sense the attached disk
-	bdevPath        = "/sys/block/"
-	deleteFile      = "/device/delete"
-	watchPath       = "/dev/disk/by-id"
-	diskWatchPath   = "/dev/disk/by-path"
+	sleepBeforeMount = 1 * time.Second          // time to sleep in case of watch failure
+	sysPciDevs       = "/sys/bus/pci/devices"   // All PCI devices on the host
+	sysPciSlots      = "/sys/bus/pci/slots"     // PCI slots on the host
+	pciAddrLen       = 10                       // Length of PCI dev addr
+	diskPathByDevID  = "/dev/disk/by-id/wwn-0x" // Path for devices named by ID
+	scsiHostPath     = "/sys/class/scsi_host/"  // Path for scsi hosts
+	devWaitTimeout   = 10 * time.Second         // give it plenty of time to sense the attached disk
+	bdevPath         = "/sys/block/"
+	deleteFile       = "/device/delete"
+	watchPath        = "/dev/disk/by-id"
+	diskWatchPath    = "/dev/disk/by-path"
 )
 
 // BinSearchPath contains search paths for host binaries
@@ -111,6 +110,11 @@ loop:
 		}
 	}
 	watcher.Close()
+}
+
+// DevAttachWaitFallback performs basic fallback in case of watch failure.
+func DevAttachWaitFallback() {
+	time.Sleep(sleepBeforeMount)
 }
 
 // Mkdir creates a directory at the specified path

--- a/vmdk_plugin/utils/fs/fs_linux.go
+++ b/vmdk_plugin/utils/fs/fs_linux.go
@@ -1,0 +1,349 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is the filesystem interface for mounting volumes on a linux guest.
+
+package fs
+
+import (
+	"errors"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"golang.org/x/exp/inotify"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	// FstypeDefault contains the default FS when not specified by the user.
+	FstypeDefault = "ext4"
+	// SleepBeforeMount specifies the time to sleep in case of watch failure.
+	SleepBeforeMount = 1 * time.Second
+
+	sysPciDevs      = "/sys/bus/pci/devices"   // All PCI devices on the host
+	sysPciSlots     = "/sys/bus/pci/slots"     // PCI slots on the host
+	pciAddrLen      = 10                       // Length of PCI dev addr
+	diskPathByDevID = "/dev/disk/by-id/wwn-0x" // Path for devices named by ID
+	scsiHostPath    = "/sys/class/scsi_host/"  // Path for scsi hosts
+	devWaitTimeout  = 10 * time.Second         // give it plenty of time to sense the attached disk
+	bdevPath        = "/sys/block/"
+	deleteFile      = "/device/delete"
+	watchPath       = "/dev/disk/by-id"
+	diskWatchPath   = "/dev/disk/by-path"
+)
+
+// BinSearchPath contains search paths for host binaries
+var BinSearchPath = []string{"/bin", "/sbin", "/usr/bin", "/usr/sbin"}
+
+// DevAttachWaitPrep creates a watcher that watches disk events.
+func DevAttachWaitPrep() (*inotify.Watcher, error) {
+	return devAttachWaitPrep(diskWatchPath)
+}
+
+// devAttachWaitPrep creates a watcher that watches devPath.
+func devAttachWaitPrep(devPath string) (*inotify.Watcher, error) {
+	watcher, errWatcher := inotify.NewWatcher()
+	if errWatcher != nil {
+		log.WithFields(log.Fields{"err": errWatcher.Error()}).Error("Failed to create watcher ")
+		return nil, errors.New("Failed to create watcher")
+	}
+
+	err := watcher.Watch(devPath)
+	if err != nil {
+		log.WithFields(log.Fields{"path": devPath, "err": err.Error()}).Error("Failed to watch ")
+		return nil, fmt.Errorf("Failed to watch path %s", devPath)
+	}
+	return watcher, nil
+}
+
+// DevAttachWait waits for attach operation to be completed
+func DevAttachWait(watcher *inotify.Watcher, volDev *VolumeDevSpec) error {
+	device, err := getDevicePath(volDev)
+	if err != nil {
+		return err
+	}
+	devAttachWait(watcher, device)
+	return nil
+}
+
+// devAttachWait waits for attach operation to be completed
+func devAttachWait(watcher *inotify.Watcher, device string) {
+loop:
+	for {
+		select {
+		case ev := <-watcher.Event:
+			log.Debug("event: ", ev)
+			if ev.Name == device {
+				// Log when the device is discovered
+				log.WithFields(
+					log.Fields{"device": device, "event": ev},
+				).Info("Scan complete ")
+				break loop
+			}
+		case err := <-watcher.Error:
+			log.WithFields(
+				log.Fields{"device": device, "error": err},
+			).Error("Hit error during watch ")
+			break loop
+		case <-time.After(devWaitTimeout):
+			log.WithFields(
+				log.Fields{"timeout": devWaitTimeout, "device": device},
+			).Warning("Exceeded timeout while waiting for device attach to complete")
+			break loop
+		}
+	}
+	watcher.Close()
+}
+
+// Mkdir creates a directory at the specified path
+func Mkdir(path string) error {
+	stat, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	if stat != nil && !stat.IsDir() {
+		return fmt.Errorf("%v already exist and it's not a directory", path)
+	}
+	return nil
+}
+
+// Mkfs creates a filesystem at the specified volDev.
+func Mkfs(fstype string, label string, volDev *VolumeDevSpec) error {
+	device, err := getDevicePath(volDev)
+	if err != nil {
+		return err
+	}
+	return MkfsByDevicePath(fstype, label, device)
+}
+
+// MkfsByDevicePath creates a filesystem at the specified device.
+func MkfsByDevicePath(fstype string, label string, device string) error {
+	var err error
+	var out []byte
+
+	// Identify mkfscmd for fstype
+	mkfscmd := mkfsLookup()[fstype]
+
+	// Workaround older versions of e2fsprogs, issue 629.
+	// If mkfscmd is of an ext* filesystem use -F flag
+	// to avoid having mkfs command to expect user confirmation.
+	if strings.Split(mkfscmd, ".")[1][0:3] == "ext" {
+		out, err = exec.Command(mkfscmd, "-F", "-L", label, device).CombinedOutput()
+	} else {
+		out, err = exec.Command(mkfscmd, "-L", label, device).CombinedOutput()
+	}
+	if err != nil {
+		return fmt.Errorf("Failed to create filesystem on %s: %s. Output = %s",
+			device, err, out)
+	}
+	return nil
+}
+
+// AssertFsSupport checks whether the fstype filesystem is supported.
+func AssertFsSupport(fstype string) error {
+	supportedFs := mkfsLookup()
+	_, result := supportedFs[fstype]
+	if result == false {
+		msg := "Not found mkfs for " + fstype + "\nSupported filesystems found: "
+		validfs := ""
+		for fs := range supportedFs {
+			if validfs != "" {
+				validfs += ", " + fs
+			} else {
+				validfs += fs
+			}
+		}
+		msg += validfs
+		return errors.New(msg)
+	}
+	return nil
+}
+
+// mkfsLookup finds existent filesystem tools
+func mkfsLookup() map[string]string {
+	supportedFs := make(map[string]string)
+	for _, sp := range BinSearchPath {
+		mkftools, _ := filepath.Glob(sp + "/mkfs.*")
+		for _, mkfs := range mkftools {
+			supportedFs[strings.Split(mkfs, ".")[1]] = mkfs
+		}
+	}
+	return supportedFs
+}
+
+// Mount the filesystem (`fs`) on the volDev at the given mountpoint.
+func Mount(mountpoint string, fstype string, volDev *VolumeDevSpec, isReadOnly bool) error {
+	device, err := getDevicePath(volDev)
+	if err != nil {
+		return err
+	}
+	return MountByDevicePath(mountpoint, fstype, device, isReadOnly)
+}
+
+// MountByDevicePath mounts the filesystem (`fs`) on the device at the given mount point.
+func MountByDevicePath(mountpoint string, fstype string, device string, isReadOnly bool) error {
+	log.WithFields(log.Fields{
+		"device":     device,
+		"fstype":     fstype,
+		"mountpoint": mountpoint,
+	}).Debug("Calling syscall.Mount() ")
+
+	flags := 0
+	if isReadOnly {
+		flags = syscall.MS_RDONLY
+	}
+	err := syscall.Mount(device, mountpoint, fstype, uintptr(flags), "")
+	if err != nil {
+		return fmt.Errorf("Failed to mount device %s at %s: %s", device, mountpoint, err)
+	}
+	return nil
+}
+
+// MountWithID - mount device with ID
+func MountWithID(mountpoint string, fstype string, id string, isReadOnly bool) error {
+	log.WithFields(log.Fields{
+		"device ID":  id,
+		"fstype":     fstype,
+		"mountpoint": mountpoint,
+	}).Debug("Calling syscall.Mount() ")
+
+	// Scan so we may have the device before attempting a mount
+	// Loop over all hosts and scan each one
+	device, err := GetDevicePathByID(id)
+	if err != nil {
+		return fmt.Errorf("Invalid device path %s for %s: %s",
+			device, mountpoint, err)
+	}
+
+	flags := 0
+	if isReadOnly {
+		flags = syscall.MS_RDONLY
+	}
+	err = syscall.Mount(device, mountpoint, fstype, uintptr(flags), "")
+	if err != nil {
+		return fmt.Errorf("Failed to mount device %s at %s fstype %s: %s",
+			device, mountpoint, fstype, err)
+	}
+	return nil
+}
+
+// Unmount a device from the given mount point.
+func Unmount(mountPoint string) error {
+	err := syscall.Unmount(mountPoint, 0)
+	if err != nil {
+		return fmt.Errorf("Unmount device at %s failed: %s",
+			mountPoint, err)
+	}
+	return nil
+}
+
+func makeDevicePathWithID(id string) string {
+	return diskPathByDevID + strings.Join(strings.Split(id, "-"), "")
+}
+
+// GetDevicePathByID - return full path for device with given ID
+func GetDevicePathByID(id string) (string, error) {
+	hosts, err := ioutil.ReadDir(scsiHostPath)
+	if err != nil {
+		return "", err
+	}
+	time.Sleep(10)
+	for _, host := range hosts {
+		//Scan so we may have the device before attempting a mount
+		scanHost := scsiHostPath + host.Name() + "/scan"
+		bytes := []byte("- - -")
+		log.WithFields(log.Fields{"disk id": id, "scan cmd": scanHost}).Info("Rescanning ... ")
+		err = ioutil.WriteFile(scanHost, bytes, 0644)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	watcher, errWatch := devAttachWaitPrep(watchPath)
+
+	device := makeDevicePathWithID(id)
+
+	if errWatch != nil {
+		time.Sleep(10)
+	} else {
+		// Wait for the attach to complete, may timeout
+		// in which case we continue creating the file system.
+		devAttachWait(watcher, device)
+	}
+	_, err = os.Stat(device)
+	if err != nil {
+		return "", err
+	}
+	return device, nil
+}
+
+// DeleteDevicePathWithID - delete device with given ID
+func DeleteDevicePathWithID(id string) error {
+	// Delete the device node
+	device := makeDevicePathWithID(id)
+	dev, err := os.Readlink(device)
+	if err != nil {
+		return fmt.Errorf("Failed to read sym link for %s: %s",
+			device, err)
+	}
+	links := strings.Split(dev, "/")
+	node := bdevPath + links[len(links)-1] + deleteFile
+	bytes := []byte("1")
+
+	log.Debugf("Deleteing device node - id: %s, node: %s", id, node)
+	err = ioutil.WriteFile(node, bytes, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// getDevicePath returns the device path or error.
+func getDevicePath(volDev *VolumeDevSpec) (string, error) {
+	// Get the device node for the unit returned from the attach.
+	// Lookup each device that has a label and if that label matches
+	// the one for the given bus number.
+	// The device we need is then constructed from the dir name with
+	// the matching label.
+	pciSlotAddr := fmt.Sprintf("%s/%s/address", sysPciSlots, volDev.ControllerPciSlotNumber)
+
+	fh, err := os.Open(pciSlotAddr)
+	if err != nil {
+		log.WithFields(log.Fields{"Error": err}).Warn("Get device path failed for unit# %s @ PCI slot %s: ",
+			volDev.Unit, volDev.ControllerPciSlotNumber)
+		return "", fmt.Errorf("Device not found")
+	}
+
+	buf := make([]byte, pciAddrLen)
+	_, err = fh.Read(buf)
+
+	fh.Close()
+	if err != nil && err != io.EOF {
+		log.WithFields(log.Fields{"Error": err}).Warn("Get device path failed for unit# %s @ PCI slot %s: ",
+			volDev.Unit, volDev.ControllerPciSlotNumber)
+		return "", fmt.Errorf("Device not found")
+	}
+	return fmt.Sprintf("/dev/disk/by-path/pci-%s.0-scsi-0:0:%s:0", string(buf), volDev.Unit), nil
+}

--- a/vmdk_plugin/utils/fs/fs_linux.go
+++ b/vmdk_plugin/utils/fs/fs_linux.go
@@ -77,6 +77,7 @@ func devAttachWaitPrep(devPath string) (*inotify.Watcher, error) {
 func DevAttachWait(watcher *inotify.Watcher, volDev *VolumeDevSpec) error {
 	device, err := getDevicePath(volDev)
 	if err != nil {
+		log.WithFields(log.Fields{"volDev": *volDev, "err": err}).Error("Failed to get device path ")
 		return err
 	}
 	devAttachWait(watcher, device)
@@ -133,6 +134,7 @@ func Mkdir(path string) error {
 func Mkfs(fstype string, label string, volDev *VolumeDevSpec) error {
 	device, err := getDevicePath(volDev)
 	if err != nil {
+		log.WithFields(log.Fields{"volDev": *volDev, "err": err}).Error("Failed to get device path ")
 		return err
 	}
 	return MkfsByDevicePath(fstype, label, device)
@@ -161,8 +163,8 @@ func MkfsByDevicePath(fstype string, label string, device string) error {
 	return nil
 }
 
-// AssertFsSupport checks whether the fstype filesystem is supported.
-func AssertFsSupport(fstype string) error {
+// VerifyFSSupport checks whether the fstype filesystem is supported.
+func VerifyFSSupport(fstype string) error {
 	supportedFs := mkfsLookup()
 	_, result := supportedFs[fstype]
 	if result == false {
@@ -197,6 +199,7 @@ func mkfsLookup() map[string]string {
 func Mount(mountpoint string, fstype string, volDev *VolumeDevSpec, isReadOnly bool) error {
 	device, err := getDevicePath(volDev)
 	if err != nil {
+		log.WithFields(log.Fields{"volDev": *volDev, "err": err}).Error("Failed to get device path ")
 		return err
 	}
 	return MountByDevicePath(mountpoint, fstype, device, isReadOnly)

--- a/vmdk_plugin/utils/fs/fs_test.go
+++ b/vmdk_plugin/utils/fs/fs_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fs_test
+package fs
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/vmdk_plugin/utils/fs/fs_test.go
+++ b/vmdk_plugin/utils/fs/fs_test.go
@@ -1,0 +1,33 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/fs"
+	"testing"
+)
+
+const funnyfs = "funnyfs"
+
+func TestVerifyFSSupport(t *testing.T) {
+	err := fs.VerifyFSSupport(fs.FstypeDefault)
+	assert.Nil(t, err, "Fstype %s should be supported", fs.FstypeDefault)
+}
+
+func TestVerifyFSSupportError(t *testing.T) {
+	err := fs.VerifyFSSupport(funnyfs)
+	assert.NotNil(t, err, "Fstype %s shouldn't be supported", funnyfs)
+}


### PR DESCRIPTION
## Description
This PR refactors `fs.*` APIs to make `vmdk_driver` platform independent. It also refactors the `vmdkops` module to explicitly disallow mocking of `VmdkCmdRunner` on non-linux platforms.

* Refactors `fs.*` APIs.
* Refactors `photon` and `vmdk` drivers.
* Disallows `VmdkCmdRunner` mocking on non-linux platforms.
* Adds `fs` module unit tests.
* Updates `vsphere` driver version.

## Test Results
The `test-all` target passes locally, and following is the tail'd output:
```
ssh  -kTax -o StrictHostKeyChecking=no root@10.160.205.225 /tmp/docker-volume-vsphere/vmdkops.test -test.v
=== RUN   TestCommands
Detaching loopback device /dev/loop1001
Detaching loopback device /dev/loop1001
Detaching loopback device /dev/loop1001
--- PASS: TestCommands (0.79s)
	cmd_linux_test.go:30: 
		Creating Test Volume with name = [TestVol]...
PASS
coverage: 41.8% of statements
ssh  -kTax -o StrictHostKeyChecking=no root@10.160.205.225 /tmp/docker-volume-vsphere/docker-volume-vsphere.test -test.v \
		-v DefaultTestVol \
		-H1 tcp://10.160.205.225:2375 -H2 tcp://10.160.207.83:2375
=== RUN   TestSanity
2017-06-28T11:26:46-07:00 START: Running TestSanity on  tcp://10.160.205.225:2375 (may take a while)...
2017-06-28T11:26:53-07:00 END: Running TestSanity on  tcp://10.160.205.225:2375 (may take a while)...
--- PASS: TestSanity (6.60s)
	sanity_test.go:201: Successfully connected to tcp://10.160.205.225:2375
	sanity_test.go:201: Successfully connected to tcp://10.160.207.83:2375
	sanity_test.go:219: Creating vol=DefaultTestVol on client tcp://10.160.205.225:2375.
	sanity_test.go:105: Running cmd=&[touch /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.160.205.225:2375
	sanity_test.go:105: Running cmd=&[stat /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.160.205.225:2375
=== RUN   TestConcurrency
2017-06-28T11:26:53-07:00 Running concurrent tests on tcp://10.160.205.225:2375 and tcp://10.160.207.83:2375 (may take a while)...
2017-06-28T11:26:53-07:00 START: Running create/delete multi-host concurrent test ...
2017-06-28T11:27:07-07:00 END: Running create/delete multi-host concurrent test ...
Running same docker host concurrent create/delete test on tcp://10.160.205.225:2375...
2017-06-28T11:27:13-07:00 START: Running clone concurrent test...
2017-06-28T11:27:22-07:00 END: Running clone concurrent test...
--- PASS: TestConcurrency (28.65s)
	sanity_test.go:201: Successfully connected to tcp://10.160.205.225:2375
	sanity_test.go:201: Successfully connected to tcp://10.160.207.83:2375
PASS
coverage: 37.4% of statements
```