### PR TITLE
Add support of new global plugin compilation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,16 @@ build-all: dockerized-build-ui
 	$(MAKE) --directory=vmdk_plugin $@
 	$(MAKE) --directory=plugin all
 
+build-global: dockerized-build-ui
+	$(MAKE) --directory=global_plugin build-all
+	$(MAKE) --directory=global_plugin_docker all
+
 # clean inside docker run to avoid sudo make clean
 # dev builds are inside docker which creates folders
 # as root.
 clean: dockerized-clean-ui
 	$(MAKE) --directory=vmdk_plugin $@
+	$(MAKE) --directory=global_plugin $@
 
 # Non dockerized build, used by CI
 build:
@@ -54,6 +59,7 @@ ifeq ($(INCLUDE_UI), true)
 	$(MAKE) --directory=ui $@
 endif
 	$(MAKE) --directory=vmdk_plugin $@
+	$(MAKE) --directory=global_plugin $@
 
 # Forward to UI inside docker run
 dockerized-build-ui:

--- a/global_plugin/Makefile
+++ b/global_plugin/Makefile
@@ -1,0 +1,140 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Makefile for Docker data volume plugin
+
+# Guest Package Version
+
+# PKG_VERSION is either set externally as part of a build off a tag or
+# suffixed with a sha1 of the most recent commit to the prefix of the
+# most recent tag. Tagged builds use the externally defined version,
+# developer builds use last tagged release and sha1 of the most recent commit.
+# Format: <last tagged release>.<last commit hash>
+PKG_VERSION ?= $(shell \
+	       git describe --tags `git rev-list --tags --max-count=1` \
+	       ).$(shell \
+	       git log --pretty=format:'%h' -n 1)
+
+export PKG_VERSION
+export INCLUDE_UI
+
+-include ../global_plugin_docker/Makefile
+
+EPOCH := 0
+
+# Place binaries here
+BIN := ../build
+MANAGED_PLUGIN := ../plugin
+
+# Location for scripts
+SCRIPTS     := ../misc/scripts
+
+# Packaging variables
+BASEPLUGNAME := docker-volume-vsphere
+PLUGNAME  := docker-volume-global
+GOPATH_PLUGNAME := $(BASEPLUGNAME)/global_plugin
+GOPATH_ORG :=vmware
+MAINTAINERS := cna-storage@vmware.com
+REPO_URL    := https://github.com/$(GOPATH_ORG)/$(BASEPLUGNAME)
+MIN_DOCKER_VERSION :=1.9
+DOCKER_PACKAGE := docker-engine
+
+#
+# Scripts to deploy and control services - used from Makefile and from Drone CI
+#
+CHECK	    := $(SCRIPTS)/check.sh
+BUILD       := $(SCRIPTS)/build.sh
+
+#  binaries location
+PLUGIN_BIN = $(BIN)/$(PLUGNAME)
+
+# all binaries for VMs - plugin and tests
+#VM_BINS = $(PLUGIN_BIN) $(BIN)/$(PLUGNAME).test
+VM_BINS = $(PLUGIN_BIN)
+
+# plugin name, for go build
+PLUGIN := github.com/$(GOPATH_ORG)/$(GOPATH_PLUGNAME)
+
+GO := GO15VENDOREXPERIMENT=1 go
+
+# All sources. We rebuild if anything changes here
+SRC = main.go ../vmdk_plugin/utils/refcount/refcnt.go \
+	../vmdk_plugin/utils/config/config.go \
+	../vmdk_plugin/utils/log_formatter/log_formatter.go \
+	drivers/global/global_driver.go
+
+TEST_SRC = ../tests/utils/inputparams/testparams.go
+
+# Canned recipe
+define log_target
+@echo
+@echo "=> Running target $@" `date`
+@echo
+endef
+
+# The default build is using a prebuilt docker image that has all dependencies.
+.PHONY: dockerbuild build-all
+build-all: dockerbuild
+
+dockerbuild:
+	@$(CHECK) dockerbuild
+	$(BUILD) global
+
+# The non docker build.
+.PHONY: build
+build: prereqs .code_verify $(VM_BINS)
+
+.PHONY: gvt
+gvt:
+	$(BUILD) gvt
+
+.PHONY: documentation
+documentation:
+	$(BUILD) documentation
+
+.PHONY: prereqs
+prereqs:
+	@$(CHECK) global
+
+$(PLUGIN_BIN): $(SRC)
+	@-mkdir -p $(BIN) && chmod a+w $(BIN)
+	$(GO) build --ldflags '-extldflags "-static"' -o $(PLUGIN_BIN) $(PLUGIN)
+
+(BIN)/$(PLUGNAME).test: $(SRC) $(SRC) $(TEST_SRC) *_test.go
+	$(GO) test -c -o $@ $(PLUGIN) -cover
+
+.PHONY: clean
+clean:
+	$(BUILD) clean-as-root
+
+.PHONY: clean-as-root
+clean-as-root: pkg-post
+	rm -rf $(BIN) .code_verify
+
+# GO Code quality checks.
+
+DIRS_TO_VERIFY := . drivers/global
+
+FILES_TO_VERIFY := $(foreach dir, $(DIRS_TO_VERIFY), $(dir)/*.go)
+.code_verify: $(FILES_TO_VERIFY)
+	@for i in $(DIRS_TO_VERIFY) ; do ${GOPATH}/bin/golint $$i ; done
+	go tool vet .
+	gofmt -s -l -w .
+	@touch $@
+
+
+# if we do not recognize the target, warn and keep going.
+.DEFAULT:
+	@echo "***" Warning: Skipping unsupported target \"$@\"

--- a/global_plugin/constants.go
+++ b/global_plugin/constants.go
@@ -12,17 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package main
 
 const (
-	// Default paths - used in log init in main() and test:
+	// vDVS Global driver.
+	globalDriver = "global"
 
-	// DefaultConfigPath is the default location of Log configuration file
-	DefaultConfigPath = "/etc/docker-volume-vsphere.conf"
-	// DefaultLogPath is the default location of log (trace) file
-	DefaultLogPath = "/var/log/docker-volume-vsphere.log"
-	// DefaultGlobalConfigPath is the default location of Log configuration file for global plugin
-	DefaultGlobalConfigPath = "/etc/docker-volume-global.conf"
-	// DefaultGlobalLogPath is the default location of log (trace) file for global plugin
-	DefaultGlobalLogPath = "/var/log/docker-volume-global.log"
+	// Docker driver types.
+	volumeDriver = "VolumeDriver"
+
+	// Docker plugin handshake endpoint.
+	// Also see https://docs.docker.com/engine/extend/plugin_api/#handshake-api
+	pluginActivatePath = "/Plugin.Activate"
+
+	// Docker volume plugin endpoints.
+	// Also see https://docs.docker.com/engine/extend/plugins_volume/#volume-plugin-protocol
+	volumeDriverCreatePath = "/VolumeDriver.Create"
 )

--- a/global_plugin/drivers/driver.go
+++ b/global_plugin/drivers/driver.go
@@ -1,0 +1,24 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drivers
+
+// VolumeDriver interface used by the refcountedVolume module to handle
+// recovery mounts/unmounts.
+type VolumeDriver interface {
+	MountVolume(string, string, string, bool, bool) (string, error)
+	UnmountVolume(string) error
+	GetVolume(string) (map[string]interface{}, error)
+	VolumesInRefMap() []string
+}

--- a/global_plugin/drivers/global/global_driver.go
+++ b/global_plugin/drivers/global/global_driver.go
@@ -1,0 +1,209 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package global
+
+//
+// VMWare Global Docker Data Volume plugin.
+//
+// Provide support for --driver=global in Docker.
+//
+// Serves requests from Docker Engine related to global volume operations.
+///
+
+import (
+	"fmt"
+	"path/filepath"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/go-plugins-helpers/volume"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/plugin_utils"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/refcount"
+)
+
+const (
+	version = "Global Volume Driver v0.1"
+)
+
+// VolumeDriver - global volume driver struct
+type VolumeDriver struct {
+	refCounts     *refcount.RefCountsMap
+	mountIDtoName map[string]string // map of mountID -> full volume name
+}
+
+var mountRoot string
+
+// NewVolumeDriver creates driver instance
+func NewVolumeDriver(mountDir string, driverName string) *VolumeDriver {
+	var d *VolumeDriver
+
+	mountRoot = mountDir
+
+	d = &VolumeDriver{
+		refCounts: refcount.NewRefCountsMap(),
+	}
+
+	d.mountIDtoName = make(map[string]string)
+	d.refCounts.Init(d, mountDir, driverName)
+
+	log.WithFields(log.Fields{
+		"version": version,
+	}).Info("Docker Global plugin started ")
+
+	return d
+}
+
+// In following three operations on refcount, if refcount
+// map hasn't been initialized, return 1 to prevent detach and remove.
+
+// Return the number of references for the given volume
+func (d *VolumeDriver) getRefCount(vol string) uint {
+	if d.refCounts.IsInitialized() != true {
+		return 1
+	}
+	return d.refCounts.GetCount(vol)
+}
+
+// Increment the reference count for the given volume
+func (d *VolumeDriver) incrRefCount(vol string) uint {
+	if d.refCounts.IsInitialized() != true {
+		return 1
+	}
+	return d.refCounts.Incr(vol)
+}
+
+// Decrement the reference count for the given volume
+func (d *VolumeDriver) decrRefCount(vol string) (uint, error) {
+	if d.refCounts.IsInitialized() != true {
+		return 1, nil
+	}
+	return d.refCounts.Decr(vol)
+}
+
+// Returns the given volume mountpoint
+func getMountPoint(volName string) string {
+	return filepath.Join(mountRoot, volName)
+}
+
+// Get info about a single volume
+func (d *VolumeDriver) Get(r volume.Request) volume.Response {
+	log.Errorf("VolumeDriver Get to be implemented")
+	return volume.Response{Err: ""}
+}
+
+// List volumes known to the driver
+func (d *VolumeDriver) List(r volume.Request) volume.Response {
+	log.Errorf("VolumeDriver List to be implemented")
+	return volume.Response{Err: ""}
+}
+
+// GetVolume - return volume meta-data.
+func (d *VolumeDriver) GetVolume(name string) (map[string]interface{}, error) {
+	var statusMap map[string]interface{}
+	statusMap = make(map[string]interface{})
+	log.Errorf("VolumeDriver GetVolume to be implemented")
+	return statusMap, nil
+}
+
+// MountVolume - Request attach and them mounts the volume.
+func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isReadOnly bool, skipAttach bool) (string, error) {
+	log.Errorf("VolumeDriver MountVolume to be implemented")
+	mountpoint := getMountPoint(name)
+	return mountpoint, nil
+}
+
+// UnmountVolume - Unmounts the volume and then requests detach
+func (d *VolumeDriver) UnmountVolume(name string) error {
+	log.Errorf("VolumeDriver UnmountVolume to be implemented")
+	return nil
+}
+
+// Create - create a volume.
+func (d *VolumeDriver) Create(r volume.Request) volume.Response {
+	log.Errorf("VolumeDriver Create to be implemented")
+	return volume.Response{Err: ""}
+}
+
+// Remove - removes individual volume. Docker would call it only if is not using it anymore
+func (d *VolumeDriver) Remove(r volume.Request) volume.Response {
+	log.WithFields(log.Fields{"name": r.Name}).Info("Removing volume ")
+
+	// Cannot remove volumes till plugin completely initializes (refcounting is complete)
+	// because we don't know if it is being used or not
+	if d.refCounts.IsInitialized() != true {
+		msg := fmt.Sprintf(plugin_utils.PluginInitError+" Cannot remove volume=%s", r.Name)
+		log.Error(msg)
+		return volume.Response{Err: msg}
+	}
+
+	// Docker is supposed to block 'remove' command if the volume is used.
+	if d.getRefCount(r.Name) != 0 {
+		msg := fmt.Sprintf("Remove failure - volume is still mounted. "+
+			" volume=%s, refcount=%d", r.Name, d.getRefCount(r.Name))
+		log.Error(msg)
+		return volume.Response{Err: msg}
+	}
+
+	log.Errorf("VolumeDriver Remove to be implemented")
+	return volume.Response{Err: ""}
+}
+
+// Path - give docker a reminder of the volume mount path
+func (d *VolumeDriver) Path(r volume.Request) volume.Response {
+	return volume.Response{Mountpoint: getMountPoint(r.Name)}
+}
+
+// Mount - Provide a volume to docker container - called once per container start.
+// We need to keep refcount and unmount on refcount drop to 0
+//
+// The serialization of operations per volume is assured by the volume/store
+// of the docker daemon.
+// As long as the refCountsMap is protected is unnecessary to do any locking
+// at this level during create/mount/umount/remove.
+//
+func (d *VolumeDriver) Mount(r volume.MountRequest) volume.Response {
+	log.WithFields(log.Fields{"name": r.Name}).Info("Mounting volume ")
+
+	// lock the state
+	d.refCounts.StateMtx.Lock()
+	defer d.refCounts.StateMtx.Unlock()
+
+	log.Errorf("VolumeDriver Mount to be implemented")
+	return volume.Response{Err: ""}
+}
+
+// Unmount request from Docker. If mount refcount is drop to 0.
+func (d *VolumeDriver) Unmount(r volume.UnmountRequest) volume.Response {
+	log.WithFields(log.Fields{"name": r.Name}).Info("Unmounting Volume ")
+
+	// lock the state
+	d.refCounts.StateMtx.Lock()
+	defer d.refCounts.StateMtx.Unlock()
+
+	if d.refCounts.IsInitialized() != true {
+		// if refcounting hasn't been succesful,
+		// no refcounting, no unmount. All unmounts are delayed
+		// until we succesfully populate the refcount map
+		d.refCounts.MarkDirty()
+		return volume.Response{Err: ""}
+	}
+
+	log.Errorf("VolumeDriver Unmount to be implemented")
+	return volume.Response{Err: ""}
+}
+
+// Capabilities - Report plugin scope to Docker
+func (d *VolumeDriver) Capabilities(r volume.Request) volume.Response {
+	return volume.Response{Capabilities: volume.Capability{Scope: "global"}}
+}

--- a/global_plugin/main_linux.go
+++ b/global_plugin/main_linux.go
@@ -1,0 +1,70 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// A VMDK Docker Data Volume plugin implementation for linux that
+// relies on the docker/go-plugins-helpers/volume API.
+
+import (
+	"os"
+	"path/filepath"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/go-plugins-helpers/volume"
+)
+
+const (
+	mountRoot     = "/mnt/global"         // VMDK and photon volumes are mounted here
+	pluginSockDir = "/run/docker/plugins" // Unix sock for the plugin is maintained here
+)
+
+// SockPluginServer serves HTTP requests from Docker over unix sock.
+type SockPluginServer struct {
+	PluginServer
+	sockAddr string         // Server's unix sock address
+	driver   *volume.Driver // The driver implementation
+}
+
+// An equivalent function is not exported from the SDK.
+// API supports passing a full address instead of just name.
+// Using the full path during creation and deletion. The path
+// is the same as the one generated internally. Ideally SDK
+// should have ability to clean up sock file instead of replicating
+// it here.
+func fullSocketAddress(pluginName string) string {
+	return filepath.Join(pluginSockDir, pluginName+".sock")
+}
+
+// NewPluginServer creates a new instance of SockPluginServer.
+func NewPluginServer(driverName string, driver *volume.Driver) *SockPluginServer {
+	return &SockPluginServer{sockAddr: fullSocketAddress(driverName), driver: driver}
+}
+
+// Init registers the volume driver with a handler to service HTTP
+// requests from Docker.
+func (s *SockPluginServer) Init() {
+	handler := volume.NewHandler(*s.driver)
+
+	log.WithFields(log.Fields{
+		"address": s.sockAddr,
+	}).Info("Going into ServeUnix - Listening on Unix socket ")
+
+	log.Info(handler.ServeUnix("root", s.sockAddr))
+}
+
+// Destroy removes the Docker plugin sock.
+func (s *SockPluginServer) Destroy() {
+	os.Remove(s.sockAddr)
+}

--- a/global_plugin/main_windows.go
+++ b/global_plugin/main_windows.go
@@ -1,0 +1,130 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// A VMDK Docker Data Volume plugin implementation for Windows OS.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/Microsoft/go-winio"
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/go-plugins-helpers/volume"
+)
+
+const (
+	npipeAddr = `\\.\pipe\global` // Plugin's npipe address
+)
+
+var (
+	mountRoot = filepath.Join(os.Getenv("LOCALAPPDATA"), "docker-volume-global", "mounts") // VMDK volumes are mounted here
+)
+
+// NpipePluginServer serves HTTP requests from Docker over windows npipe.
+type NpipePluginServer struct {
+	PluginServer
+	driver   *volume.Driver // The driver implementation
+	mux      *http.ServeMux // The HTTP mux
+	listener net.Listener   // The npipe listener
+}
+
+// Response for /Plugin.Activate to activate the Docker plugin.
+type PluginActivateResponse struct {
+	Implements []string // Slice of implemented driver types
+}
+
+// NewPluginServer returns a new instance of NpipePluginServer.
+func NewPluginServer(driverName string, driver *volume.Driver) *NpipePluginServer {
+	return &NpipePluginServer{driver: driver, mux: http.NewServeMux()}
+}
+
+// writeJSON writes the JSON encoding of resp to the writer.
+func writeJSON(resp interface{}, writer *http.ResponseWriter) error {
+	bytes, err := json.Marshal(resp)
+	if err == nil {
+		fmt.Fprintf(*writer, string(bytes))
+	}
+	return err
+}
+
+// writeError writes an error message and status to the writer.
+func writeError(path string, writer http.ResponseWriter, req *http.Request, status int, err error) {
+	log.WithFields(log.Fields{"path": path, "req": req, "status": status,
+		"err": err}).Error("Failed to service request ")
+	http.Error(writer, err.Error(), status)
+}
+
+// PluginActivate writes the plugin's handshake response to the writer.
+func (s *NpipePluginServer) PluginActivate(writer http.ResponseWriter, req *http.Request) {
+	resp := &PluginActivateResponse{Implements: []string{volumeDriver}}
+	errJSON := writeJSON(resp, &writer)
+	if errJSON != nil {
+		writeError(pluginActivatePath, writer, req, http.StatusInternalServerError, errJSON)
+		return
+	}
+	log.WithFields(log.Fields{"resp": resp}).Info("Plugin activated ")
+}
+
+// VolumeDriverCreate creates a volume and writes the response to the writer.
+func (s *NpipePluginServer) VolumeDriverCreate(writer http.ResponseWriter, req *http.Request) {
+	var volumeReq volume.Request
+	err := json.NewDecoder(req.Body).Decode(&volumeReq)
+	if err != nil {
+		writeError(volumeDriverCreatePath, writer, req, http.StatusBadRequest, err)
+		return
+	}
+
+	resp := (*s.driver).Create(volumeReq)
+	errJSON := writeJSON(resp, &writer)
+	if errJSON != nil {
+		writeError(volumeDriverCreatePath, writer, req, http.StatusInternalServerError, errJSON)
+		return
+	}
+	log.WithFields(log.Fields{"resp": resp}).Info("Serviced /VolumeDriver.Create ")
+}
+
+// registerHttpHandlers registers handlers with the HTTP mux.
+func (s *NpipePluginServer) registerHandlers() {
+	s.mux.HandleFunc(pluginActivatePath, s.PluginActivate)
+	s.mux.HandleFunc(volumeDriverCreatePath, s.VolumeDriverCreate)
+}
+
+// Init initializes the npipe listener which serves HTTP requests
+// from Docker using the HTTP mux.
+func (s *NpipePluginServer) Init() {
+	var err error
+	s.listener, err = winio.ListenPipe(npipeAddr, nil)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to initialize npipe at %s - exiting", npipeAddr)
+		log.WithFields(log.Fields{"err": err}).Fatal(msg)
+		fmt.Println(msg)
+		os.Exit(1)
+	}
+
+	s.registerHandlers()
+	log.WithFields(log.Fields{"npipe": npipeAddr}).Info("Going into Serve - Listening on npipe ")
+	log.Info(http.Serve(s.listener, s.mux))
+}
+
+// Destroy shuts down the npipe listener.
+func (s *NpipePluginServer) Destroy() {
+	log.WithFields(log.Fields{"npipe": npipeAddr}).Info("Closing npipe listener ")
+	s.listener.Close()
+}

--- a/global_plugin_docker/.gitignore
+++ b/global_plugin_docker/.gitignore
@@ -1,0 +1,2 @@
+docker-volume-global
+rootfs/

--- a/global_plugin_docker/Dockerfile
+++ b/global_plugin_docker/Dockerfile
@@ -1,0 +1,15 @@
+# Dockerile for packaging https://github.com/vmware/docker-volume-vsphere as
+# Docker managed plugin.
+#
+# Image created with this file is used to unpack to plugin rootfs and then build
+# plugin image
+#
+# We need <fs>progs to allow formatting fresh disks from within the plugin
+
+
+FROM alpine:3.5
+
+RUN apk update ; apk add e2fsprogs xfsprogs
+RUN mkdir -p /mnt/global
+COPY docker-volume-global /usr/bin
+CMD ["/usr/bin/docker-volume-global"]

--- a/global_plugin_docker/Makefile
+++ b/global_plugin_docker/Makefile
@@ -1,0 +1,106 @@
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Makefile for Docker data volume *managed* plugin.
+#
+# This Makefile assumes it's in ./global_plugin_docker in the tree and the binaries are already built
+
+#
+# Makefile names the plugin simlarly to this (for example) 'msterin/docker-volume-global:0.1-dev'
+#
+# Make targets:
+#    info (helpful info), clean (remove build artefacts), plugin, (build plugin), push (push to dockerhub)
+#
+# Use the following environment vars to change the behavior :
+#
+# DOCKER_HUB_REPO - Dockerhub repo to use, in both name forming and in pushing to dockerhub.
+#                   Defaults to the result of `whoami` command.
+#                   Note: you first need to run 'docker login' in order for 'make push' to succeed
+# VERSION_TAG     - How you want the version to look. Default is "current git tag +1 "
+# EXTRA_TAG       - additional info you want in tag. Default is "-dev"
+#
+# To check resulting settings use  "make info"
+# examples:
+#   make
+#          --> resulting name (for now)  msterin/docker-volume-global:0.1-dev
+#
+# 	DOCKER_HUB_REPO=vmware EXTRA_TAG= VERSION_TAG=latest make
+#           --> resulting name vmware/docker-volume-global:latest
+#
+#   DOCKER_HUB_REPO=cnastorage EXTRA_TAG=-CI make
+#           --> resulting name cnastorage/docker-volume-global:0.1-CI
+#
+
+# grab the latest commit SHA and related tag from git so we can construct plugin tag
+GIT_SHA := $(shell git rev-parse --revs-only --short HEAD)
+GIT_TAG := $(shell git describe --tags --abbrev=0 $(GIT_SHA))
+
+# Allow these vars to be suplied in environment
+DOCKER_HUB_REPO ?= $(shell whoami)
+# "git tag + 1" , so "0.11" becomes "0.12"
+VERSION_TAG ?= $(shell echo $(GIT_TAG) | awk -F. '{printf ("%d.%d", $$1, $$2+1)}' )
+EXTRA_TAG ?= -dev
+
+# final tag
+PLUGIN_TAG := $(VERSION_TAG)$(EXTRA_TAG)
+
+# plugin name - used as a base for full plugin name and container for extracting rootfs
+PLUGIN_NAME=$(DOCKER_HUB_REPO)/docker-volume-global
+
+# Binaries we want to pick up from the actual build
+BIN_LOC := ../build
+BINARY := docker-volume-global
+
+# Tmp docker image used to construct rootfs + our binaries
+TMP_IMAGE = $(PLUGIN_NAME):rootfs
+# Tmp container used for exporting rootfs from it
+TMP_CONTAINER := tempContainer
+# Tmp location on local FS to manipulate plugin files
+TMP_LOC := /tmp/plugin
+
+# default target
+all: info plugin push
+
+# unconditionally run those
+.PHONY: all clean info plugin
+
+info:
+	@echo Using the following config:
+	@echo DOCKER_HUB_REPO $(DOCKER_HUB_REPO) EXTRA_TAG $(EXTRA_TAG) VERSION_TAG $(VERSION_TAG)
+	@echo PLUGIN_NAME $(PLUGIN_NAME):$(PLUGIN_TAG)
+
+clean:
+	@echo "=== Cleaning work files, images and plugin(s)..."
+	rm -rf $(TMP_LOC)
+	rm -f $(BINARY)
+	-docker plugin rm $(PLUGIN_NAME):$(PLUGIN_TAG) -f
+	-docker rm -vf $(TMP_CONTAINER)
+	-docker rmi $(TMP_IMAGE)
+
+plugin: clean
+	@echo "== building Docker image, unpacking to ./rootfs and creating plugin..."
+	cp $(BIN_LOC)/$(BINARY) .
+	docker build -q -t $(TMP_IMAGE) .
+	docker create --name $(TMP_CONTAINER) $(TMP_IMAGE)
+	mkdir -p $(TMP_LOC)/rootfs
+	docker export  $(TMP_CONTAINER)  | tar -x -C $(TMP_LOC)/rootfs
+	cp config.json $(BINARY) $(TMP_LOC)
+	@echo "-- Creating  plugin $(PLUGIN_NAME):$(PLUGIN_TAG) ..."
+	docker plugin create $(PLUGIN_NAME):$(PLUGIN_TAG) $(TMP_LOC)
+
+push:
+	@echo Pushing $(PLUGIN_NAME):$(PLUGIN_TAG)  to dockerhub.io...
+	@docker plugin push $(PLUGIN_NAME):$(PLUGIN_TAG) || \
+			echo 'Please make sure the plugin is built ("make clean plugin") and you have logged in to docker hub first ("docker login -u $(DOCKER_HUB_REPO)")'

--- a/global_plugin_docker/Readme.md
+++ b/global_plugin_docker/Readme.md
@@ -1,0 +1,1 @@
+### Support for building docker-volume-global as Docker Managed Plugin

--- a/global_plugin_docker/config.json
+++ b/global_plugin_docker/config.json
@@ -1,0 +1,65 @@
+{
+	"Description": "VMWare Global Docker Volume plugin",
+	"Documentation": "http://vmware.github.io/docker-volume-vsphere/documentation",
+	"Entrypoint": ["/usr/bin/docker-volume-global",
+					"--config", "/etc/docker-volume-global.conf"
+	],
+	"PropagatedMount": "/mnt/global",
+	"Mounts": [
+		{
+			"Description" : "The plugin uses dev to mount volumes and watch for attaches",
+			"Source" : "/dev",
+			"Destination" : "/dev",
+			"Type": "bind",
+			"Options": ["rbind", "shared"]
+		},
+		{
+			"Description" : "The plugin uses /var/run/docker.sock to ask Docker some questions",
+			"Source" : "/var/run",
+			"Destination" : "/var/run",
+			"Type": "bind",
+			"Options": ["rbind"]
+		},
+		{
+			"Description" : "Location to look for config file (/etc/docker-volume-global.conf)",
+			"Source" : "/etc",
+			"Destination" : "/etc",
+			"Type": "bind",
+			"Options": ["rbind"]
+		},
+		{
+			"Description" : "Expose plugin logs in /var/log/docker-volume-global.log",
+			"Source" : "/var/log",
+			"Destination" : "/var/log",
+			"Type": "bind",
+			"Options": ["rbind"]
+		}
+	],
+	"Network": {
+		"Type": ""
+	},
+	"Interface" : {
+		"Types": ["docker.volumedriver/1.0"],
+		"Socket": "vsphere.sock"
+	},
+	"Linux": {
+		"AllowAllDevices": true,
+		"Capabilities": ["CAP_SYS_ADMIN"],
+		"Devices": null
+
+	},
+	"Env": [ {
+      "name": "VDVS_LOG_LEVEL",
+      "description": "Log level - info, warn, error or debug",
+      "value": "info",
+      "Settable": [ "value"]
+	},
+	{
+      "name": "VDVS_TEST_PROTOCOL_VERSION",
+      "description": "Client protocol version used in test",
+      "value": "",
+      "Settable": [ "value"]
+	}
+	]
+}
+

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -96,6 +96,7 @@ host_dir=$PWD/..
 MAKE="$DEBUG make --directory=vmdk_plugin"
 MAKE_UI="$DEBUG make --directory=ui"
 MAKE_ESX="$DEBUG make --directory=esx_service"
+MAKE_GLOBAL="$DEBUG make --directory=global_plugin"
 
 DOCKER="$DEBUG docker"
 
@@ -121,6 +122,25 @@ then
 elif [ "$1" == "pylint" ]
 then
   $DOCKER run --rm  -v $PWD/..:$dir -w $dir $pylint_container $MAKE_ESX pylint
+elif [ "$1" == "global" ]
+then
+  docker_socket=/var/run/docker.sock
+  if [ -z $SSH_KEY_OPT ]
+  then
+    SSH_KEY_OPT="-i /root/.ssh/id_rsa"
+  fi
+  ssh_key_opt_container=`echo $SSH_KEY_OPT | cut -d" " -f2`
+  ssh_key_path=$SSH_KEY_PATH
+  if [ -z $ssh_key_path ]
+  then
+    ssh_key_path=~/.ssh/id_rsa
+  fi
+  $DOCKER run --privileged --rm  \
+    -e "PKG_VERSION=$PKG_VERSION" \
+    -e "INCLUDE_UI=$INCLUDE_UI" \
+    -v $docker_socket:$docker_socket  \
+    -v $ssh_key_path:$ssh_key_opt_container:ro \
+    -v $PWD/..:$dir -w $dir $plug_container $MAKE_GLOBAL build
 else
   docker_socket=/var/run/docker.sock
   if [ -z $SSH_KEY_OPT ]

--- a/misc/scripts/check.sh
+++ b/misc/scripts/check.sh
@@ -84,7 +84,12 @@ then
    printNQuit "GOPATH environment variable needs to be set"
 fi
 
+if [ "$1" == "global" ]
+then
+EXPECTED_PATH="$GOPATH/src/github.com/vmware/docker-volume-vsphere/global_plugin"
+else
 EXPECTED_PATH="$GOPATH/src/github.com/vmware/docker-volume-vsphere/vmdk_plugin"
+fi
 
 if [[ "$EXPECTED_PATH" != "$PWD" ]]
 then

--- a/vmdk_plugin/Makefile
+++ b/vmdk_plugin/Makefile
@@ -96,7 +96,8 @@ VMDKOPS_MODULE_SRC = $(VMDKOPS_MODULE)/*.go $(VMCI_SRC)
 
 # All sources. We rebuild if anything changes here
 SRC = main.go log_formatter.go utils/refcount/refcnt.go \
-	utils/fs/fs.go utils/config/config.go utils/plugin_utils/plugin_utils.go\
+	utils/fs/fs.go utils/config/config.go utils/log_formatter/log_formatter.go \
+	utils/plugin_utils/plugin_utils.go \
 	drivers/photon/photon_driver.go drivers/vmdk/vmdk_driver.go
 
 TEST_SRC = ../tests/utils/inputparams/testparams.go

--- a/vmdk_plugin/sanity_test.go
+++ b/vmdk_plugin/sanity_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/docker/engine-api/types/strslice"
 	testutil "github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
 	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/config"
+	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/log_formatter"
 	"github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/refcount"
 	"golang.org/x/net/context"
 )
@@ -86,7 +87,7 @@ func init() {
 		"conf_file":                *configFile,
 		"using_conf_file_defaults": usingConfigFileDefaults,
 	}).Info("VMDK plugin tests started ")
-	log.SetFormatter(new(VmwareFormatter))
+	log.SetFormatter(new(log_formatter.VmwareFormatter))
 }
 
 // returns in-container mount point for a volume

--- a/vmdk_plugin/utils/config/config.go
+++ b/vmdk_plugin/utils/config/config.go
@@ -57,9 +57,6 @@ func Load(path string) (Config, error) {
 
 // SetDefaults for any config setting that is at its `bottom`
 func SetDefaults(config *Config) {
-	if config.LogPath == "" {
-		config.LogPath = DefaultLogPath
-	}
 	if config.MaxLogSizeMb == 0 {
 		config.MaxLogSizeMb = defaultMaxLogSizeMb
 	}

--- a/vmdk_plugin/utils/config/config_windows.go
+++ b/vmdk_plugin/utils/config/config_windows.go
@@ -24,4 +24,8 @@ var (
 	DefaultConfigPath = filepath.Join(os.Getenv("PROGRAMDATA"), "docker-volume-vsphere", "docker-volume-vsphere.conf")
 	// DefaultLogPath is the default location of the log (trace) file.
 	DefaultLogPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "docker-volume-vsphere", "logs", "docker-volume-vsphere.log")
+	// DefaultGlobalConfigPath is the default location of the config file.
+	DefaultGlobalConfigPath = filepath.Join(os.Getenv("PROGRAMDATA"), "docker-volume-global", "docker-volume-global.conf")
+	// DefaultGlobalLogPath is the default location of the log (trace) file.
+	DefaultGlobalLogPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "docker-volume-global", "logs", "docker-volume-global.log")
 )

--- a/vmdk_plugin/utils/log_formatter/log_formatter.go
+++ b/vmdk_plugin/utils/log_formatter/log_formatter.go
@@ -17,7 +17,7 @@
 // * storage team specifications. The `appendKeyValue` and `needsQuoting` functions are copied
 // * from the implementation of the TextFormatter in Logrus.
 
-package main
+package log_formatter
 
 import (
 	"bytes"


### PR DESCRIPTION
Plugin name: global
Driver name: global
Default config file path: /etc/docker-volume-global.conf
Default log file path: /var/log/docker-volume-global.log
To build the new global plugin: make build-global
Only docker-based build is supported for now.