### PR TITLE
Test util to verify detached status and poll the detached status of a volume

### DIFF
--- a/tests/e2e/restart_test.go
+++ b/tests/e2e/restart_test.go
@@ -20,21 +20,22 @@
 package e2e
 
 import (
-	. "gopkg.in/check.v1"
-	"strings"
 	"log"
+	"strings"
 
-	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
-	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
-	"github.com/vmware/docker-volume-vsphere/tests/utils/verification"
-	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
+	. "gopkg.in/check.v1"
+
 	adminconst "github.com/vmware/docker-volume-vsphere/tests/constants/admincli"
 	adminutil "github.com/vmware/docker-volume-vsphere/tests/utils/admincli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/verification"
 )
 
 type RestartTestData struct {
-	config        *inputparams.TestConfig
-	volumeName    string
+	config            *inputparams.TestConfig
+	volumeName        string
 	containerNameList []string
 }
 
@@ -51,8 +52,8 @@ func (s *RestartTestData) SetUpSuite(c *C) {
 
 	s.volumeName = inputparams.GetUniqueVolumeName("restart_test")
 	s.containerNameList = []string{inputparams.GetUniqueContainerName("restart_test"),
-				inputparams.GetUniqueContainerName("restart_test"),
-				inputparams.GetUniqueContainerName("restart_test")}
+		inputparams.GetUniqueContainerName("restart_test"),
+		inputparams.GetUniqueContainerName("restart_test")}
 
 	// Create a volume
 	out, err := dockercli.CreateVolume(s.config.DockerHosts[1], s.volumeName)
@@ -61,7 +62,7 @@ func (s *RestartTestData) SetUpSuite(c *C) {
 	// Get volume status
 	status, err := dockercli.GetVolumeStatus(s.config.DockerHosts[1], s.volumeName)
 	c.Assert(err, IsNil, Commentf("Failed to fetch status for volume %s", s.volumeName))
-	
+
 	ds2 = s.config.Datastores[0]
 	if strings.Compare(status["datastore"], s.config.Datastores[0]) == 0 {
 		ds2 = s.config.Datastores[1]
@@ -72,7 +73,7 @@ func (s *RestartTestData) SetUpSuite(c *C) {
 	c.Assert(err, IsNil, Commentf(out))
 
 	// Create a volume on the second datastore
-	out, err = dockercli.CreateVolume(s.config.DockerHosts[1], s.volumeName + "@" + ds2)
+	out, err = dockercli.CreateVolume(s.config.DockerHosts[1], s.volumeName+"@"+ds2)
 	c.Assert(err, IsNil, Commentf(out))
 
 	log.Printf("Restart tests setup complete")
@@ -128,7 +129,7 @@ func (s *RestartTestData) TestVolumeDetached(c *C) {
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 4. Verify detached status. Volume should be detached (within the timeout)
-	status = verification.VerifyDetachedStatus(s.volumeName, s.config.DockerHosts[1], s.config.EsxHost)
+	status = verification.PollDetachedStatus(s.volumeName, s.config.DockerHosts[1], s.config.EsxHost)
 	c.Assert(status, Equals, true, Commentf("Volume %s is still attached", s.volumeName))
 
 	out, err = dockercli.RemoveContainer(s.config.DockerHosts[1], s.containerNameList[0])
@@ -218,7 +219,7 @@ func (s *RestartTestData) TestRecoverMountsAfterRestart(c *C) {
 	out, err := dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName, s.containerNameList[0])
 	c.Assert(err, IsNil, Commentf(out))
 
-	// Run second container 
+	// Run second container
 	out, err = dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName, s.containerNameList[1])
 	c.Assert(err, IsNil, Commentf(out))
 
@@ -271,7 +272,7 @@ func (s *RestartTestData) TestLongVolumeName(c *C) {
 
 	misc.SleepForSec(20)
 
-	// 3. Run second container 
+	// 3. Run second container
 	out, err = dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName, s.containerNameList[1])
 	c.Assert(err, IsNil, Commentf(out))
 
@@ -280,7 +281,7 @@ func (s *RestartTestData) TestLongVolumeName(c *C) {
 	c.Assert(err, IsNil, Commentf("Failed to fetch status for volume %s", s.volumeName))
 
 	// 4. Run third container with long volume name
-	out, err = dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName + "@" + status["datastore"], s.containerNameList[2])
+	out, err = dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName+"@"+status["datastore"], s.containerNameList[2])
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 5. Stop the three containers
@@ -307,8 +308,8 @@ func (s *RestartTestData) TestDuplicateVolumeName(c *C) {
 	out, err := dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName, s.containerNameList[0])
 	c.Assert(err, IsNil, Commentf(out))
 
-	// 2. Run second container with same volume name on the other datastore 
-	out, err = dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName + "@" + ds2, s.containerNameList[1])
+	// 2. Run second container with same volume name on the other datastore
+	out, err = dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName+"@"+ds2, s.containerNameList[1])
 	c.Assert(err, IsNil, Commentf(out))
 
 	status, err := dockercli.GetVolumeStatus(s.config.DockerHosts[1], s.volumeName)
