### PR TITLE
Refactoring utility functions

### DIFF
--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -89,7 +89,8 @@ VMDKOPS_TEST_MODULE := vmdkops
 VMDKOPS_MODULE_SRC = $(VMDKOPS_MODULE)/*.go $(VMCI_SRC)
 
 # All sources. We rebuild if anything changes here
-SRC = vmdk_plugin/main.go vmdk_plugin/log_formatter.go utils/refcount/refcnt.go \
+SRC = vmdk_plugin/main.go utils/log_formatter/log_formatter.go \
+	utils/refcount/refcnt.go utils/plugin_server/plugin_server.go \
 	utils/fs/fs.go utils/config/config.go utils/plugin_utils/plugin_utils.go\
 	drivers/photon/photon_driver.go drivers/vmdk/vmdk_driver.go
 

--- a/client_plugin/utils/config/config_linux.go
+++ b/client_plugin/utils/config/config_linux.go
@@ -21,4 +21,7 @@ const (
 	DefaultConfigPath = "/etc/docker-volume-vsphere.conf"
 	// DefaultLogPath is the default location of log (trace) file
 	DefaultLogPath = "/var/log/docker-volume-vsphere.log"
+
+	// MountRoot is the path where VMDK and photon volumes are mounted
+	MountRoot = "/mnt/vmdk"
 )

--- a/client_plugin/utils/config/config_windows.go
+++ b/client_plugin/utils/config/config_windows.go
@@ -24,4 +24,7 @@ var (
 	DefaultConfigPath = filepath.Join(os.Getenv("PROGRAMDATA"), "docker-volume-vsphere", "docker-volume-vsphere.conf")
 	// DefaultLogPath is the default location of the log (trace) file.
 	DefaultLogPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "docker-volume-vsphere", "logs", "docker-volume-vsphere.log")
+
+	// VMDK volumes are mounted here
+	MountRoot = filepath.Join(os.Getenv("LOCALAPPDATA"), "docker-volume-vsphere", "mounts")
 )

--- a/client_plugin/utils/log_formatter/log_formatter.go
+++ b/client_plugin/utils/log_formatter/log_formatter.go
@@ -17,7 +17,7 @@
 // * storage team specifications. The `appendKeyValue` and `needsQuoting` functions are copied
 // * from the implementation of the TextFormatter in Logrus.
 
-package main
+package log_formatter
 
 import (
 	"bytes"

--- a/client_plugin/utils/plugin_server/plugin_server.go
+++ b/client_plugin/utils/plugin_server/plugin_server.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package plugin_server
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/go-plugins-helpers/volume"
+	"os"
+	"os/signal"
+	"syscall"
+)
 
 const (
-	// vDVS drivers.
-	photonDriver  = "photon"
-	vmdkDriver    = "vmdk" // deprecated
-	vsphereDriver = "vsphere"
-
-	// Default ESX service port.
-	defaultPort = 1019
-
-	// Docker driver types.
-	volumeDriver = "VolumeDriver"
-
 	// Docker plugin handshake endpoint.
 	// Also see https://docs.docker.com/engine/extend/plugin_api/#handshake-api
 	pluginActivatePath = "/Plugin.Activate"
@@ -34,3 +31,27 @@ const (
 	// Also see https://docs.docker.com/engine/extend/plugins_volume/#volume-plugin-protocol
 	volumeDriverCreatePath = "/VolumeDriver.Create"
 )
+
+// PluginServer responds to HTTP requests from Docker.
+type PluginServer interface {
+	// Init initializes the server.
+	Init()
+	// Destroy destroys the server.
+	Destroy()
+}
+
+// StartServer starts a plugin server based on runtime OS
+func StartServer(driverName string, driver *volume.Driver) {
+	server := NewPluginServer(driverName, driver)
+
+	sigChannel := make(chan os.Signal, 1)
+	signal.Notify(sigChannel, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigChannel
+		log.WithFields(log.Fields{"signal": sig}).Warning("Received signal ")
+		server.Destroy()
+		os.Exit(0)
+	}()
+
+	server.Init()
+}

--- a/client_plugin/utils/plugin_server/plugin_server_linux.go
+++ b/client_plugin/utils/plugin_server/plugin_server_linux.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package plugin_server
 
 // A VMDK Docker Data Volume plugin implementation for linux that
 // relies on the docker/go-plugins-helpers/volume API.
@@ -25,10 +25,8 @@ import (
 	"github.com/docker/go-plugins-helpers/volume"
 )
 
-const (
-	mountRoot     = "/mnt/vmdk"           // VMDK and photon volumes are mounted here
-	pluginSockDir = "/run/docker/plugins" // Unix sock for the plugin is maintained here
-)
+// Unix sock for the plugin is maintained here
+const pluginSockDir = "/run/docker/plugins"
 
 // SockPluginServer serves HTTP requests from Docker over unix sock.
 type SockPluginServer struct {

--- a/client_plugin/utils/plugin_server/plugin_server_windows.go
+++ b/client_plugin/utils/plugin_server/plugin_server_windows.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package plugin_server
 
 // A VMDK Docker Data Volume plugin implementation for Windows OS.
 
@@ -31,10 +31,9 @@ import (
 
 const (
 	npipeAddr = `\\.\pipe\vsphere-dvs` // Plugin's npipe address
-)
 
-var (
-	mountRoot = filepath.Join(os.Getenv("LOCALAPPDATA"), "docker-volume-vsphere", "mounts") // VMDK volumes are mounted here
+	// Docker driver types.
+	volumeDriver = "VolumeDriver"
 )
 
 // NpipePluginServer serves HTTP requests from Docker over windows npipe.

--- a/client_plugin/utils/plugin_server/plugin_server_windows_test.go
+++ b/client_plugin/utils/plugin_server/plugin_server_windows_test.go
@@ -14,7 +14,7 @@
 
 // Basic tests for the NpipePluginServer implementation.
 
-package main
+package plugin_server
 
 import (
 	"bufio"

--- a/client_plugin/vmdk_plugin/sanity_test.go
+++ b/client_plugin/vmdk_plugin/sanity_test.go
@@ -75,7 +75,14 @@ func init() {
 	flag.IntVar(&parallelVolumes, "parallel_volumes", 3, "Volumes per docker daemon for create/delete concurrent tests")
 	flag.IntVar(&parallelClones, "parallel_clones", 2, "Volumes per docker daemon for clone concurrent tests")
 	flag.Parse()
-	usingConfigFileDefaults := logInit(logLevel, logFile, configFile)
+
+	logInfo := &config.LogInfo{
+		LogLevel:       logLevel,
+		LogFile:        logFile,
+		DefaultLogFile: config.DefaultLogPath,
+		ConfigFile:     configFile,
+	}
+	usingConfigFileDefaults := config.LogInit(logInfo)
 
 	defaultHeaders = map[string]string{"User-Agent": "engine-api-client-1.0"}
 
@@ -86,7 +93,6 @@ func init() {
 		"conf_file":                *configFile,
 		"using_conf_file_defaults": usingConfigFileDefaults,
 	}).Info("VMDK plugin tests started ")
-	log.SetFormatter(new(VmwareFormatter))
 }
 
 // returns in-container mount point for a volume


### PR DESCRIPTION
Create and move new utility functions into utils folder:
main/log_formatter.go -> utils/log_formatter/log_formatter.go
main/main.go PluginServer main -> utils/plugin_server/plugin_server.go StartServer
main/main.go logInit  main -> utils/config/config.go LogInit InitConfig

The new utility functions will be shared between different plugins.