### PR TITLE
Replaces diskpart (format) script with a PS script

### DIFF
--- a/vmdk_plugin/utils/fs/constants.go
+++ b/vmdk_plugin/utils/fs/constants.go
@@ -17,7 +17,6 @@
 package fs
 
 const (
-	cr   = "\r"   // carriage return
-	lf   = "\n"   // line feed
-	crlf = "\r\n" // carriage return line feed
+	cr = "\r" // carriage return
+	lf = "\n" // line feed
 )

--- a/vmdk_plugin/utils/fs/fs_windows.go
+++ b/vmdk_plugin/utils/fs/fs_windows.go
@@ -19,7 +19,6 @@ package fs
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os/exec"
 	"strings"
 	"time"
@@ -35,8 +34,6 @@ const (
 	ntfs                 = "ntfs"
 	powershell           = "powershell"
 	diskNotFound         = "DiskNotFound"
-	diskpart             = "diskpart"
-	diskpartSuccessMsg   = "DiskPart successfully formatted the volume."
 
 	// Using a PowerShell script here due to lack of a functional Go WMI library.
 	// PowerShell script to identify the disk number given a scsi controller
@@ -67,17 +64,14 @@ const (
 		Write-Host "DiskNotFound"
 	`
 
-	// DiskPart script to format a disk with a filesystem.
+	// PowerShell script to format a disk with a filesystem.
+	// Note: -Confirm:$false suppresses the confirmation prompt.
 	formatDiskScript = `
-		select disk %s
-		clean
-		online disk
-		attribute disk clear readonly
-		create partition primary
-		select partition 1
-		active
-		format fs=%s label="%s" quick
-		exit
+		Set-Disk -Number %s -IsOffline $false
+		Set-Disk -Number %s -IsReadOnly $false
+		Initialize-Disk -Number %s -PartitionStyle MBR -PassThru |
+		New-Partition -UseMaximumSize |
+		Format-Volume -FileSystem %s -NewFileSystemLabel "%s" -Confirm:$false
 	`
 )
 
@@ -151,24 +145,15 @@ func Mkfs(fstype string, label string, volDev *VolumeDevSpec) error {
 		return err
 	}
 
-	// The diskpart utility consumes the script via stdin and formats a disk.
-	cmd := exec.Command(diskpart)
-	stdin, _ := cmd.StdinPipe()
-	defer stdin.Close()
-	io.WriteString(stdin, fmt.Sprintf(formatDiskScript, diskNum, ntfs, label))
-
-	out, err := cmd.CombinedOutput()
+	script := fmt.Sprintf(formatDiskScript, diskNum, diskNum, diskNum, fstype, label)
+	out, err := exec.Command(powershell, script).Output()
 	if err != nil {
 		log.WithFields(log.Fields{"fstype": fstype, "label": label, "volDev": *volDev,
-			"diskNum": diskNum, "err": err}).Error("DiskPart script failed to execute ")
+			"diskNum": diskNum, "err": err}).Error("Format disk script failed to execute ")
 		return err
-	} else if tailSegment(out, crlf, 5) != diskpartSuccessMsg {
-		log.WithFields(log.Fields{"fstype": fstype, "label": label, "volDev": *volDev,
-			"diskNum": diskNum, "out": string(out)}).Error("DiskPart failed to format the disk ")
-		return fmt.Errorf("DiskPart failed to format the disk for diskNum = %s", diskNum)
 	} else {
 		log.WithFields(log.Fields{"fstype": fstype, "label": label, "volDev": *volDev,
-			"diskNum": diskNum, "out": string(out)}).Info("DiskPart script executed successfully ")
+			"diskNum": diskNum, "out": string(out)}).Info("Format disk script executed successfully ")
 		return nil
 	}
 }

--- a/vmdk_plugin/utils/fs/fs_windows.go
+++ b/vmdk_plugin/utils/fs/fs_windows.go
@@ -149,7 +149,7 @@ func Mkfs(fstype string, label string, volDev *VolumeDevSpec) error {
 	out, err := exec.Command(powershell, script).Output()
 	if err != nil {
 		log.WithFields(log.Fields{"fstype": fstype, "label": label, "volDev": *volDev,
-			"diskNum": diskNum, "err": err}).Error("Format disk script failed to execute ")
+			"diskNum": diskNum, "err": err}).Error("Format disk script failed ")
 		return err
 	} else {
 		log.WithFields(log.Fields{"fstype": fstype, "label": label, "volDev": *volDev,


### PR DESCRIPTION
## Description
This PR replaces the `diskpart` disk format script with a `PowerShell` script for better efficiency. 

Fixes #1559.

## Test Results
The `test-all` target passes locally. Here's the tail'd output:
```
=== RUN   TestSanity
2017-07-07T13:14:45-07:00 START: Running TestSanity on  tcp://10.160.205.225:2375 (may take a while)...
2017-07-07T13:14:56-07:00 END: Running TestSanity on  tcp://10.160.205.225:2375 (may take a while)...
--- PASS: TestSanity (10.76s)
	sanity_test.go:201: Successfully connected to tcp://10.160.205.225:2375
	sanity_test.go:201: Successfully connected to tcp://10.160.207.83:2375
	sanity_test.go:219: Creating vol=DefaultTestVol on client tcp://10.160.205.225:2375.
	sanity_test.go:105: Running cmd=&[touch /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.160.205.225:2375
	sanity_test.go:105: Running cmd=&[stat /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.160.205.225:2375
=== RUN   TestConcurrency
2017-07-07T13:14:56-07:00 Running concurrent tests on tcp://10.160.205.225:2375 and tcp://10.160.207.83:2375 (may take a while)...
2017-07-07T13:14:56-07:00 START: Running create/delete multi-host concurrent test ...
2017-07-07T13:15:18-07:00 END: Running create/delete multi-host concurrent test ...
Running same docker host concurrent create/delete test on tcp://10.160.205.225:2375...
2017-07-07T13:15:29-07:00 START: Running clone concurrent test...
2017-07-07T13:15:57-07:00 END: Running clone concurrent test...
--- PASS: TestConcurrency (61.78s)
	sanity_test.go:201: Successfully connected to tcp://10.160.205.225:2375
	sanity_test.go:201: Successfully connected to tcp://10.160.207.83:2375
PASS
coverage: 37.4% of statements
```