### PR TITLE
Adds NpipePluginServer unit tests

### DIFF
--- a/vmdk_plugin/main_windows.go
+++ b/vmdk_plugin/main_windows.go
@@ -52,7 +52,9 @@ type PluginActivateResponse struct {
 
 // NewPluginServer returns a new instance of NpipePluginServer.
 func NewPluginServer(driverName string, driver *volume.Driver) *NpipePluginServer {
-	return &NpipePluginServer{driver: driver, mux: http.NewServeMux()}
+	server := &NpipePluginServer{driver: driver, mux: http.NewServeMux()}
+	server.registerHandlers()
+	return server
 }
 
 // writeJSON writes the JSON encoding of resp to the writer.
@@ -117,8 +119,6 @@ func (s *NpipePluginServer) Init() {
 		fmt.Println(msg)
 		os.Exit(1)
 	}
-
-	s.registerHandlers()
 	log.WithFields(log.Fields{"npipe": npipeAddr}).Info("Going into Serve - Listening on npipe ")
 	log.Info(http.Serve(s.listener, s.mux))
 }

--- a/vmdk_plugin/main_windows_test.go
+++ b/vmdk_plugin/main_windows_test.go
@@ -37,8 +37,8 @@ func TestNewPluginServer(t *testing.T) {
 
 func initPluginServer() *NpipePluginServer {
 	server := NewPluginServer(mock, nil)
-	go server.Init()            // server.Init() is a blocking call
-	time.Sleep(2 * time.Second) // wait for goroutine to execute
+	go server.Init()                   // server.Init() blocks forever
+	time.Sleep(100 * time.Millisecond) // wait for goroutine to execute
 	return server
 }
 

--- a/vmdk_plugin/main_windows_test.go
+++ b/vmdk_plugin/main_windows_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Basic tests for the NpipePluginServer implementation.
+
 package main
 
 import (

--- a/vmdk_plugin/main_windows_test.go
+++ b/vmdk_plugin/main_windows_test.go
@@ -1,0 +1,73 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/Microsoft/go-winio"
+	"github.com/stretchr/testify/assert"
+	"net"
+	"testing"
+	"time"
+)
+
+const (
+	mock           = "mock"
+	requestPattern = "POST %s HTTP/1.0\r\n\r\n"
+	httpOK         = "HTTP/1.0 200 OK\r\n"
+)
+
+func TestNewPluginServer(t *testing.T) {
+	server := NewPluginServer(mock, nil)
+	assert.NotNil(t, server, "NewPluginServer should return a server instance")
+}
+
+func initPluginServer() *NpipePluginServer {
+	server := NewPluginServer(mock, nil)
+	go server.Init()            // server.Init() is a blocking call
+	time.Sleep(2 * time.Second) // wait for goroutine to execute
+	return server
+}
+
+func TestPluginServerInit(t *testing.T) {
+	server := initPluginServer()
+	_, err := winio.ListenPipe(npipeAddr, nil)
+	assert.NotNil(t, err, "PluginServer failed to listen over npipe %s", npipeAddr)
+	server.Destroy()
+}
+
+func TestPluginServerDestroy(t *testing.T) {
+	server := initPluginServer()
+	server.Destroy()
+	listener, err := winio.ListenPipe(npipeAddr, nil)
+	assert.Nil(t, err, "PluginServer failed to release npipe %s", npipeAddr)
+	listener.Close()
+}
+
+func request(conn net.Conn, path string) string {
+	fmt.Fprintf(conn, fmt.Sprintf(requestPattern, path))
+	resp, _ := bufio.NewReader(conn).ReadString('\n')
+	return resp
+}
+
+func TestPluginServerActivate(t *testing.T) {
+	server := initPluginServer()
+	conn, err := winio.DialPipe(npipeAddr, nil)
+	assert.Nil(t, err, "Failed to dial to npipe %s", npipeAddr)
+	resp := request(conn, pluginActivatePath)
+	assert.Equal(t, httpOK, resp, "Plugin activate request failed")
+	server.Destroy()
+}


### PR DESCRIPTION
## Description
This PR adds a few basic tests for the `NpipePluginServer` implementation.

## Test Results
Following is the unit test output.
```
=== RUN   TestNewPluginServer
--- PASS: TestNewPluginServer (0.00s)
=== RUN   TestPluginServerInit
time="2017-07-01T02:29:12+05:30" level=info msg="Going into Serve - Listening on npipe " npipe="\\\\.\\pipe\\vsphere-dvs"
time="2017-07-01T02:29:14+05:30" level=info msg="Closing npipe listener " npipe="\\\\.\\pipe\\vsphere-dvs"
--- PASS: TestPluginServerInit (2.00s)
time="2017-07-01T02:29:14+05:30" level=info msg="use of closed network connection"
=== RUN   TestPluginServerDestroy
time="2017-07-01T02:29:14+05:30" level=info msg="Going into Serve - Listening on npipe " npipe="\\\\.\\pipe\\vsphere-dvs"
time="2017-07-01T02:29:16+05:30" level=info msg="Closing npipe listener " npipe="\\\\.\\pipe\\vsphere-dvs"
--- PASS: TestPluginServerDestroy (2.00s)
time="2017-07-01T02:29:16+05:30" level=info msg="use of closed network connection"
=== RUN   TestPluginServerActivate
time="2017-07-01T02:29:16+05:30" level=info msg="Going into Serve - Listening on npipe " npipe="\\\\.\\pipe\\vsphere-dvs"
time="2017-07-01T02:29:18+05:30" level=info msg="Plugin activated " resp=&{[VolumeDriver]}
time="2017-07-01T02:29:18+05:30" level=info msg="Closing npipe listener " npipe="\\\\.\\pipe\\vsphere-dvs"
--- PASS: TestPluginServerActivate (2.02s)
PASS
time="2017-07-01T02:29:18+05:30" level=info msg="use of closed network connection"
ok      command-line-arguments  6.224s
```