### PR TITLE
Fix to fail e2e tests gracefully if setup is not ideal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,10 +108,8 @@ correct environment.
 - The build will use your `username` (the output of `whoami`) to decide on the `DOCKER_HUB_REPO` name to complete our move to use [managed plugin](https://github.com/vmware/docker-volume-vsphere/blob/master/plugin/Makefile#L30).
 If you want to user another DockerHub repository you need to set `DOCKER_HUB_REPO` as environment variable.
 
-- Test verification is extended using gvmomi integration and `govc` cli is **required to set** following environment variables.
-  - `GOVC_INSECURE` as `1`
-  - `GOVC_URL` same as `ESX IP`
-  - `GOVC_USERNAME` & `GOVC_PASSWORD`: user credentials logging in to `ESX IP`
+- Test verification is extended using govmomi integration and `govc` cli is **required to set** following environment variables.
+  - `GOVC_USERNAME` & `GOVC_PASSWORD`: user credentials for logging in to `ESX IP`
 
 - You **need** to set following environment variables to run swarm cluster related tests. You **need** to configure swarm cluster in order to run swarm related testcase otherwise there will be a test failure. As mentioned above, you may reuse the same set of VMs here; no need to create separately.
 
@@ -135,8 +133,6 @@ export VM1=10.20.105.121
 export VM2=10.20.104.210
 export VM3=10.20.104.241
 export DOCKER_HUB_REPO=cnastorage
-export GOVC_INSECURE=1
-export GOVC_URL=10.20.105.54
 export GOVC_USERNAME=root
 export GOVC_PASSWORD=<ESX login passwd>
 export MANAGER1=10.20.105.122

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -139,8 +139,8 @@ else
     -e "ESX=$ESX" \
     -e "VM1=$VM1" \
     -e "VM2=$VM2" \
-    -e "GOVC_INSECURE=$GOVC_INSECURE" \
-    -e "GOVC_URL=$GOVC_URL" \
+    -e "GOVC_INSECURE=1" \
+    -e "GOVC_URL=$ESX" \
     -e "GOVC_USERNAME=$GOVC_USERNAME" \
     -e "GOVC_PASSWORD=$GOVC_PASSWORD" \
     -e "MANAGER1=$MANAGER1" \

--- a/tests/e2e/swarm_test.go
+++ b/tests/e2e/swarm_test.go
@@ -46,11 +46,11 @@ type SwarmTestSuite struct {
 func (s *SwarmTestSuite) SetUpSuite(c *C) {
 	s.esxName = inputparams.GetEsxIP()
 	s.master = inputparams.GetSwarmManager1()
-	c.Assert(s.master, Not(IsNil), Commentf("Master node is nil"))
+	c.Assert(s.master, Not(IsNil), Commentf("Master node is not set."))
 	s.worker1 = inputparams.GetSwarmWorker1()
-	c.Assert(s.worker1, Not(IsNil), Commentf("Worker1 node is nil"))
+	c.Assert(s.worker1, Not(IsNil), Commentf("Worker1 node is not set."))
 	s.worker2 = inputparams.GetSwarmWorker2()
-	c.Assert(s.worker2, Not(IsNil), Commentf("Worker2 node is nil"))
+	c.Assert(s.worker2, Not(IsNil), Commentf("Worker2 node is not set."))
 	s.swarmNodes = inputparams.GetSwarmNodes()
 
 	// Verify if swarm cluster is already initialized

--- a/tests/e2e/swarm_test.go
+++ b/tests/e2e/swarm_test.go
@@ -46,8 +46,11 @@ type SwarmTestSuite struct {
 func (s *SwarmTestSuite) SetUpSuite(c *C) {
 	s.esxName = inputparams.GetEsxIP()
 	s.master = inputparams.GetSwarmManager1()
+	c.Assert(s.master, Not(IsNil), Commentf("Master node is nil"))
 	s.worker1 = inputparams.GetSwarmWorker1()
+	c.Assert(s.worker1, Not(IsNil), Commentf("Worker1 node is nil"))
 	s.worker2 = inputparams.GetSwarmWorker2()
+	c.Assert(s.worker2, Not(IsNil), Commentf("Worker2 node is nil"))
 	s.swarmNodes = inputparams.GetSwarmNodes()
 
 	// Verify if swarm cluster is already initialized

--- a/tests/utils/inputparams/testparams.go
+++ b/tests/utils/inputparams/testparams.go
@@ -101,20 +101,18 @@ func GetEndPoint2() string {
 
 // GetSwarmManager1 returns swarm manager node IP from the configured swarm cluster
 func GetSwarmManager1() string {
-	manager1 := os.Getenv("MANAGER1")
-	return manager1
+	return os.Getenv("MANAGER1")
 }
 
 // GetSwarmWorker1 returns 1st swarm worker node IP from the configured swarm cluster
 func GetSwarmWorker1() string {
-	worker1 := os.Getenv("WORKER1")
-	return worker1
+	return os.Getenv("WORKER1")
 }
 
 // GetSwarmWorker2 returns 2nd swarm worker node IP from the configured swarm cluster
 func GetSwarmWorker2() string {
-	worker2 := os.Getenv("WORKER2")
-	return worker2
+	return os.Getenv("WORKER2")
+
 }
 
 // GetSwarmNodes returns all nodes in the configured swarm cluster
@@ -139,13 +137,13 @@ func getInstance() *TestConfig {
 	config.EsxHost = GetEsxIP()
 	config.DockerHosts = append(config.DockerHosts, os.Getenv("VM1"))
 	config.DockerHosts = append(config.DockerHosts, os.Getenv("VM2"))
-	if config.DockerHosts[0] == "" && config.DockerHosts[1] == "" {
-		log.Fatal("No docker hosts found. At least one host is needed to run tests.")
+	if config.DockerHosts[0] == "" || config.DockerHosts[1] == "" {
+		log.Fatal("Two docker hosts are needed to run tests.")
 	}
 	config.DockerHostNames = append(config.DockerHostNames, esx.RetrieveVMNameFromIP(config.DockerHosts[0]))
 	config.DockerHostNames = append(config.DockerHostNames, esx.RetrieveVMNameFromIP(config.DockerHosts[1]))
-	if config.DockerHostNames[0] == noVMName && config.DockerHostNames[1] == noVMName {
-		log.Fatalf("No names found for docker hosts - %s , %s ", config.DockerHosts[0], config.DockerHosts[1])
+	if config.DockerHostNames[0] == noVMName || config.DockerHostNames[1] == noVMName {
+		log.Fatalf("Failed to find vm name for docker hosts - %s , %s ", config.DockerHosts[0], config.DockerHosts[1])
 	}
 	config.Datastores = esx.GetDatastoreList()
 	if len(config.Datastores) < 1 {

--- a/tests/utils/inputparams/testparams.go
+++ b/tests/utils/inputparams/testparams.go
@@ -145,10 +145,7 @@ func GetEsxIP() string {
 func getInstance() *TestConfig {
 	noVMName := "no such VM"
 	config = new(TestConfig)
-	config.EsxHost = os.Getenv("ESX")
-	if config.EsxHost == "" {
-		log.Fatal("ESX host not found. Stopping the test run.")
-	}
+	config.EsxHost = GetEsxIP()
 	config.DockerHosts = append(config.DockerHosts, os.Getenv("VM1"))
 	config.DockerHosts = append(config.DockerHosts, os.Getenv("VM2"))
 	if config.DockerHosts[0] == "" && config.DockerHosts[1] == "" {


### PR DESCRIPTION
Fixes issue #1463 and #1398

1. Added a fix to ensure E2E tests will run even with one datastore - #1463
2. Added the fix to verify the minimum required environment variables are properly initialized before running e2e test else fail the test run.
3. Made changes to inputparams.GetTestConfig() so we have only one instance of config and not each E2E test creating a new instance.


Tested locally: All tests passed other than swarm tests as there was no swarm configured
```
=> Running target test-e2e-runalways
OK: 6 passed
--- PASS: Test (120.40s)
PASS

=> Running target test-e2e-runonce
--- FAIL: Test (601.62s)
FAIL
OOPS: 23 passed, 3 skipped, 1 FAILED, 2 MISSED
exit status 1
FAIL	github.com/vmware/docker-volume-vsphere/tests/e2e	601.626s
make: *** [test-e2e-runonce] Error 1
```