### PR TITLE
Using VC UUID for attach/detach where possible

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -1121,7 +1121,7 @@ def setStatusAttached(vmdk_path, vm, vm_dev_info=None):
     if not vol_meta:
         vol_meta = {}
     vol_meta[kv.STATUS] = kv.ATTACHED
-    vol_meta[kv.ATTACHED_VM_UUID] = vm.config.uuid
+    vol_meta[kv.ATTACHED_VM_UUID] = vm.config.instanceUuid
     vol_meta[kv.ATTACHED_VM_NAME] = vm.config.name
     if vm_dev_info:
         vol_meta[kv.ATTACHED_VM_DEV] = vm_dev_info
@@ -1176,19 +1176,19 @@ def getStatusAttached(vmdk_path):
     return attached, uuid, attach_as, vm_name
 
 def log_attached_volume(vmdk_path, kv_uuid, vol_name):
-       '''
-       Log appropriate message for volume thats already attached.
-       '''
-       cur_vm = findVmByUuid(kv_uuid)
+    '''
+    Log appropriate message for volume thats already attached.
+    '''
+    cur_vm = findVmByUuid(kv_uuid)
 
-       if cur_vm:
-          msg = "Disk {0} is already attached to VM {1}".format(vmdk_path,
-                                                             cur_vm.config.name)
-       else:
-          msg = "Failed to find VM {0}({1}), disk {2} is already attached".format(vol_name,
-                                                                                 kv_uuid,
-                                                                                 vmdk_path)
-       logging.warning(msg)
+    if cur_vm:
+        msg = "Disk {0} is already attached to VM {1}".format(vmdk_path,
+                                                              cur_vm.config.name)
+    else:
+        msg = "Failed to find VM {0}({1}), disk {2} is already attached".format(vol_name,
+                                                                                kv_uuid,
+                                                                                vmdk_path)
+    logging.warning(msg)
 
 def add_pvscsi_controller(vm, controllers, max_scsi_controllers, offset_from_bus_number):
     '''

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -1560,6 +1560,8 @@ def execRequestThread(client_socket, cartel, request):
                     reply_string = err("vSphere Docker Volume Service client version ({}) is newer than server version ({}), "
                                     "please update the server.".format(client_protocol_version, SERVER_PROTOCOL_VERSION))
                 send_vmci_reply(client_socket, reply_string)
+                logging.info("executeRequest '%s' failed: %s", req["cmd"], reply_string)
+                return
 
             opts = req["details"]["Opts"] if "Opts" in req["details"] else {}
             reply_string = executeRequest(vm_uuid=vm_uuid,


### PR DESCRIPTION
Fixes #1373 

When communication from VMCI vSocket is established n vmdk_ops.py, we find out VM ID from
the socket, and then locate VM ManagedObject by this ID. 

There are 2 IDs - VC UUID and BIOS UUID. When .vmx file is
copied (e.g. VCD or other products), BIOS UUID can be duplicate thus failures like #1373 . 

However, VC UUID is unique on creation of VM, and unique as long as ESXi is a
part of a VC. So it is a much better candidate for using as a unique ID.

This change tries to use VC UUID first, and fails back to BIOS UUID
next. The change also checks that the VM name (for a found VM by ID)
matches the one we see from vSocket, and does a few other minor prints.

Test:
* manual (edit UUID for 2 VMs to be the same and run docker create/run with checking logs). Before fix it generates #1373 
[tbd: cut-n-paste results here] 
* make test-esx
* In progress: CI