@@ -321,7 +322,7 @@ func (s *RestartTestData) TestDuplicateVolumeName(c *C) {
 	misc.SleepForSec(20)
 
 	// 4. Run third container with same volume as the first container
-	out, err = dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName + "@" + status["datastore"], s.containerNameList[2])
+	out, err = dockercli.AttachVolumeWithRestart(s.config.DockerHosts[1], s.volumeName+"@"+status["datastore"], s.containerNameList[2])
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 5. Stop the three containers
@@ -329,7 +330,7 @@ func (s *RestartTestData) TestDuplicateVolumeName(c *C) {
 	c.Assert(err, IsNil, Commentf(out))
 
 	// Cleanup volume on the second datastore
-	out, err = dockercli.DeleteVolume(s.config.DockerHosts[1], s.volumeName + "@" + ds2)
+	out, err = dockercli.DeleteVolume(s.config.DockerHosts[1], s.volumeName+"@"+ds2)
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 6. Run container on other host to verify the volume is detached after stopping the containers

--- a/tests/e2e/swarm_test.go
+++ b/tests/e2e/swarm_test.go
@@ -171,7 +171,7 @@ func (s *SwarmTestSuite) TestFailoverAcrossSwarmNodes(c *C) {
 	out, err = dockercli.ListService(s.master, s.serviceName)
 	c.Assert(err, NotNil, Commentf("Expected error does not happen"))
 
-	status = verification.VerifyDetachedStatus(s.volumeName, s.master, s.esxName)
+	status = verification.PollDetachedStatus(s.volumeName, s.master, s.esxName)
 	c.Assert(status, Equals, true, Commentf("Volume %s is still attached", s.volumeName))
 
 	misc.LogTestEnd(c.TestName())
@@ -248,7 +248,7 @@ func (s *SwarmTestSuite) TestFailoverAcrossReplicas(c *C) {
 	out, err = dockercli.ListService(s.master, s.serviceName)
 	c.Assert(err, NotNil, Commentf("Expected error does not happen"))
 
-	status = verification.VerifyDetachedStatus(s.volumeName, s.master, s.esxName)
+	status = verification.PollDetachedStatus(s.volumeName, s.master, s.esxName)
 	c.Assert(status, Equals, true, Commentf("Volume %s is still attached", s.volumeName))
 
 	misc.LogTestEnd(c.TestName())

--- a/tests/e2e/vmlistener_test.go
+++ b/tests/e2e/vmlistener_test.go
@@ -160,7 +160,7 @@ func (s *VMListenerTestParams) TestBasicFailover(c *C) {
 	c.Assert(verification.IsVDVSIsRunning(s.vm1), Equals, true, Commentf("vDVS is not running on [%s]", s.vm1Name))
 
 	// Status should be detached
-	status = verification.VerifyDetachedStatus(s.volumeName, s.vm1, s.esx)
+	status = verification.PollDetachedStatus(s.volumeName, s.vm1, s.esx)
 	c.Assert(status, Equals, true, Commentf("Volume %s is still attached", s.volumeName))
 
 	// Remove the container if it still exists
@@ -325,7 +325,7 @@ func (s *VMListenerTestParams) TestFailoverAcrossVmOnVsan(c *C) {
 	c.Assert(verification.IsVDVSIsRunning(s.vm1), Equals, true, Commentf("vDVS is not running on [%s]", s.vm1Name))
 
 	// Status should be still detached
-	status = verification.VerifyDetachedStatus(s.volumeName, s.vm1, s.esx)
+	status = verification.PollDetachedStatus(s.volumeName, s.vm1, s.esx)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not detached", s.volumeName))
 
 	// Remove the container if it still exists

--- a/tests/utils/verification/volumeproperties.go
+++ b/tests/utils/verification/volumeproperties.go
@@ -143,6 +143,8 @@ func getVolumeStatusHost(name, hostName string) string {
 
 // VerifyDetachedStatus - check if the status gets detached within the timeout.
 // The name of the volume MUST be a shorter name without @datastore suffix.
+// Use this util in test scenarios where the test expects instant change of status to detached.
+// eg: start a container ->  stop a container -> verify detached status
 func VerifyDetachedStatus(name, hostName, esxName string) bool {
 	log.Printf("Confirming detached status for volume [%s]\n", name)
 
@@ -164,6 +166,8 @@ func VerifyDetachedStatus(name, hostName, esxName string) bool {
 
 // PollDetachedStatus Poll for detached status of a volume after 2 seconds till maxAttemps
 // returns true if status is detached within retrials, else returns false
+// Use this util in test scenarios where status update takes time.
+// eg: restarts, failovers where some time is spent for plugin to stabilize and then perform mount/unmounts
 func PollDetachedStatus(name, hostName, esxName string) bool {
 	log.Printf("Polling detached status for volume [%s]\n", name)
 

--- a/tests/utils/verification/volumeproperties.go
+++ b/tests/utils/verification/volumeproperties.go
@@ -146,24 +146,34 @@ func getVolumeStatusHost(name, hostName string) string {
 func VerifyDetachedStatus(name, hostName, esxName string) bool {
 	log.Printf("Confirming detached status for volume [%s]\n", name)
 
-	// Use full name to check volume status on docker host
 	fullName := GetFullVolumeName(hostName, name)
+	// Use full name to check volume status on docker host
+	status := getVolumeStatusHost(fullName, hostName)
+	if status != properties.DetachedStatus {
+		return false
+	}
+	// Use short name to check volume status on ESX
+	// this api returnes "detached" in when volume is detached
+	status = GetVMAttachedToVolUsingAdminCli(name, esxName)
+	if status != properties.DetachedStatus {
+		return false
+	}
+
+	return true
+}
+
+// PollDetachedStatus Poll for detached status of a volume after 2 seconds till maxAttemps
+// returns true if status is detached within retrials, else returns false
+func PollDetachedStatus(name, hostName, esxName string) bool {
+	log.Printf("Polling detached status for volume [%s]\n", name)
 
 	//TODO: Need to implement generic polling logic for better reuse
 	const maxAttempt = 60
 	for attempt := 0; attempt < maxAttempt; attempt++ {
-		misc.SleepForSec(2)
-		// Use full name to check volume status on docker host
-		status := getVolumeStatusHost(fullName, hostName)
-		if status != properties.DetachedStatus {
-			continue
-		}
-		// Use short name to check volume status on ESX
-		// this api returnes "detached" in when volume is detached
-		status = GetVMAttachedToVolUsingAdminCli(name, esxName)
-		if status == properties.DetachedStatus {
+		if VerifyDetachedStatus(name, hostName, esxName) {
 			return true
 		}
+		misc.SleepForSec(2)
 	}
 	log.Printf("Timed out to poll status\n")
 	return false


### PR DESCRIPTION
This PR does two things.
1. Removes unnecessary wait in VerifyDetachedStatus. It instantly checks if the status is "detached". This is used in most of the places except destructive test scenarios i.e. restarts and failovers.

2. PollDetachedStatus retries to make check if volume status is detached. This is used in scenarios of restarts and failovers where plugin takes a bit of time to stabilize.

Testing:
test-e2e passes locally.
```
2017/07/07 00:10:51 END: VsanTestSuite.TestValidPolicy
2017/07/07 00:10:51 Destroying volume [vsanVol_volume_400787@vsanDatastore]
2017/07/07 00:10:52 Removing policy [validPolicy] on esx [10.192.248.54]
--- PASS: Test (926.32s)
PASS
OK: 30 passed
ok  	github.com/vmware/docker-volume-vsphere/tests/e2e	926.330s
```

Fixes #1528