### PR TITLE
Adds fs implementation for Windows OS

### DIFF
--- a/vmdk_plugin/drivers/vmdk/vmdkops/esx_vmdkcmd.go
+++ b/vmdk_plugin/drivers/vmdk/vmdkops/esx_vmdkcmd.go
@@ -34,7 +34,7 @@ import (
 
 /*
 #cgo CFLAGS: -I ../../../../esx_service/vmci
-#cgo windows LDFLAGS: -L. -lvmci_client
+#cgo windows LDFLAGS: -L${SRCDIR}/../../../ -lvmci_client
 #include "vmci_client.h"
 #include "vmci_client_proxy.c"
 */

--- a/vmdk_plugin/utils/fs/constants.go
+++ b/vmdk_plugin/utils/fs/constants.go
@@ -12,22 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Platform independent fs module constants.
+
 package fs
 
-import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
+const (
+	lf   = "\n"   // line feed
+	crlf = "\r\n" // carriage return line feed
 )
-
-const funnyfs = "funnyfs"
-
-func TestVerifyFSSupport(t *testing.T) {
-	err := VerifyFSSupport(FstypeDefault)
-	assert.Nil(t, err, "Fstype %s should be supported", FstypeDefault)
-}
-
-func TestVerifyFSSupportError(t *testing.T) {
-	err := VerifyFSSupport(funnyfs)
-	assert.NotNil(t, err, "Fstype %s shouldn't be supported", funnyfs)
-}

--- a/vmdk_plugin/utils/fs/constants.go
+++ b/vmdk_plugin/utils/fs/constants.go
@@ -17,6 +17,7 @@
 package fs
 
 const (
+	cr   = "\r"   // carriage return
 	lf   = "\n"   // line feed
 	crlf = "\r\n" // carriage return line feed
 )

--- a/vmdk_plugin/utils/fs/device_watcher_windows.go
+++ b/vmdk_plugin/utils/fs/device_watcher_windows.go
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 // Device watching logic for Windows OS.
+// This code is to be called when a device shows on a bus. The code will ensure
+// that a newly attached disk is ready for use by waiting until it's fully accessible.
 
 package fs
 
@@ -26,6 +28,7 @@ import (
 const (
 	devChangeTimeoutSec = 1 // Number of seconds to wait for a Win32_DeviceChangeEvent
 
+	// Using a PowerShell script here due to lack of a functional Go WMI library.
 	// PowerShell script to register and wait for a Win32_DeviceChangeEvent.
 	// The script blocks until a Win32_DeviceChangeEvent occurs or the event times out.
 	devChangeWaitScript = `

--- a/vmdk_plugin/utils/fs/device_watcher_windows.go
+++ b/vmdk_plugin/utils/fs/device_watcher_windows.go
@@ -1,0 +1,108 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Device watching logic for Windows OS.
+
+package fs
+
+import (
+	"fmt"
+	"os/exec"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+const (
+	devChangeTimeout = 1 // Number of seconds to wait for a Win32_DeviceChangeEvent
+
+	// PowerShell script to register and wait for a Win32_DeviceChangeEvent.
+	// The script blocks until a Win32_DeviceChangeEvent occurs or the event times out.
+	devChangeWaitScript = `
+		Register-WmiEvent -Class Win32_DeviceChangeEvent -SourceIdentifier DeviceChangeEvent
+		$event = Wait-Event -SourceIdentifier DeviceChangeEvent -Timeout %d
+		If ($event) {
+			Write-Host "DeviceChangeEvent"
+		}
+		Else {
+			Write-Host "EventTimedOut"
+		}
+	`
+)
+
+// DeviceWatcher represents a device change watcher.
+type DeviceWatcher struct {
+	Event      chan string   // chan for emitting events
+	Error      chan error    // chan for emitting errors
+	stop       bool          // flag to initiate watcher termination
+	terminated chan struct{} // chan to notify watcher termination status
+}
+
+// NewDeviceWatcher returns a new instance of DeviceWatcher.
+func NewDeviceWatcher() *DeviceWatcher {
+	return &DeviceWatcher{Event: make(chan string), Error: make(chan error),
+		stop: false, terminated: make(chan struct{})}
+}
+
+// Init starts a goroutine that emits device events/errors via watcher channels.
+func (w *DeviceWatcher) Init() {
+	go func() {
+		for !w.stop {
+			log.Info("Waiting for a device change event ")
+			w.awaitEventAndEmit()
+		}
+		close(w.Event)
+		close(w.Error)
+		log.Info("Watcher channels closed ")
+		w.terminated <- struct{}{}
+	}()
+}
+
+// awaitEventAndEmit awaits and emits a device change event or an error.
+func (w *DeviceWatcher) awaitEventAndEmit() {
+	script := fmt.Sprintf(devChangeWaitScript, devChangeTimeout)
+	out, err := exec.Command(powershell, script).Output()
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Error("Failed to watch device event ")
+		select {
+		case w.Error <- err:
+			log.WithFields(log.Fields{"err": err}).Info("Successfully emitted error ")
+		default:
+			log.WithFields(log.Fields{"err": err}).Warn("Couldn't emit error, continuing.. ")
+		}
+		return
+	}
+
+	log.WithFields(log.Fields{"out": string(out)}).Info("Watcher script executed ")
+	event := tailSegment(out, lf, 2)
+	select {
+	case w.Event <- event:
+		log.WithFields(log.Fields{"event": event}).Info("Successfully emitted event ")
+	default:
+		log.WithFields(log.Fields{"event": event}).Warn("Couldn't emit event, continuing.. ")
+	}
+}
+
+// Terminate initiates watcher termination and returns immediately.
+func (w *DeviceWatcher) Terminate() {
+	log.Info("Initiated watcher termination ")
+	w.stop = true
+}
+
+// AwaitTermination blocks until watcher termination is completed.
+func (w *DeviceWatcher) AwaitTermination() {
+	log.Info("Awaiting watcher termination ")
+	<-w.terminated
+	close(w.terminated)
+	log.Info("Watcher termination complete ")
+}

--- a/vmdk_plugin/utils/fs/device_watcher_windows.go
+++ b/vmdk_plugin/utils/fs/device_watcher_windows.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	devChangeTimeout = 1 // Number of seconds to wait for a Win32_DeviceChangeEvent
+	devChangeTimeoutSec = 1 // Number of seconds to wait for a Win32_DeviceChangeEvent
 
 	// PowerShell script to register and wait for a Win32_DeviceChangeEvent.
 	// The script blocks until a Win32_DeviceChangeEvent occurs or the event times out.
@@ -70,7 +70,7 @@ func (w *DeviceWatcher) Init() {
 
 // awaitEventAndEmit awaits and emits a device change event or an error.
 func (w *DeviceWatcher) awaitEventAndEmit() {
-	script := fmt.Sprintf(devChangeWaitScript, devChangeTimeout)
+	script := fmt.Sprintf(devChangeWaitScript, devChangeTimeoutSec)
 	out, err := exec.Command(powershell, script).Output()
 	if err != nil {
 		log.WithFields(log.Fields{"err": err}).Error("Failed to watch device event ")

--- a/vmdk_plugin/utils/fs/device_watcher_windows_test.go
+++ b/vmdk_plugin/utils/fs/device_watcher_windows_test.go
@@ -33,6 +33,9 @@ func TestDeviceWatcherInit(t *testing.T) {
 	watcher.Init()
 	select {
 	case event := <-watcher.Event:
+		// Only EventTimedOut will be tested here.
+		// Mocking a disk attach isn't easily possible so DeviceChangeEvent will
+		// be tested via e2e tests.
 		assert.NotNil(t, event, "Event chan shouldn't return nil")
 	case err := <-watcher.Error:
 		assert.NotNil(t, err, "Error chan shouldn't return nil")

--- a/vmdk_plugin/utils/fs/device_watcher_windows_test.go
+++ b/vmdk_plugin/utils/fs/device_watcher_windows_test.go
@@ -1,0 +1,56 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// DeviceWatcher unit tests.
+
+package fs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDeviceWatcher(t *testing.T) {
+	watcher := NewDeviceWatcher()
+	assert.NotNil(t, watcher, "NewDeviceWatcher must return a watcher instance")
+}
+
+func TestDeviceWatcherInit(t *testing.T) {
+	watcher := NewDeviceWatcher()
+	watcher.Init()
+	select {
+	case event := <-watcher.Event:
+		assert.NotNil(t, event, "Event chan shouldn't return nil")
+	case err := <-watcher.Error:
+		assert.NotNil(t, err, "Error chan shouldn't return nil")
+		assert.FailNow(t, "Watcher shouldn't return an error")
+	case <-time.After(5 * time.Second):
+		assert.FailNow(t, "Watcher didn't emit an event/error in 5 seconds")
+	}
+	watcher.Terminate()
+	watcher.AwaitTermination()
+}
+
+func TestDeviceWatcherTerminate(t *testing.T) {
+	watcher := NewDeviceWatcher()
+	watcher.Init()
+	watcher.Terminate()
+	watcher.AwaitTermination()
+	_, evOk := <-watcher.Event
+	_, errOk := <-watcher.Error
+	assert.False(t, evOk, "Event chan wasn't closed")
+	assert.False(t, errOk, "Error chan wasn't closed")
+}

--- a/vmdk_plugin/utils/fs/fs_windows.go
+++ b/vmdk_plugin/utils/fs/fs_windows.go
@@ -198,7 +198,7 @@ func getDiskNum(volDev *VolumeDevSpec) (string, error) {
 	log.WithFields(log.Fields{"volDev": *volDev,
 		"out": string(out)}).Info("Disk mapping script executed ")
 
-	diskNum := tailSegment(out, lf, 2)
+	diskNum := strings.Replace(tailSegment(out, lf, 2), cr, "", -1)
 	if diskNum == diskNotFound {
 		msg := fmt.Sprintf("Could not identify disk for controller = %s, unit = %s",
 			volDev.ControllerPciSlotNumber, volDev.Unit)

--- a/vmdk_plugin/utils/fs/fs_windows.go
+++ b/vmdk_plugin/utils/fs/fs_windows.go
@@ -38,6 +38,7 @@ const (
 	diskpart             = "diskpart"
 	diskpartSuccessMsg   = "DiskPart successfully formatted the volume."
 
+	// Using a PowerShell script here due to lack of a functional Go WMI library.
 	// PowerShell script to identify the disk number given a scsi controller
 	// number and a unit number. The script returns an integer if the disk was
 	// found, else it returns DiskNotFound.
@@ -107,8 +108,7 @@ func DevAttachWait(watcher *DeviceWatcher, volDev *VolumeDevSpec) error {
 		case event := <-watcher.Event:
 			log.WithFields(log.Fields{"volDev": *volDev,
 				"event": event}).Info("Watcher emitted an event ")
-			diskNum, err := getDiskNum(volDev)
-			if err != nil {
+			if diskNum, err := getDiskNum(volDev); err != nil {
 				log.WithFields(log.Fields{"volDev": *volDev,
 					"err": err}).Warn("Couldn't map volDev to diskNum, continuing.. ")
 			} else {
@@ -138,6 +138,7 @@ func DevAttachWaitFallback() {
 
 // Mkdir creates a directory at the specified path.
 func Mkdir(path string) error {
+	// TODO: Implement for the volume mount workflow.
 	return nil
 }
 
@@ -174,11 +175,13 @@ func Mkfs(fstype string, label string, volDev *VolumeDevSpec) error {
 
 // Mount mounts the filesystem on the volDev at the given mountpoint.
 func Mount(mountpoint string, fstype string, volDev *VolumeDevSpec, isReadOnly bool) error {
+	// TODO: Implement for the volume mount workflow.
 	return nil
 }
 
 // Unmount unmounts a disk from the given mount point.
 func Unmount(mountpoint string) error {
+	// TODO: Implement for the volume unmount workflow.
 	return nil
 }
 

--- a/vmdk_plugin/utils/fs/fs_windows.go
+++ b/vmdk_plugin/utils/fs/fs_windows.go
@@ -1,0 +1,236 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is the filesystem interface for mounting volumes on a Windows guest.
+
+package fs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+const (
+	// FstypeDefault specifies the default FS to be used when not specified by the user.
+	FstypeDefault = ntfs
+
+	maxDiskAttachWait  = 10 * time.Second // Max time to wait for a disk to be attached
+	ntfs               = "ntfs"
+	powershell         = "powershell"
+	diskNotFound       = "DiskNotFound"
+	diskpart           = "diskpart"
+	diskpartSuccessMsg = "DiskPart successfully formatted the volume."
+
+	// PowerShell script to identify the disk number given a scsi controller
+	// number and a unit number. The script returns an integer if the disk was
+	// found, else it returns DiskNotFound.
+	scsiAddrToDiskNumScript = `
+		Get-PnpDevice -FriendlyName 'VMware Virtual disk SCSI Disk Device' |
+		Select-Object -ExpandProperty InstanceId |
+		ForEach-Object {
+			$instanceId = $_
+			$uiNum = (
+				Get-PnpDeviceProperty -InstanceId $instanceId -KeyName 'DEVPKEY_Device_UINumber' |
+				Select -expand Data -erroraction 'silentlycontinue'
+			)
+			$addr = (
+				Get-PnpDeviceProperty -InstanceId $instanceId -KeyName 'DEVPKEY_Device_Address' |
+				Select -expand Data -erroraction 'silentlycontinue'
+			)
+			If ($uiNum -eq '%s' -And $addr -eq '%s') {
+				Write-Host ""
+				Get-WmiObject Win32_DiskDrive |
+				Where-Object { $_.PNPDeviceId -eq $instanceId} |
+				Select-Object -ExpandProperty Index
+				exit
+			}
+		}
+		Write-Host ""
+		Write-Host "DiskNotFound"
+	`
+
+	// DiskPart script to format a disk with a filesystem.
+	formatDiskScript = `
+		select disk %s
+		clean
+		online disk
+		attribute disk clear readonly
+		create partition primary
+		select partition 1
+		active
+		format fs=%s label="%s" quick
+		exit
+	`
+)
+
+// VerifyFSSupport checks whether the fstype filesystem is supported.
+func VerifyFSSupport(fstype string) error {
+	if fstype != ntfs {
+		return fmt.Errorf("Not found mkfs for %s\nSupported filesystems: %s",
+			fstype, ntfs)
+	}
+	return nil
+}
+
+// DevAttachWaitPrep initializes and returns a new DiskWatcher.
+func DevAttachWaitPrep() (*DeviceWatcher, error) {
+	watcher := NewDeviceWatcher()
+	watcher.Init()
+	return watcher, nil
+}
+
+// DevAttachWait waits until the specified disk is attached, or returns
+// an error on watcher failure.
+func DevAttachWait(watcher *DeviceWatcher, volDev *VolumeDevSpec) error {
+	defer watcher.Terminate()
+	for {
+		log.WithFields(log.Fields{"volDev": *volDev}).Info("Waiting for a watcher event ")
+		select {
+		case event := <-watcher.Event:
+			log.WithFields(log.Fields{"volDev": *volDev,
+				"event": event}).Info("Watcher emitted an event ")
+			if diskNum, _ := getDiskNum(volDev); diskNum != "" {
+				log.WithFields(log.Fields{"volDev": *volDev,
+					"diskNum": diskNum}).Info("Successfully mapped volDev to diskNum ")
+				return nil
+			}
+			log.WithFields(log.Fields{"volDev": *volDev}).Warn("Couldn't locate disk, waiting.. ")
+
+		case err := <-watcher.Error:
+			log.WithFields(log.Fields{"volDev": *volDev,
+				"err": err}).Error("Watcher returned an error ")
+			return err
+
+		case <-time.After(maxDiskAttachWait):
+			msg := "Disk mapping timed out "
+			log.WithFields(log.Fields{"volDev": *volDev}).Error(msg)
+			return errors.New(msg)
+		}
+	}
+}
+
+// DevAttachWaitFallback is a NOP.
+func DevAttachWaitFallback() {
+	// NOP since DevAttachWaitPrep never returns an error
+}
+
+// Mkdir creates a directory at the specified path.
+func Mkdir(path string) error {
+	return nil
+}
+
+// Mkfs creates a filesystem at the specified volDev.
+func Mkfs(fstype string, label string, volDev *VolumeDevSpec) error {
+	diskNum, err := getDiskNum(volDev)
+	if err != nil {
+		log.WithFields(log.Fields{"fstype": fstype, "label": label, "volDev": *volDev,
+			"err": err}).Error("Failed to locate disk ")
+		return err
+	}
+
+	cmd := exec.Command(diskpart)
+	stdin, _ := cmd.StdinPipe()
+	defer stdin.Close()
+	io.WriteString(stdin, fmt.Sprintf(formatDiskScript, diskNum, ntfs, label))
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.WithFields(log.Fields{"fstype": fstype, "label": label, "volDev": *volDev,
+			"diskNum": diskNum, "err": err}).Error("DiskPart script failed to execute ")
+		return err
+	} else if tailSegment(out, crlf, 5) != diskpartSuccessMsg {
+		log.WithFields(log.Fields{"fstype": fstype, "label": label, "volDev": *volDev,
+			"diskNum": diskNum, "out": string(out)}).Error("DiskPart failed to format the disk ")
+		return fmt.Errorf("DiskPart failed to format the disk for diskNum = %s", diskNum)
+	} else {
+		log.WithFields(log.Fields{"fstype": fstype, "label": label, "volDev": *volDev,
+			"diskNum": diskNum, "out": string(out)}).Info("DiskPart script executed successfully ")
+		return nil
+	}
+}
+
+// Mount mounts the filesystem on the volDev at the given mountpoint.
+func Mount(mountpoint string, fstype string, volDev *VolumeDevSpec, isReadOnly bool) error {
+	return nil
+}
+
+// Unmount unmounts a disk from the given mount point.
+func Unmount(mountpoint string) error {
+	return nil
+}
+
+// getDiskNum returns the disk number corresponding to volDev, or an error on
+// failing to identify the disk.
+func getDiskNum(volDev *VolumeDevSpec) (string, error) {
+	script := fmt.Sprintf(scsiAddrToDiskNumScript, volDev.ControllerPciSlotNumber, volDev.Unit)
+	out, err := exec.Command(powershell, script).Output()
+	if err != nil {
+		log.WithFields(log.Fields{"volDev": *volDev,
+			"err": err}).Error("Failed to execute the disk mapping script ")
+		return "", err
+	}
+	log.WithFields(log.Fields{"volDev": *volDev,
+		"out": string(out)}).Info("Disk mapping script executed ")
+
+	diskNum := tailSegment(out, lf, 2)
+	if diskNum == diskNotFound {
+		msg := fmt.Sprintf("Could not identify disk for controller = %s, unit = %s",
+			volDev.ControllerPciSlotNumber, volDev.Unit)
+		log.Error(msg)
+		return "", errors.New(msg)
+	}
+	log.WithFields(log.Fields{"volDev": *volDev,
+		"diskNum": diskNum}).Info("Successfully located disk ")
+	return diskNum, nil
+}
+
+// tailSegment returns the nth to last segment of a string delimited with delim.
+func tailSegment(b []byte, delim string, n int) string {
+	segments := strings.Split(string(b), delim)
+	segment := segments[len(segments)-n]
+	return segment
+}
+
+// Functions needed by the photon driver, but not implemented for the Windows OS.
+
+// DeleteDevicePathWithID returns an error.
+func DeleteDevicePathWithID(id string) error {
+	return errors.New("DeleteDevicePathWithID is not supported")
+}
+
+// GetDevicePathByID returns an error.
+func GetDevicePathByID(id string) (string, error) {
+	return "", errors.New("GetDevicePathByID is not supported")
+}
+
+// MkfsByDevicePath returns an error.
+func MkfsByDevicePath(fstype string, label string, device string) error {
+	return errors.New("MkfsByDevicePath is not supported")
+}
+
+// MountByDevicePath returns an error.
+func MountByDevicePath(mountpoint string, fstype string, device string, isReadOnly bool) error {
+	return errors.New("MountByDevicePath is not supported")
+}
+
+// MountWithID returns an error.
+func MountWithID(mountpoint string, fstype string, id string, isReadOnly bool) error {
+	return errors.New("MountWithID is not supported")
+}


### PR DESCRIPTION
## Description
This PR adds a `fs` implementation for Windows OS.

* Adds `DeviceWatcher` impl and unit tests.
* Adds `fs` impl for Windows OS.
* Refactors `fs_test`.

## Build Instructions
The volume create workflow will be fully functional on merging this PR, and you could use this plugin on `Windows 2016 Server` or `Windows 10 Pro/Enterprise/Education` (anniversary release) by following these instructions.
1. Install [MSVC Build Tools 2017](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017).
2. Compile the `vmci_client.dll` by executing the following command from the `esx_service/vmci/` directory.
```
cl /D_USRDLL /D_WINDLL .\vmci_client.c -I "C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\ucrt" -I "C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\um" -I "C:\Program Files (x86)\Windows Kits\10\Include\10.0    .15063.0\shared" -I "C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\winrt" -I "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\include" /link /defaultlib:ws2_32.lib /libpath:"C:\P    rogram Files (x86)\Windows Kits\10\Lib\10.0.15063.0\um\x64" /libpath:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.15063.0\ucrt\x64" /libpath:"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.2501    7\lib\x64" /DLL /OUT:vmci_client.dll /DEF:vmci_client.def
```
3. Copy `vmci_client.dll` to the `vmdk_plugin/` directory.
4. Append `windows` at the end of `// +build linux` inside `vmdk_plugin/utils/refcount/refcnt.go`.
5. Build `main.exe` using the following command.
```
go build -v .\main.go .\main_windows.go .\constants.go .\log_formatter.go
```
6. Create a `vsphere.json` file under `C:\ProgramData\docker\plugins\` with the following contents.
```
{
    "Name": "vsphere",
    "Addr": "npipe:////./pipe/vsphere-dvs"
}
```

## Plugin Usage
1. Run `main.exe`.
2. Issue `docker volume create --driver=vsphere volumeName` from `cmd` or `powershell`.

## Output
#### PowerShell Output
```
PS C:\Users\Administrator> docker volume create --driver=vsphere testVol
testVol
```
#### Admin CLI Output
```
/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py volume ls

Volume        Datastore  VMGroup   Capacity  Used   Filesystem  Policy  Disk Format  Attached-to       Access      Attach-as               Created By        Created Date              
------------  ---------  --------  --------  -----  ----------  ------  -----------  ----------------  ----------  ----------------------  ----------------  ------------------------  
testVol       Local2     _DEFAULT  100MB     12MB   ntfs        N/A     thin         detached          read-write  independent_persistent  win2016-v5-Venil  Fri Jul  7 02:45:52 2017  
```

## Test Results
Following is the `fs` unit test output:
```
=== RUN   TestNewDeviceWatcher
--- PASS: TestNewDeviceWatcher (0.00s)
=== RUN   TestDeviceWatcherInit
time="2017-07-06T02:35:43+05:30" level=info msg="Waiting for a device change event "
time="2017-07-06T02:35:45+05:30" level=info msg="Watcher script executed " out="EventTimedOut\n"
time="2017-07-06T02:35:45+05:30" level=info msg="Successfully emitted event " event=EventTimedOut
time="2017-07-06T02:35:45+05:30" level=info msg="Initiated watcher termination "
time="2017-07-06T02:35:45+05:30" level=info msg="Waiting for a device change event "
time="2017-07-06T02:35:45+05:30" level=info msg="Awaiting watcher termination "
time="2017-07-06T02:35:47+05:30" level=info msg="Watcher script executed " out="EventTimedOut\n"
time="2017-07-06T02:35:47+05:30" level=warning msg="Couldn't emit event, continuing.. " event=EventTimedOut
time="2017-07-06T02:35:47+05:30" level=info msg="Watcher channels closed "
time="2017-07-06T02:35:47+05:30" level=info msg="Watcher termination complete "
--- PASS: TestDeviceWatcherInit (3.44s)
=== RUN   TestDeviceWatcherTerminate
time="2017-07-06T02:35:47+05:30" level=info msg="Initiated watcher termination "
time="2017-07-06T02:35:47+05:30" level=info msg="Awaiting watcher termination "
time="2017-07-06T02:35:47+05:30" level=info msg="Waiting for a device change event "
time="2017-07-06T02:35:49+05:30" level=info msg="Watcher script executed " out="EventTimedOut\n"
time="2017-07-06T02:35:49+05:30" level=warning msg="Couldn't emit event, continuing.. " event=EventTimedOut
time="2017-07-06T02:35:49+05:30" level=info msg="Watcher channels closed "
time="2017-07-06T02:35:49+05:30" level=info msg="Watcher termination complete "
--- PASS: TestDeviceWatcherTerminate (1.73s)
=== RUN   TestVerifyFSSupport
--- PASS: TestVerifyFSSupport (0.00s)
=== RUN   TestVerifyFSSupportError
--- PASS: TestVerifyFSSupportError (0.00s)
PASS
ok      github.com/vmware/docker-volume-vsphere/vmdk_plugin/utils/fs    5.533s
```

The `test-all` target passes locally with the following output (tail'd):
```
coverage: 40.7% of statements
ssh  -kTax -o StrictHostKeyChecking=no root@10.160.205.225 /tmp/docker-volume-vsphere/docker-volume-vsphere.test -test.v \
		-v DefaultTestVol \
		-H1 tcp://10.160.205.225:2375 -H2 tcp://10.160.207.83:2375
=== RUN   TestSanity
2017-07-05T13:51:38-07:00 START: Running TestSanity on  tcp://10.160.205.225:2375 (may take a while)...
2017-07-05T13:51:50-07:00 END: Running TestSanity on  tcp://10.160.205.225:2375 (may take a while)...
--- PASS: TestSanity (12.02s)
	sanity_test.go:201: Successfully connected to tcp://10.160.205.225:2375
	sanity_test.go:201: Successfully connected to tcp://10.160.207.83:2375
	sanity_test.go:219: Creating vol=DefaultTestVol on client tcp://10.160.205.225:2375.
	sanity_test.go:105: Running cmd=&[touch /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.160.205.225:2375
	sanity_test.go:105: Running cmd=&[stat /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.160.205.225:2375
=== RUN   TestConcurrency
2017-07-05T13:51:50-07:00 Running concurrent tests on tcp://10.160.205.225:2375 and tcp://10.160.207.83:2375 (may take a while)...
2017-07-05T13:51:50-07:00 START: Running create/delete multi-host concurrent test ...
2017-07-05T13:52:00-07:00 END: Running create/delete multi-host concurrent test ...
Running same docker host concurrent create/delete test on tcp://10.160.205.225:2375...
2017-07-05T13:52:06-07:00 START: Running clone concurrent test...
2017-07-05T13:52:17-07:00 END: Running clone concurrent test...
--- PASS: TestConcurrency (27.13s)
	sanity_test.go:201: Successfully connected to tcp://10.160.205.225:2375
	sanity_test.go:201: Successfully connected to tcp://10.160.207.83:2375
PASS
coverage: 37.4% of statements
```