### PR TITLE
Automation test for upgrade. [SKIP CI]

### DIFF
--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -291,8 +291,8 @@ deploy-esx: clean-esx
 	$(DEPLOY_ESX_SH) "$(ESX)" "$(VIB_BIN)"
 
 test-upgrade:
-	$(BUILD) upgrade-test
-upgrade-test:
+	$(BUILD) run-upgrade-test
+run-upgrade-test:
 	ESX='$(ESX)' VM1='$(VM1)' UPGRADE_FROM_VER='$(UPGRADE_FROM_VER)' UPGRADE_TO_VER='$(UPGRADE_TO_VER)' $(UPGRADE_TEST)
 #	$(UPGRADE_TEST)
 
@@ -365,7 +365,7 @@ coverage:
 test-e2e:
 	$(log_target)
 	$(BUILD) test-e2e-runalways
-#	$(BUILD) test-e2e-runonce
+	$(BUILD) test-e2e-runonce
 
 #
 # E2E test target to control test run on CI.

--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -80,6 +80,12 @@ PLUGIN := github.com/$(GOPATH_ORG)/$(GOPATH_PLUGNAME)
 # test location, picking up E2E tests
 E2E_Tests := github.com/$(GOPATH_ORG)/$(PLUGNAME)/tests/e2e
 
+# Pre upgrade test location
+PRE_Upgrade_Tests := github.com/$(GOPATH_ORG)/$(PLUGNAME)/tests/e2e/pre_upgrade_test.go
+
+# Post upgrade test location
+POST_Upgrade_Tests := github.com/$(GOPATH_ORG)/$(PLUGNAME)/tests/e2e/post_upgrade_test.go
+
 GO := GO15VENDOREXPERIMENT=1 go
 FPM := fpm
 
@@ -271,6 +277,7 @@ DEPLOY_VM_SH  := $(DEPLOY_TOOLS) deployvm
 DEPLOY_VM_TEST_SH  := $(DEPLOY_TOOLS) deployvmtest
 DEPLOY_VM_PLUGIN_SH := $(DEPLOY_TOOLS) deployplugin
 DEPLOY_ESX_SH := $(DEPLOY_TOOLS) deployesx
+DEPLOY_ESX_FOR_UPGRADE := $(DEPLOY_TOOLS) deployesxForUpgrade
 CLEANVM_SH    := $(DEPLOY_TOOLS) cleanvm
 CLEANESX_SH   := $(DEPLOY_TOOLS) cleanesx
 
@@ -281,6 +288,29 @@ CLEANESX_SH   := $(DEPLOY_TOOLS) cleanesx
 .PHONY: deploy-esx deploy-vm deploy-vm-test deploy deploy-all deploy
 deploy-esx: clean-esx
 	$(DEPLOY_ESX_SH) "$(ESX)" "$(VIB_BIN)"
+
+test-upgrade:
+	$(BUILD) upgrade-test
+upgrade-test:
+	@echo "Upgrade test: from ver $(UPGRADE_FROM_VER) to ver $(UPGRADE_TO_VER)"
+	@echo "Upgrade test step 1: deploy on $(ESX) with $(FROM_VIB_URL)"
+	$(DEPLOY_ESX_FOR_UPGRADE)  "$(ESX)" "$(FROM_VIB_URL)"
+	@echo "Upgrade test step 2.1: remove plugin $(MANAGED_PLUGIN_NAME) on $(VM1)"
+	$(CLEANVM_SH) "$(VM1)" "$(MANAGED_PLUGIN_NAME)"
+	@echo "Upgrade test step 2.2: deploy plugin vmware/docker-volume-vsphere:$(UPGRADE_FROM_VER) on $(VM1)"
+	$(DEPLOY_VM_SH) "$(VM1)" vmware/docker-volume-vsphere:$(UPGRADE_FROM_VER)
+	$(SSH) $(VM1) "systemctl restart docker || service docker restart"
+	@echo "Upgrade test step 3: run pre-upgrade test"
+	$(GO) test -v -timeout 30m -tags runpreupgrade $(E2E_Tests)
+	@echo "Upgrade test step 4: deploy on $(ESX) with $(TO_VIB_URL)"
+	$(DEPLOY_ESX_FOR_UPGRADE)  "$(ESX)" "$(TO_VIB_URL)"
+	@echo "Upgrade test step 5.1: remove plugin $(MANAGED_PLUGIN_NAME) on $(VM1)"
+	$(CLEANVM_SH) "$(VM1)" "$(MANAGED_PLUGIN_NAME)"
+	@echo "Upgrade test step 5.2: deploy plugin vmware/docker-volume-vsphere:$(UPGRADE_TO_VER) on $(VM1)"
+	$(DEPLOY_VM_SH) "$(VM1)" vmware/docker-volume-vsphere:$(UPGRADE_TO_VER)
+	$(SSH) $(VM1) "systemctl restart docker || service docker restart"
+	@echo "Upgrade test step 6: run pre-upgrade test"
+	$(GO) test -v -timeout 30m -tags runpostupgrade $(E2E_Tests)
 
 VMS= $(VM1) $(VM2) $(WORKER2) $(CI_NODE4)
 
@@ -351,7 +381,7 @@ coverage:
 test-e2e:
 	$(log_target)
 	$(BUILD) test-e2e-runalways
-	$(BUILD) test-e2e-runonce
+#	$(BUILD) test-e2e-runonce
 
 #
 # E2E test target to control test run on CI.

--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -284,6 +284,7 @@ CLEANESX_SH   := $(DEPLOY_TOOLS) cleanesx
 deploy-esx: clean-esx
 	$(DEPLOY_ESX_SH) "$(ESX)" "$(VIB_BIN)"
 
+# This target is added to run upgrade test
 test-upgrade:
 	$(BUILD) run-upgrade-test
 run-upgrade-test:

--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -81,12 +81,6 @@ PLUGIN := github.com/$(GOPATH_ORG)/$(GOPATH_PLUGNAME)
 # test location, picking up E2E tests
 E2E_Tests := github.com/$(GOPATH_ORG)/$(PLUGNAME)/tests/e2e
 
-# Pre upgrade test location
-PRE_Upgrade_Tests := github.com/$(GOPATH_ORG)/$(PLUGNAME)/tests/e2e/pre_upgrade_test.go
-
-# Post upgrade test location
-POST_Upgrade_Tests := github.com/$(GOPATH_ORG)/$(PLUGNAME)/tests/e2e/post_upgrade_test.go
-
 GO := GO15VENDOREXPERIMENT=1 go
 FPM := fpm
 
@@ -294,7 +288,6 @@ test-upgrade:
 	$(BUILD) run-upgrade-test
 run-upgrade-test:
 	ESX='$(ESX)' VM1='$(VM1)' UPGRADE_FROM_VER='$(UPGRADE_FROM_VER)' UPGRADE_TO_VER='$(UPGRADE_TO_VER)' $(UPGRADE_TEST)
-#	$(UPGRADE_TEST)
 
 VMS= $(VM1) $(VM2) $(WORKER2) $(CI_NODE4)
 

--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -54,6 +54,7 @@ AFTER_REMOVE   := $(SCRIPTS)/install/after-remove.sh
 CHECK	    := $(SCRIPTS)/check.sh
 BUILD       := $(SCRIPTS)/build.sh
 DEPLOY_TOOLS := $(SCRIPTS)/deploy-tools.sh
+UPGRADE_TEST := $(SCRIPTS)/upgrade_test.sh
 SYSTEMD_UNIT := $(SCRIPTS)/install/$(PLUGNAME).service
 UPSTART_CONF := $(SCRIPTS)/install/$(PLUGNAME).conf
 PACKAGE      := package
@@ -292,25 +293,8 @@ deploy-esx: clean-esx
 test-upgrade:
 	$(BUILD) upgrade-test
 upgrade-test:
-	@echo "Upgrade test: from ver $(UPGRADE_FROM_VER) to ver $(UPGRADE_TO_VER)"
-	@echo "Upgrade test step 1: deploy on $(ESX) with $(FROM_VIB_URL)"
-	$(DEPLOY_ESX_FOR_UPGRADE)  "$(ESX)" "$(FROM_VIB_URL)"
-	@echo "Upgrade test step 2.1: remove plugin $(MANAGED_PLUGIN_NAME) on $(VM1)"
-	$(CLEANVM_SH) "$(VM1)" "$(MANAGED_PLUGIN_NAME)"
-	@echo "Upgrade test step 2.2: deploy plugin vmware/docker-volume-vsphere:$(UPGRADE_FROM_VER) on $(VM1)"
-	$(DEPLOY_VM_SH) "$(VM1)" vmware/docker-volume-vsphere:$(UPGRADE_FROM_VER)
-	$(SSH) $(VM1) "systemctl restart docker || service docker restart"
-	@echo "Upgrade test step 3: run pre-upgrade test"
-	$(GO) test -v -timeout 30m -tags runpreupgrade $(E2E_Tests)
-	@echo "Upgrade test step 4: deploy on $(ESX) with $(TO_VIB_URL)"
-	$(DEPLOY_ESX_FOR_UPGRADE)  "$(ESX)" "$(TO_VIB_URL)"
-	@echo "Upgrade test step 5.1: remove plugin $(MANAGED_PLUGIN_NAME) on $(VM1)"
-	$(CLEANVM_SH) "$(VM1)" "$(MANAGED_PLUGIN_NAME)"
-	@echo "Upgrade test step 5.2: deploy plugin vmware/docker-volume-vsphere:$(UPGRADE_TO_VER) on $(VM1)"
-	$(DEPLOY_VM_SH) "$(VM1)" vmware/docker-volume-vsphere:$(UPGRADE_TO_VER)
-	$(SSH) $(VM1) "systemctl restart docker || service docker restart"
-	@echo "Upgrade test step 6: run pre-upgrade test"
-	$(GO) test -v -timeout 30m -tags runpostupgrade $(E2E_Tests)
+	ESX='$(ESX)' VM1='$(VM1)' UPGRADE_FROM_VER='$(UPGRADE_FROM_VER)' UPGRADE_TO_VER='$(UPGRADE_TO_VER)' $(UPGRADE_TEST)
+#	$(UPGRADE_TEST)
 
 VMS= $(VM1) $(VM2) $(WORKER2) $(CI_NODE4)
 

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -147,6 +147,10 @@ else
     -e "WORKER1=$WORKER1" \
     -e "WORKER2=$WORKER2" \
     -e "SSH_KEY_OPT=$SSH_KEY_OPT" \
+    -e "UPGRADE_FROM_VER=$UPGRADE_FROM_VER" \
+    -e "UPGRADE_TO_VER=$UPGRADE_TO_VER" \
+    -e "FROM_VIB_URL=$FROM_VIB_URL" \
+    -e "TO_VIB_URL=$TO_VIB_URL" \
     -v $docker_socket:$docker_socket  \
     -v $ssh_key_path:$ssh_key_opt_container:ro \
     -v $PWD/..:$dir -w $dir $plug_container $MAKE $1

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -149,8 +149,6 @@ else
     -e "SSH_KEY_OPT=$SSH_KEY_OPT" \
     -e "UPGRADE_FROM_VER=$UPGRADE_FROM_VER" \
     -e "UPGRADE_TO_VER=$UPGRADE_TO_VER" \
-    -e "FROM_VIB_URL=$FROM_VIB_URL" \
-    -e "TO_VIB_URL=$TO_VIB_URL" \
     -v $docker_socket:$docker_socket  \
     -v $ssh_key_path:$ssh_key_opt_container:ro \
     -v $PWD/..:$dir -w $dir $plug_container $MAKE $1

--- a/misc/scripts/deploy-tools.sh
+++ b/misc/scripts/deploy-tools.sh
@@ -185,7 +185,7 @@ function deployESXInstallForUpgrade {
     fi
 }
 
-function deployesxForUpgrade {
+function deployesxforupgrade {
         TARGET=root@$ESX
         log "Deploying to ESX $TARGET"
         deployESXInstallForUpgrade
@@ -351,13 +351,13 @@ deployesx)
         fi
         deployesx
         ;;
-deployesxForUpgrade)
+deployesxforupgrade)
         VIB_URL="$2"
         if [ -z "$VIB_URL" ]
         then
             usage "Missing params: URL to vib file" ;
         fi
-        deployesxForUpgrade
+        deployesxforupgrade
         ;;
 cleanesx)
         cleanesx

--- a/misc/scripts/deploy-tools.sh
+++ b/misc/scripts/deploy-tools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 # Copyright 2016 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -177,8 +177,7 @@ function deployESXPost {
 }
 
 function deployESXInstallForUpgrade {
-    counter = 5
-    wait_for "$SSH $TARGET $VIB_INSTALL -v $VIB_URL" $counter
+    $SSH $TARGET $VIB_INSTALL -v $VIB_URL
     if [ $? -ne 0 ]
     then
         log "deployESXInstall: Installation hit an error on $TARGET"
@@ -189,7 +188,6 @@ function deployESXInstallForUpgrade {
 function deployesxForUpgrade {
         TARGET=root@$ESX
         log "Deploying to ESX $TARGET"
-        $SSH $TARGET  rm -f /etc/vmware/vmdkops/log_config.json
         deployESXInstallForUpgrade
         deployESXPost
 }

--- a/misc/scripts/deploy-tools.sh
+++ b/misc/scripts/deploy-tools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 # Copyright 2016 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/misc/scripts/deploy-tools.sh
+++ b/misc/scripts/deploy-tools.sh
@@ -176,6 +176,24 @@ function deployESXPost {
     fi
 }
 
+function deployESXInstallForUpgrade {
+    counter = 5
+    wait_for "$SSH $TARGET $VIB_INSTALL -v $VIB_URL" $counter
+    if [ $? -ne 0 ]
+    then
+        log "deployESXInstall: Installation hit an error on $TARGET"
+        exit 2
+    fi
+}
+
+function deployesxForUpgrade {
+        TARGET=root@$ESX
+        log "Deploying to ESX $TARGET"
+        $SSH $TARGET  rm -f /etc/vmware/vmdkops/log_config.json
+        deployESXInstallForUpgrade
+        deployESXPost
+}
+
 # cleanesx
 #
 # Does vib and tmp files cleanup on ESX
@@ -334,6 +352,14 @@ deployesx)
             usage "Missing params: folder hosting vib-name" ;
         fi
         deployesx
+        ;;
+deployesxForUpgrade)
+        VIB_URL="$2"
+        if [ -z "$VIB_URL" ]
+        then
+            usage "Missing params: URL to vib file" ;
+        fi
+        deployesxForUpgrade
         ;;
 cleanesx)
         cleanesx

--- a/misc/scripts/upgrade_test.sh
+++ b/misc/scripts/upgrade_test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash -x
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+    MANAGED_PLUGIN_NAME="vsphere:latest"
+    E2E_Tests="github.com/vmware/docker-volume-vsphere/tests/e2e"
+    GO="go"
+    SSH="ssh -i /root/.ssh/id_rsa -kTax -o StrictHostKeyChecking=no"
+
+    get_vib_url() {
+        echo "Get version $1"
+        if [ $1 == "0.14" ]
+        then
+            VIB_URL="https://bintray.com/vmware/vDVS/download_file?file_path=VMWare_bootbank_esx-vmdkops-service_0.14.0577889-0.0.1.vib"
+        elif [ $1 == "0.15" ]
+        then
+            VIB_URL="https://bintray.com/vmware/vDVS/download_file?file_path=VMWare_bootbank_esx-vmdkops-service_0.15.b93c186-0.0.1.vib"
+        fi
+    }
+
+    VIB_URL=""
+    get_vib_url $UPGRADE_FROM_VER
+    FROM_VIB_URL=$VIB_URL
+    echo "FROM_VIB_URL=$FROM_VIB_URL"
+
+    get_vib_url $UPGRADE_TO_VER
+    FROM_VIB_URL=$VIB_URL
+    echo "TO_VIB_URL=$TO_VIB_URL"
+
+    echo "Upgrade test: from ver $UPGRADE_FROM_VER to ver $UPGRADE_TO_VER"
+
+	echo "Upgrade test step 1: deploy on $ESX with $FROM_VIB_URL"
+	../misc/scripts/deploy-tools.sh deployesxForUpgrade $ESX $FROM_VIB_URL
+
+	echo "Upgrade test step 2.1: remove plugin $MANAGED_PLUGIN_NAME on $VM1"
+	../misc/scripts/deploy-tools.sh cleanvm $VM1 $MANAGED_PLUGIN_NAME
+
+	echo "Upgrade test step 2.2: deploy plugin vmware/docker-volume-vsphere:$UPGRADE_FROM_VER on $VM1"
+	../misc/scripts/deploy-tools.sh deployvm $VM1 vmware/docker-volume-vsphere:$UPGRADE_FROM_VER
+	$SSH $VM1 "systemctl restart docker || service docker restart"
+
+	echo "Upgrade test step 3: run pre-upgrade test"
+	$GO test -v -timeout 30m -tags runpreupgrade $E2E_Tests
+
+	echo "Upgrade test step 4: deploy on $ESX with $TO_VIB_URL"
+	../misc/scripts/deploy-tools.sh deployesxForUpgrade  $ESX $TO_VIB_URL
+
+	echo "Upgrade test step 5.1: remove plugin $MANAGED_PLUGIN_NAME on $VM1"
+	../misc/scripts/deploy-tools.sh cleanvm $VM1 $MANAGED_PLUGIN_NAME
+
+	echo "Upgrade test step 5.2: deploy plugin vmware/docker-volume-vsphere:$UPGRADE_TO_VER on $VM1"
+	../misc/scripts/deploy-tools.sh deployvm $VM1 vmware/docker-volume-vsphere:$UPGRADE_TO_VER
+	$SSH $VM1 "systemctl restart docker || service docker restart"
+
+	echo "Upgrade test step 6: run pre-upgrade test"
+	$GO test -v -timeout 30m -tags runpostupgrade $E2E_Tests

--- a/misc/scripts/upgrade_test.sh
+++ b/misc/scripts/upgrade_test.sh
@@ -13,11 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+    source ../misc/scripts/command.sh
     MANAGED_PLUGIN_NAME="vsphere:latest"
     E2E_Tests="github.com/vmware/docker-volume-vsphere/tests/e2e"
     GO="go"
-    SSH="ssh -i /root/.ssh/id_rsa -kTax -o StrictHostKeyChecking=no"
 
     get_vib_url() {
         echo "Get version $1"

--- a/misc/scripts/upgrade_test.sh
+++ b/misc/scripts/upgrade_test.sh
@@ -30,39 +30,39 @@
         fi
     }
 
-    VIB_URL=""
-    get_vib_url $UPGRADE_FROM_VER
-    FROM_VIB_URL=$VIB_URL
-    echo "FROM_VIB_URL=$FROM_VIB_URL"
+    # VIB_URL=""
+    # get_vib_url $UPGRADE_FROM_VER
+    # FROM_VIB_URL=$VIB_URL
+    # echo "FROM_VIB_URL=$FROM_VIB_URL"
 
-    get_vib_url $UPGRADE_TO_VER
-    FROM_VIB_URL=$VIB_URL
-    echo "TO_VIB_URL=$TO_VIB_URL"
+    # get_vib_url $UPGRADE_TO_VER
+    # FROM_VIB_URL=$VIB_URL
+    # echo "TO_VIB_URL=$TO_VIB_URL"
 
-    echo "Upgrade test: from ver $UPGRADE_FROM_VER to ver $UPGRADE_TO_VER"
+    # echo "Upgrade test: from ver $UPGRADE_FROM_VER to ver $UPGRADE_TO_VER"
 
-	echo "Upgrade test step 1: deploy on $ESX with $FROM_VIB_URL"
-	../misc/scripts/deploy-tools.sh deployesxForUpgrade $ESX $FROM_VIB_URL
+	# echo "Upgrade test step 1: deploy on $ESX with $FROM_VIB_URL"
+	# ../misc/scripts/deploy-tools.sh deployesxForUpgrade $ESX $FROM_VIB_URL
 
-	echo "Upgrade test step 2.1: remove plugin $MANAGED_PLUGIN_NAME on $VM1"
-	../misc/scripts/deploy-tools.sh cleanvm $VM1 $MANAGED_PLUGIN_NAME
+	# echo "Upgrade test step 2.1: remove plugin $MANAGED_PLUGIN_NAME on $VM1"
+	# ../misc/scripts/deploy-tools.sh cleanvm $VM1 $MANAGED_PLUGIN_NAME
 
-	echo "Upgrade test step 2.2: deploy plugin vmware/docker-volume-vsphere:$UPGRADE_FROM_VER on $VM1"
-	../misc/scripts/deploy-tools.sh deployvm $VM1 vmware/docker-volume-vsphere:$UPGRADE_FROM_VER
-	$SSH $VM1 "systemctl restart docker || service docker restart"
+	# echo "Upgrade test step 2.2: deploy plugin vmware/docker-volume-vsphere:$UPGRADE_FROM_VER on $VM1"
+	# ../misc/scripts/deploy-tools.sh deployvm $VM1 vmware/docker-volume-vsphere:$UPGRADE_FROM_VER
+	# $SSH $VM1 "systemctl restart docker || service docker restart"
 
 	echo "Upgrade test step 3: run pre-upgrade test"
 	$GO test -v -timeout 30m -tags runpreupgrade $E2E_Tests
 
-	echo "Upgrade test step 4: deploy on $ESX with $TO_VIB_URL"
-	../misc/scripts/deploy-tools.sh deployesxForUpgrade  $ESX $TO_VIB_URL
+	# echo "Upgrade test step 4: deploy on $ESX with $TO_VIB_URL"
+	# ../misc/scripts/deploy-tools.sh deployesxForUpgrade  $ESX $TO_VIB_URL
 
-	echo "Upgrade test step 5.1: remove plugin $MANAGED_PLUGIN_NAME on $VM1"
-	../misc/scripts/deploy-tools.sh cleanvm $VM1 $MANAGED_PLUGIN_NAME
+	# echo "Upgrade test step 5.1: remove plugin $MANAGED_PLUGIN_NAME on $VM1"
+	# ../misc/scripts/deploy-tools.sh cleanvm $VM1 $MANAGED_PLUGIN_NAME
 
-	echo "Upgrade test step 5.2: deploy plugin vmware/docker-volume-vsphere:$UPGRADE_TO_VER on $VM1"
-	../misc/scripts/deploy-tools.sh deployvm $VM1 vmware/docker-volume-vsphere:$UPGRADE_TO_VER
-	$SSH $VM1 "systemctl restart docker || service docker restart"
+	# echo "Upgrade test step 5.2: deploy plugin vmware/docker-volume-vsphere:$UPGRADE_TO_VER on $VM1"
+	# ../misc/scripts/deploy-tools.sh deployvm $VM1 vmware/docker-volume-vsphere:$UPGRADE_TO_VER
+	# $SSH $VM1 "systemctl restart docker || service docker restart"
 
 	echo "Upgrade test step 6: run pre-upgrade test"
 	$GO test -v -timeout 30m -tags runpostupgrade $E2E_Tests

--- a/misc/scripts/upgrade_test.sh
+++ b/misc/scripts/upgrade_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 # Copyright 2016 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,39 +30,39 @@
         fi
     }
 
-    # VIB_URL=""
-    # get_vib_url $UPGRADE_FROM_VER
-    # FROM_VIB_URL=$VIB_URL
-    # echo "FROM_VIB_URL=$FROM_VIB_URL"
+    VIB_URL=""
+    get_vib_url $UPGRADE_FROM_VER
+    FROM_VIB_URL=$VIB_URL
+    echo "FROM_VIB_URL=$FROM_VIB_URL"
 
-    # get_vib_url $UPGRADE_TO_VER
-    # FROM_VIB_URL=$VIB_URL
-    # echo "TO_VIB_URL=$TO_VIB_URL"
+    get_vib_url $UPGRADE_TO_VER
+    TO_VIB_URL=$VIB_URL
+    echo "TO_VIB_URL=$TO_VIB_URL"
 
-    # echo "Upgrade test: from ver $UPGRADE_FROM_VER to ver $UPGRADE_TO_VER"
+    echo "Upgrade test: from ver $UPGRADE_FROM_VER to ver $UPGRADE_TO_VER"
 
-	# echo "Upgrade test step 1: deploy on $ESX with $FROM_VIB_URL"
-	# ../misc/scripts/deploy-tools.sh deployesxForUpgrade $ESX $FROM_VIB_URL
+	echo "Upgrade test step 1: deploy on $ESX with $FROM_VIB_URL"
+	../misc/scripts/deploy-tools.sh deployesxForUpgrade $ESX $FROM_VIB_URL
 
-	# echo "Upgrade test step 2.1: remove plugin $MANAGED_PLUGIN_NAME on $VM1"
-	# ../misc/scripts/deploy-tools.sh cleanvm $VM1 $MANAGED_PLUGIN_NAME
+	echo "Upgrade test step 2.1: remove plugin $MANAGED_PLUGIN_NAME on $VM1"
+	../misc/scripts/deploy-tools.sh cleanvm $VM1 $MANAGED_PLUGIN_NAME
 
-	# echo "Upgrade test step 2.2: deploy plugin vmware/docker-volume-vsphere:$UPGRADE_FROM_VER on $VM1"
-	# ../misc/scripts/deploy-tools.sh deployvm $VM1 vmware/docker-volume-vsphere:$UPGRADE_FROM_VER
-	# $SSH $VM1 "systemctl restart docker || service docker restart"
+	echo "Upgrade test step 2.2: deploy plugin vmware/docker-volume-vsphere:$UPGRADE_FROM_VER on $VM1"
+	../misc/scripts/deploy-tools.sh deployvm $VM1 vmware/docker-volume-vsphere:$UPGRADE_FROM_VER
+	$SSH $VM1 "systemctl restart docker || service docker restart"
 
 	echo "Upgrade test step 3: run pre-upgrade test"
 	$GO test -v -timeout 30m -tags runpreupgrade $E2E_Tests
 
-	# echo "Upgrade test step 4: deploy on $ESX with $TO_VIB_URL"
-	# ../misc/scripts/deploy-tools.sh deployesxForUpgrade  $ESX $TO_VIB_URL
+	echo "Upgrade test step 4: deploy on $ESX with $TO_VIB_URL"
+	../misc/scripts/deploy-tools.sh deployesxForUpgrade  $ESX $TO_VIB_URL
 
-	# echo "Upgrade test step 5.1: remove plugin $MANAGED_PLUGIN_NAME on $VM1"
-	# ../misc/scripts/deploy-tools.sh cleanvm $VM1 $MANAGED_PLUGIN_NAME
+	echo "Upgrade test step 5.1: remove plugin $MANAGED_PLUGIN_NAME on $VM1"
+	../misc/scripts/deploy-tools.sh cleanvm $VM1 $MANAGED_PLUGIN_NAME
 
-	# echo "Upgrade test step 5.2: deploy plugin vmware/docker-volume-vsphere:$UPGRADE_TO_VER on $VM1"
-	# ../misc/scripts/deploy-tools.sh deployvm $VM1 vmware/docker-volume-vsphere:$UPGRADE_TO_VER
-	# $SSH $VM1 "systemctl restart docker || service docker restart"
+	echo "Upgrade test step 5.2: deploy plugin vmware/docker-volume-vsphere:$UPGRADE_TO_VER on $VM1"
+	../misc/scripts/deploy-tools.sh deployvm $VM1 vmware/docker-volume-vsphere:$UPGRADE_TO_VER
+	$SSH $VM1 "systemctl restart docker || service docker restart"
 
 	echo "Upgrade test step 6: run pre-upgrade test"
 	$GO test -v -timeout 30m -tags runpostupgrade $E2E_Tests

--- a/misc/scripts/upgrade_test.sh
+++ b/misc/scripts/upgrade_test.sh
@@ -13,55 +13,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-    source ../misc/scripts/command.sh
+    source ../misc/scripts/commands.sh
     MANAGED_PLUGIN_NAME="vsphere:latest"
     E2E_Tests="github.com/vmware/docker-volume-vsphere/tests/e2e"
     GO="go"
+    DEPLOY_TOOLS_SH=../misc/scripts/deploy-tools.sh
 
     get_vib_url() {
         echo "Get version $1"
-        if [ $1 == "0.14" ]
-        then
-            VIB_URL="https://bintray.com/vmware/vDVS/download_file?file_path=VMWare_bootbank_esx-vmdkops-service_0.14.0577889-0.0.1.vib"
-        elif [ $1 == "0.15" ]
-        then
-            VIB_URL="https://bintray.com/vmware/vDVS/download_file?file_path=VMWare_bootbank_esx-vmdkops-service_0.15.b93c186-0.0.1.vib"
-        fi
+        MATCH_ENTRY=$( grep $1 ../misc/scripts/upgrade_test_vib.txt)
+        echo $MATCH_URL_ENTRY
+        IFS=' ' read -a match_array <<< "${MATCH_ENTRY}"
+        VIB_URL=${match_array[1]}
     }
 
     VIB_URL=""
     get_vib_url $UPGRADE_FROM_VER
-    FROM_VIB_URL=$VIB_URL
-    echo "FROM_VIB_URL=$FROM_VIB_URL"
+    BASE_VIB_URL=$VIB_URL
+    echo "BASE_VIB_URL=$BASE_VIB_URL"
 
     get_vib_url $UPGRADE_TO_VER
-    TO_VIB_URL=$VIB_URL
-    echo "TO_VIB_URL=$TO_VIB_URL"
+    UPGRADE_VIB_URL=$VIB_URL
+    echo "UPGRADE_VIB_URL=$UPGRADE_VIB_URL"
 
     echo "Upgrade test: from ver $UPGRADE_FROM_VER to ver $UPGRADE_TO_VER"
 
-	echo "Upgrade test step 1: deploy on $ESX with $FROM_VIB_URL"
-	../misc/scripts/deploy-tools.sh deployesxForUpgrade $ESX $FROM_VIB_URL
+	echo "Upgrade test step 1: deploy on $ESX with $BASE_VIB_URL"
+	$DEPLOY_TOOLS_SH deployesxforupgrade $ESX $BASE_VIB_URL
 
 	echo "Upgrade test step 2.1: remove plugin $MANAGED_PLUGIN_NAME on $VM1"
-	../misc/scripts/deploy-tools.sh cleanvm $VM1 $MANAGED_PLUGIN_NAME
+	$DEPLOY_TOOLS_SH cleanvm $VM1 $MANAGED_PLUGIN_NAME
 
 	echo "Upgrade test step 2.2: deploy plugin vmware/docker-volume-vsphere:$UPGRADE_FROM_VER on $VM1"
 	../misc/scripts/deploy-tools.sh deployvm $VM1 vmware/docker-volume-vsphere:$UPGRADE_FROM_VER
 	$SSH $VM1 "systemctl restart docker || service docker restart"
 
 	echo "Upgrade test step 3: run pre-upgrade test"
-	$GO test -v -timeout 30m -tags runpreupgrade $E2E_Tests
+	$GO test -v -tags runpreupgrade $E2E_Tests
 
-	echo "Upgrade test step 4: deploy on $ESX with $TO_VIB_URL"
-	../misc/scripts/deploy-tools.sh deployesxForUpgrade  $ESX $TO_VIB_URL
+	echo "Upgrade test step 4: deploy on $ESX with $UPGRADE_VIB_URL"
+	$DEPLOY_TOOLS_SH deployesxforupgrade  $ESX $UPGRADE_VIB_URL
 
 	echo "Upgrade test step 5.1: remove plugin $MANAGED_PLUGIN_NAME on $VM1"
-	../misc/scripts/deploy-tools.sh cleanvm $VM1 $MANAGED_PLUGIN_NAME
+	$DEPLOY_TOOLS_SH cleanvm $VM1 $MANAGED_PLUGIN_NAME
 
 	echo "Upgrade test step 5.2: deploy plugin vmware/docker-volume-vsphere:$UPGRADE_TO_VER on $VM1"
 	../misc/scripts/deploy-tools.sh deployvm $VM1 vmware/docker-volume-vsphere:$UPGRADE_TO_VER
 	$SSH $VM1 "systemctl restart docker || service docker restart"
 
-	echo "Upgrade test step 6: run pre-upgrade test"
-	$GO test -v -timeout 30m -tags runpostupgrade $E2E_Tests
+	echo "Upgrade test step 6: run post-upgrade test"
+	$GO test -v -tags runpostupgrade $E2E_Tests

--- a/misc/scripts/upgrade_test_vib.txt
+++ b/misc/scripts/upgrade_test_vib.txt
@@ -1,0 +1,2 @@
+0.14 https://bintray.com/vmware/vDVS/download_file?file_path=VMWare_bootbank_esx-vmdkops-service_0.14.0577889-0.0.1.vib
+0.15 https://bintray.com/vmware/vDVS/download_file?file_path=VMWare_bootbank_esx-vmdkops-service_0.15.b93c186-0.0.1.vib

--- a/tests/constants/admincli/upgrade.go
+++ b/tests/constants/admincli/upgrade.go
@@ -1,0 +1,25 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A home to hold test constants used in upgrade test.
+
+package admincli
+
+const (
+	// PreUpgradeTestVol is the volume name created before upgrade
+	PreUpgradeTestVol = "preUpgradeTestVol"
+
+	// PostUpgradeTestVol is the volume created after upgrade
+	PostUpgradeTestVol = "postUpgradeTestVol"
+)

--- a/tests/constants/upgrade/upgrade.go
+++ b/tests/constants/upgrade/upgrade.go
@@ -14,7 +14,7 @@
 
 // A home to hold test constants used in upgrade test.
 
-package admincli
+package upgrade
 
 const (
 	// PreUpgradeTestVol is the volume name created before upgrade
@@ -22,4 +22,12 @@ const (
 
 	// PostUpgradeTestVol is the volume created after upgrade
 	PostUpgradeTestVol = "postUpgradeTestVol"
+
+	TestData = "Hello World!"
+
+	TestFile = "hello.txt"
+
+	TestData1 = "Hello World Again!"
+
+	TestFile1 = "hello1.txt"
 )

--- a/tests/e2e/post_upgrade_test.go
+++ b/tests/e2e/post_upgrade_test.go
@@ -1,0 +1,159 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This test suite includes test cases to verify basic functionality
+// in most common configurations
+
+// +build runpostupgrade
+
+package e2e
+
+import (
+	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/verification"
+	. "gopkg.in/check.v1"
+)
+
+type PostUpgradeTestSuite struct {
+	config         *inputparams.TestConfig
+	esx            string
+	vm1            string
+	vm2            string
+	vm1Name        string
+	vm2Name        string
+	volName1       string
+	volName2       string
+	containerName1 string
+	containerName2 string
+}
+
+func (s *PostUpgradeTestSuite) SetUpSuite(c *C) {
+	s.config = inputparams.GetTestConfig()
+	if s.config == nil {
+		c.Skip("Unable to retrieve test config, skipping basic tests")
+	}
+
+	s.esx = s.config.EsxHost
+	s.vm1 = s.config.DockerHosts[0]
+	s.vm2 = s.config.DockerHosts[1]
+	s.vm1Name = s.config.DockerHostNames[0]
+	s.vm2Name = s.config.DockerHostNames[1]
+}
+
+func (s *PostUpgradeTestSuite) SetUpTest(c *C) {
+	s.volName1 = "preUpgradeTestVol"
+	s.volName2 = "postUpgradeTestVol"
+	s.containerName1 = inputparams.GetUniqueContainerName(c.TestName())
+	s.containerName2 = inputparams.GetUniqueContainerName(c.TestName())
+}
+
+var _ = Suite(&PostUpgradeTestSuite{})
+
+// Test steps:
+// 1. Verify volume created in pre-upgrade test is available
+// 2. Verify the volume is detached
+// 3. Attach the volume from a new conatainer
+// 4. Verify volume status is attached
+// 5. Read data from that volume to make sure data written in pre-upgrade test remains same
+// 5. Write more data to that volume
+// 6. Read the data from the volume to make sure it matches the data written in previous step
+// 7. Stop the container and verify volume status is detached
+// 8. Remove the container
+// 9. Remove the volume created in pre-upgrade test
+// 10. Create a new volume
+// 11. Verify the status is detached
+// 12. Attach the new volume from a new container
+// 13. Verify the volume status is attached
+// 14. Write some data to the new volume
+// 15. Read the data from the new volume to make it matches the data written in previous step
+// 16. Stop the container
+// 17. Remove the container
+// 18. Remove the new volume
+func (s *PostUpgradeTestSuite) TestVolumeLifecycle(c *C) {
+	const (
+		testData  = "Hello World!"
+		testFile  = "hello.txt"
+		testData1 = "Hello World Again!"
+		testFile1 = "hello1.txt"
+		volPath   = "/vol"
+	)
+	misc.LogTestStart(c.TestName())
+
+	accessible := verification.CheckVolumeAvailability(s.vm1, s.volName1)
+	c.Assert(accessible, Equals, true, Commentf("Volume %s is not available on docker host %s",
+		s.volName1, s.vm1))
+
+	status := verification.VerifyDetachedStatus(s.volName1, s.vm1, s.esx)
+	c.Assert(status, Equals, true, Commentf("Volume %s is not detached", s.volName1))
+
+	out, err := dockercli.AttachVolume(s.vm1, s.volName1, s.containerName1)
+	c.Assert(err, IsNil, Commentf(out))
+
+	status = verification.VerifyAttachedStatus(s.volName1, s.vm1, s.esx)
+	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volName1))
+
+	out, err = dockercli.ReadFromContainer(s.vm1, s.containerName1, volPath, testFile)
+	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(out, Equals, testData)
+
+	out, err = dockercli.WriteToContainer(s.vm1, s.containerName1, volPath, testFile1, testData1)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.ReadFromContainer(s.vm1, s.containerName1, volPath, testFile1)
+	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(out, Equals, testData1)
+
+	out, err = dockercli.StopContainer(s.vm1, s.containerName1)
+	c.Assert(err, IsNil, Commentf(out))
+
+	status = verification.VerifyDetachedStatus(s.volName1, s.vm1, s.esx)
+	c.Assert(status, Equals, true, Commentf("Volume %s is not detached", s.volName1))
+
+	out, err = dockercli.RemoveContainer(s.vm1, s.containerName1)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.DeleteVolume(s.vm1, s.volName1)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.CreateVolume(s.vm1, s.volName2)
+	c.Assert(err, IsNil, Commentf(out))
+
+	status = verification.VerifyDetachedStatus(s.volName2, s.vm1, s.esx)
+	c.Assert(status, Equals, true, Commentf("Volume %s is not detached", s.volName2))
+
+	out, err = dockercli.AttachVolume(s.vm1, s.volName2, s.containerName2)
+	c.Assert(err, IsNil, Commentf(out))
+
+	status = verification.VerifyAttachedStatus(s.volName2, s.vm1, s.esx)
+	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volName2))
+
+	out, err = dockercli.WriteToContainer(s.vm1, s.containerName2, volPath, testFile, testData)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.ReadFromContainer(s.vm1, s.containerName2, volPath, testFile)
+	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(out, Equals, testData)
+
+	out, err = dockercli.StopContainer(s.vm1, s.containerName2)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.RemoveContainer(s.vm1, s.containerName2)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.DeleteVolume(s.vm1, s.volName2)
+	c.Assert(err, IsNil, Commentf(out))
+
+}

--- a/tests/e2e/post_upgrade_test.go
+++ b/tests/e2e/post_upgrade_test.go
@@ -20,8 +20,8 @@
 package e2e
 
 import (
-	admincliconst "github.com/vmware/docker-volume-vsphere/tests/constants/admincli"
 	dockerconst "github.com/vmware/docker-volume-vsphere/tests/constants/dockercli"
+	upgradeconst "github.com/vmware/docker-volume-vsphere/tests/constants/upgrade"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
@@ -30,10 +30,10 @@ import (
 )
 
 const (
-	testData  = "Hello World!"
-	testFile  = "hello.txt"
-	testData1 = "Hello World Again!"
-	testFile1 = "hello1.txt"
+	testData  = upgradeconst.TestData
+	testFile  = upgradeconst.TestFile
+	testData1 = upgradeconst.TestData1
+	testFile1 = upgradeconst.TestFile1
 	volPath   = dockerconst.ContainerMountPoint
 )
 
@@ -60,8 +60,8 @@ func (s *PostUpgradeTestSuite) SetUpSuite(c *C) {
 }
 
 func (s *PostUpgradeTestSuite) SetUpTest(c *C) {
-	s.volName1 = admincliconst.PreUpgradeTestVol
-	s.volName2 = admincliconst.PostUpgradeTestVol
+	s.volName1 = upgradeconst.PreUpgradeTestVol
+	s.volName2 = upgradeconst.PostUpgradeTestVol
 	s.containerName1 = inputparams.GetUniqueContainerName(c.TestName())
 	s.containerName2 = inputparams.GetUniqueContainerName(c.TestName())
 }
@@ -91,13 +91,6 @@ var _ = Suite(&PostUpgradeTestSuite{})
 // 17. Remove the container and verify the new volume status is detached
 // 18. Remove the new volume
 func (s *PostUpgradeTestSuite) TestVolumeLifecycle(c *C) {
-	const (
-		testData  = "Hello World!"
-		testFile  = "hello.txt"
-		testData1 = "Hello World Again!"
-		testFile1 = "hello1.txt"
-		volPath   = "/vol"
-	)
 	misc.LogTestStart(c.TestName())
 
 	accessible := verification.CheckVolumeAvailability(s.vm1, s.volName1)

--- a/tests/e2e/post_upgrade_test.go
+++ b/tests/e2e/post_upgrade_test.go
@@ -13,13 +13,15 @@
 // limitations under the License.
 
 // This test suite includes test cases to verify basic functionality
-// in most common configurations
+// after upgrade for upgrade test
 
 // +build runpostupgrade
 
 package e2e
 
 import (
+	admincliconst "github.com/vmware/docker-volume-vsphere/tests/constants/admincli"
+	dockerconst "github.com/vmware/docker-volume-vsphere/tests/constants/dockercli"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
@@ -27,13 +29,19 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+const (
+	testData  = "Hello World!"
+	testFile  = "hello.txt"
+	testData1 = "Hello World Again!"
+	testFile1 = "hello1.txt"
+	volPath   = dockerconst.ContainerMountPoint
+)
+
 type PostUpgradeTestSuite struct {
 	config         *inputparams.TestConfig
 	esx            string
 	vm1            string
-	vm2            string
 	vm1Name        string
-	vm2Name        string
 	volName1       string
 	volName2       string
 	containerName1 string
@@ -43,19 +51,17 @@ type PostUpgradeTestSuite struct {
 func (s *PostUpgradeTestSuite) SetUpSuite(c *C) {
 	s.config = inputparams.GetTestConfig()
 	if s.config == nil {
-		c.Skip("Unable to retrieve test config, skipping basic tests")
+		c.Skip("Unable to retrieve test config, skipping post-upgrade tests")
 	}
 
 	s.esx = s.config.EsxHost
 	s.vm1 = s.config.DockerHosts[0]
-	s.vm2 = s.config.DockerHosts[1]
 	s.vm1Name = s.config.DockerHostNames[0]
-	s.vm2Name = s.config.DockerHostNames[1]
 }
 
 func (s *PostUpgradeTestSuite) SetUpTest(c *C) {
-	s.volName1 = "preUpgradeTestVol"
-	s.volName2 = "postUpgradeTestVol"
+	s.volName1 = admincliconst.PreUpgradeTestVol
+	s.volName2 = admincliconst.PostUpgradeTestVol
 	s.containerName1 = inputparams.GetUniqueContainerName(c.TestName())
 	s.containerName2 = inputparams.GetUniqueContainerName(c.TestName())
 }
@@ -64,23 +70,25 @@ var _ = Suite(&PostUpgradeTestSuite{})
 
 // Test steps:
 // 1. Verify volume created in pre-upgrade test is available
-// 2. Verify the volume is detached
+// 2. Verify the volume is available and detached
 // 3. Attach the volume from a new conatainer
 // 4. Verify volume status is attached
 // 5. Read data from that volume to make sure data written in pre-upgrade test remains same
-// 5. Write more data to that volume
-// 6. Read the data from the volume to make sure it matches the data written in previous step
+// 6. Write more data to that volume
 // 7. Stop the container and verify volume status is detached
-// 8. Remove the container
+// 8. Start the same container again and read the data from the volume to make sure it matches the
+//    data written in previous step
+// 9. Remove the container and verify volume status is detached
 // 9. Remove the volume created in pre-upgrade test
 // 10. Create a new volume
-// 11. Verify the status is detached
+// 11. Verify the new volume is available
 // 12. Attach the new volume from a new container
 // 13. Verify the volume status is attached
 // 14. Write some data to the new volume
-// 15. Read the data from the new volume to make it matches the data written in previous step
-// 16. Stop the container
-// 17. Remove the container
+// 15. Stop the container and verify the new volume status is detached
+// 16. Start the same container again and read the data from the new volume to make it matches the
+//     data written in previous step
+// 17. Remove the container and verify the new volume status is detached
 // 18. Remove the new volume
 func (s *PostUpgradeTestSuite) TestVolumeLifecycle(c *C) {
 	const (
@@ -112,18 +120,25 @@ func (s *PostUpgradeTestSuite) TestVolumeLifecycle(c *C) {
 	out, err = dockercli.WriteToContainer(s.vm1, s.containerName1, volPath, testFile1, testData1)
 	c.Assert(err, IsNil, Commentf(out))
 
-	out, err = dockercli.ReadFromContainer(s.vm1, s.containerName1, volPath, testFile1)
-	c.Assert(err, IsNil, Commentf(out))
-	c.Assert(out, Equals, testData1)
-
 	out, err = dockercli.StopContainer(s.vm1, s.containerName1)
 	c.Assert(err, IsNil, Commentf(out))
 
 	status = verification.VerifyDetachedStatus(s.volName1, s.vm1, s.esx)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not detached", s.volName1))
 
+	out, err = dockercli.StartContainer(s.vm1, s.containerName1)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.ReadFromContainer(s.vm1, s.containerName1, volPath, testFile1)
+	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(out, Equals, testData1, Commentf("Data read from volume[%s] does not match written previously[%s]",
+		out, testData1))
+
 	out, err = dockercli.RemoveContainer(s.vm1, s.containerName1)
 	c.Assert(err, IsNil, Commentf(out))
+
+	status = verification.VerifyDetachedStatus(s.volName1, s.vm1, s.esx)
+	c.Assert(status, Equals, true, Commentf("Volume %s is not detached", s.volName1))
 
 	out, err = dockercli.DeleteVolume(s.vm1, s.volName1)
 	c.Assert(err, IsNil, Commentf(out))
@@ -131,8 +146,9 @@ func (s *PostUpgradeTestSuite) TestVolumeLifecycle(c *C) {
 	out, err = dockercli.CreateVolume(s.vm1, s.volName2)
 	c.Assert(err, IsNil, Commentf(out))
 
-	status = verification.VerifyDetachedStatus(s.volName2, s.vm1, s.esx)
-	c.Assert(status, Equals, true, Commentf("Volume %s is not detached", s.volName2))
+	accessible = verification.CheckVolumeAvailability(s.vm1, s.volName2)
+	c.Assert(accessible, Equals, true, Commentf("Volume %s is not available on docker host %s",
+		s.volName2, s.vm1))
 
 	out, err = dockercli.AttachVolume(s.vm1, s.volName2, s.containerName2)
 	c.Assert(err, IsNil, Commentf(out))
@@ -143,15 +159,25 @@ func (s *PostUpgradeTestSuite) TestVolumeLifecycle(c *C) {
 	out, err = dockercli.WriteToContainer(s.vm1, s.containerName2, volPath, testFile, testData)
 	c.Assert(err, IsNil, Commentf(out))
 
-	out, err = dockercli.ReadFromContainer(s.vm1, s.containerName2, volPath, testFile)
-	c.Assert(err, IsNil, Commentf(out))
-	c.Assert(out, Equals, testData)
-
 	out, err = dockercli.StopContainer(s.vm1, s.containerName2)
 	c.Assert(err, IsNil, Commentf(out))
 
+	status = verification.VerifyDetachedStatus(s.volName2, s.vm1, s.esx)
+	c.Assert(status, Equals, true, Commentf("Volume %s is not detached", s.volName2))
+
+	out, err = dockercli.StartContainer(s.vm1, s.containerName2)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.ReadFromContainer(s.vm1, s.containerName2, volPath, testFile)
+	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(out, Equals, testData, Commentf("Data read from volume[%s] does not match written previously[%s]",
+		out, testData))
+
 	out, err = dockercli.RemoveContainer(s.vm1, s.containerName2)
 	c.Assert(err, IsNil, Commentf(out))
+
+	status = verification.VerifyDetachedStatus(s.volName2, s.vm1, s.esx)
+	c.Assert(status, Equals, true, Commentf("Volume %s is not detached", s.volName2))
 
 	out, err = dockercli.DeleteVolume(s.vm1, s.volName2)
 	c.Assert(err, IsNil, Commentf(out))

--- a/tests/e2e/pre_upgrade_test.go
+++ b/tests/e2e/pre_upgrade_test.go
@@ -20,8 +20,8 @@
 package e2e
 
 import (
-	admincliconst "github.com/vmware/docker-volume-vsphere/tests/constants/admincli"
 	dockerconst "github.com/vmware/docker-volume-vsphere/tests/constants/dockercli"
+	upgradeconst "github.com/vmware/docker-volume-vsphere/tests/constants/upgrade"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	testData = "Hello World!"
-	testFile = "hello.txt"
+	testData = upgradeconst.TestData
+	testFile = upgradeconst.TestFile
 	volPath  = dockerconst.ContainerMountPoint
 )
 
@@ -56,7 +56,7 @@ func (s *PreUpgradeTestSuite) SetUpSuite(c *C) {
 }
 
 func (s *PreUpgradeTestSuite) SetUpTest(c *C) {
-	s.volName1 = admincliconst.PreUpgradeTestVol
+	s.volName1 = upgradeconst.PreUpgradeTestVol
 	s.containerName = inputparams.GetUniqueContainerName(c.TestName())
 }
 

--- a/tests/e2e/pre_upgrade_test.go
+++ b/tests/e2e/pre_upgrade_test.go
@@ -1,0 +1,119 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This test suite includes test cases to verify basic functionality
+// in most common configurations
+
+// +build runpreupgrade
+
+package e2e
+
+import (
+	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/verification"
+	. "gopkg.in/check.v1"
+)
+
+type PreUpgradeTestSuite struct {
+	config        *inputparams.TestConfig
+	esx           string
+	vm1           string
+	vm2           string
+	vm1Name       string
+	vm2Name       string
+	volName1      string
+	volName2      string
+	containerName string
+}
+
+func (s *PreUpgradeTestSuite) SetUpSuite(c *C) {
+	s.config = inputparams.GetTestConfig()
+	if s.config == nil {
+		c.Skip("Unable to retrieve test config, skipping basic tests")
+	}
+
+	s.esx = s.config.EsxHost
+	s.vm1 = s.config.DockerHosts[0]
+	s.vm2 = s.config.DockerHosts[1]
+	s.vm1Name = s.config.DockerHostNames[0]
+	s.vm2Name = s.config.DockerHostNames[1]
+}
+
+func (s *PreUpgradeTestSuite) SetUpTest(c *C) {
+	s.volName1 = "preUpgradeTestVol"
+	s.containerName = inputparams.GetUniqueContainerName(c.TestName())
+}
+
+var _ = Suite(&PreUpgradeTestSuite{})
+
+// Test steps:
+// 1. Create a volume
+// 2. Verify the volume is detached
+// 3. Attach the volume
+// 4. Verify volume status is attached
+// 5. Write some data to that volume
+// 6. Read the data from the volume to make sure it matched the data written previously
+// 7. Stop the container and verify volume status is detached
+// 8. Start container and read from container again to make sure data remains same
+// 9. Verify volume status is attached
+// 10. Remove the container
+func (s *PreUpgradeTestSuite) TestVolumeLifecycle(c *C) {
+	const (
+		testData = "Hello World!"
+		testFile = "hello.txt"
+		volPath  = "/vol"
+	)
+	misc.LogTestStart(c.TestName())
+
+	out, err := dockercli.CreateVolume(s.vm1, s.volName1)
+	c.Assert(err, IsNil, Commentf(out))
+
+	status := verification.VerifyDetachedStatus(s.volName1, s.vm1, s.esx)
+	c.Assert(status, Equals, true, Commentf("Volume %s is not detached", s.volName1))
+
+	out, err = dockercli.AttachVolume(s.vm1, s.volName1, s.containerName)
+	c.Assert(err, IsNil, Commentf(out))
+
+	status = verification.VerifyAttachedStatus(s.volName1, s.vm1, s.esx)
+	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volName1))
+
+	out, err = dockercli.WriteToContainer(s.vm1, s.containerName, volPath, testFile, testData)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.ReadFromContainer(s.vm1, s.containerName, volPath, testFile)
+	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(out, Equals, testData)
+
+	out, err = dockercli.StopContainer(s.vm1, s.containerName)
+	c.Assert(err, IsNil, Commentf(out))
+
+	status = verification.VerifyDetachedStatus(s.volName1, s.vm1, s.esx)
+	c.Assert(status, Equals, true, Commentf("Volume %s is not detached", s.volName1))
+
+	out, err = dockercli.StartContainer(s.vm1, s.containerName)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.ReadFromContainer(s.vm1, s.containerName, volPath, testFile)
+	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(out, Equals, testData)
+
+	status = verification.VerifyAttachedStatus(s.volName1, s.vm1, s.esx)
+	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volName1))
+
+	out, err = dockercli.RemoveContainer(s.vm1, s.containerName)
+	c.Assert(err, IsNil, Commentf(out))
+
+}


### PR DESCRIPTION
This PR includes:
1. Makefile and changes in deploy-tools.sh to deploy ESX with given .vib URL and install managed plugin for given version
2. basic go test before upgrade
3. basic go test after upgrade
4. This PR only support upgrade from a tagged release to another tagged release. Update from a tagged release to CURRENT is NOT supported.

How to Test:
The following parameters need to be set:
```
export UPGRADE_FROM_VER=0.14
export UPGRADE_TO_VER=0.15
```

Run the test
```
lipingx-m01:auth_r9.liping lipingx$ make test-upgrade
/Library/Developer/CommandLineTools/usr/bin/make --directory=client_plugin test-upgrade
../misc/scripts/build.sh run-upgrade-test
make: Entering directory `/go/src/github.com/vmware/docker-volume-vsphere/client_plugin'
ESX='10.162.22.190' VM1='10.162.24.183' UPGRADE_FROM_VER='0.14' UPGRADE_TO_VER='0.15' ../misc/scripts/upgrade_test.sh
Get version 0.14

BASE_VIB_URL=https://bintray.com/vmware/vDVS/download_file?file_path=VMWare_bootbank_esx-vmdkops-service_0.14.0577889-0.0.1.vib
Get version 0.15

UPGRADE_VIB_URL=https://bintray.com/vmware/vDVS/download_file?file_path=VMWare_bootbank_esx-vmdkops-service_0.15.b93c186-0.0.1.vib
Upgrade test: from ver 0.14 to ver 0.15
Upgrade test step 1: deploy on 10.162.22.190 with https://bintray.com/vmware/vDVS/download_file?file_path=VMWare_bootbank_esx-vmdkops-service_0.14.0577889-0.0.1.vib


=> Deploying to ESX root@10.162.22.190 Wed Jul 12 23:29:46 UTC 2017


Installation Result:
   Message: Host is not changed.
   Reboot Required: false
   VIBs Installed: 
   VIBs Removed: 
   VIBs Skipped: VMWare_bootbank_esx-vmdkops-service_0.14.0577889-0.0.1
vmdkops-opsd is running pid=4817758
4817790
Upgrade test step 2.1: remove plugin vsphere:latest on 10.162.24.183


=> cleanvm: Cleaning up on root@10.162.24.183 : deb Wed Jul 12 23:29:53 UTC 2017


Upgrade test step 2.2: deploy plugin vmware/docker-volume-vsphere:0.14 on 10.162.24.183


=> installManagedPlugin: Installing vDVS plugin [vmware/docker-volume-vsphere:0.14] Wed Jul 12 23:29:55 UTC 2017


0.14: Pulling from vmware/docker-volume-vsphere
74f07603471d: Verifying Checksum
74f07603471d: Download complete
Digest: sha256:7abedf6f9e25258085c24e7e1b01d7a1d05ab6032ffc97358f22ced1e549c159
Status: Downloaded newer image for vmware/docker-volume-vsphere:0.14
Installed plugin vmware/docker-volume-vsphere:0.14
19287
bash: systemctl: command not found
docker stop/waiting
docker start/running, process 19461
Upgrade test step 3: run pre-upgrade test
=== RUN   Test
2017/07/12 23:30:06 START: PreUpgradeTestSuite.TestVolumeLifecycle
2017/07/12 23:30:06 Creating volume [preUpgradeTestVol] on VM [10.162.24.183]
2017/07/12 23:30:10 Checking volume [preUpgradeTestVol] availability from VM [10.162.24.183]
2017/07/12 23:30:11 Attaching volume [preUpgradeTestVol] on VM [10.162.24.183]
2017/07/12 23:30:13 Confirming attached status for volume [preUpgradeTestVol]
2017/07/12 23:30:13 Fetching full name for volume [preUpgradeTestVol] from VM [10.162.24.183]
2017/07/12 23:30:14 Full volume name: [preUpgradeTestVol@sharedVmfs-0]
2017/07/12 23:30:17 Writing data to file [hello.txt] in container [PreUpgradeTestSuite.TestVolumeLifecycle_container_417039] on VM [10.162.24.183]
2017/07/12 23:30:17 docker exec -t PreUpgradeTestSuite.TestVolumeLifecycle_container_417039 /bin/sh -c 'echo "Hello World!" > /vol/hello.txt'
2017/07/12 23:30:18 Reading from file [hello.txt] in container [PreUpgradeTestSuite.TestVolumeLifecycle_container_417039] on VM [10.162.24.183]
2017/07/12 23:30:18 docker exec -t PreUpgradeTestSuite.TestVolumeLifecycle_container_417039 /bin/sh -c 'cat /vol/hello.txt'
2017/07/12 23:30:18 Stopping container [PreUpgradeTestSuite.TestVolumeLifecycle_container_417039] on VM [10.162.24.183]
2017/07/12 23:30:30 Confirming detached status for volume [preUpgradeTestVol]
2017/07/12 23:30:30 Fetching full name for volume [preUpgradeTestVol] from VM [10.162.24.183]
2017/07/12 23:30:31 Full volume name: [preUpgradeTestVol@sharedVmfs-0]
2017/07/12 23:30:32 Starting container [PreUpgradeTestSuite.TestVolumeLifecycle_container_417039] on VM [10.162.24.183]
2017/07/12 23:30:34 Reading from file [hello.txt] in container [PreUpgradeTestSuite.TestVolumeLifecycle_container_417039] on VM [10.162.24.183]
2017/07/12 23:30:34 docker exec -t PreUpgradeTestSuite.TestVolumeLifecycle_container_417039 /bin/sh -c 'cat /vol/hello.txt'
2017/07/12 23:30:34 Confirming attached status for volume [preUpgradeTestVol]
2017/07/12 23:30:34 Fetching full name for volume [preUpgradeTestVol] from VM [10.162.24.183]
2017/07/12 23:30:35 Full volume name: [preUpgradeTestVol@sharedVmfs-0]
2017/07/12 23:30:38 Removing container [PreUpgradeTestSuite.TestVolumeLifecycle_container_417039] on VM [10.162.24.183]
2017/07/12 23:30:39 Confirming detached status for volume [preUpgradeTestVol]
2017/07/12 23:30:39 Fetching full name for volume [preUpgradeTestVol] from VM [10.162.24.183]
2017/07/12 23:30:40 Full volume name: [preUpgradeTestVol@sharedVmfs-0]
OK: 1 passed
--- PASS: Test (39.28s)
PASS
ok  	github.com/vmware/docker-volume-vsphere/tests/e2e	39.281s
Upgrade test step 4: deploy on 10.162.22.190 with https://bintray.com/vmware/vDVS/download_file?file_path=VMWare_bootbank_esx-vmdkops-service_0.15.b93c186-0.0.1.vib


=> Deploying to ESX root@10.162.22.190 Wed Jul 12 23:30:43 UTC 2017


Installation Result:
   Message: Operation finished successfully.
   Reboot Required: false
   VIBs Installed: VMWare_bootbank_esx-vmdkops-service_0.15.b93c186-0.0.1
   VIBs Removed: VMWare_bootbank_esx-vmdkops-service_0.14.0577889-0.0.1
   VIBs Skipped: 
vmdkops-opsd is running pid=4821258
4821290
Upgrade test step 5.1: remove plugin vsphere:latest on 10.162.24.183


=> cleanvm: Cleaning up on root@10.162.24.183 : deb Wed Jul 12 23:31:19 UTC 2017


Upgrade test step 5.2: deploy plugin vmware/docker-volume-vsphere:0.15 on 10.162.24.183


=> installManagedPlugin: Installing vDVS plugin [vmware/docker-volume-vsphere:0.15] Wed Jul 12 23:31:21 UTC 2017


0.15: Pulling from vmware/docker-volume-vsphere
967f49dfadaf: Verifying Checksum
967f49dfadaf: Download complete
Digest: sha256:64a50830c2fa9befbede6efca3f28d2e2d8b4e595703f1b5984470579656e935
Status: Downloaded newer image for vmware/docker-volume-vsphere:0.15
Installed plugin vmware/docker-volume-vsphere:0.15
21324
bash: systemctl: command not found
docker stop/waiting
docker start/running, process 21495
Upgrade test step 6: run post-upgrade test
=== RUN   Test
2017/07/12 23:31:44 START: PostUpgradeTestSuite.TestVolumeLifecycle
2017/07/12 23:31:44 Checking volume [preUpgradeTestVol] availability from VM [10.162.24.183]
2017/07/12 23:31:47 Confirming detached status for volume [preUpgradeTestVol]
2017/07/12 23:31:47 Fetching full name for volume [preUpgradeTestVol] from VM [10.162.24.183]
2017/07/12 23:31:48 Full volume name: [preUpgradeTestVol@sharedVmfs-0]
2017/07/12 23:31:50 Attaching volume [preUpgradeTestVol] on VM [10.162.24.183]
2017/07/12 23:31:52 Confirming attached status for volume [preUpgradeTestVol]
2017/07/12 23:31:52 Fetching full name for volume [preUpgradeTestVol] from VM [10.162.24.183]
2017/07/12 23:31:53 Full volume name: [preUpgradeTestVol@sharedVmfs-0]
2017/07/12 23:31:56 Reading from file [hello.txt] in container [PostUpgradeTestSuite.TestVolumeLifecycle_container_120652] on VM [10.162.24.183]
2017/07/12 23:31:56 docker exec -t PostUpgradeTestSuite.TestVolumeLifecycle_container_120652 /bin/sh -c 'cat /vol/hello.txt'
2017/07/12 23:31:57 Writing data to file [hello1.txt] in container [PostUpgradeTestSuite.TestVolumeLifecycle_container_120652] on VM [10.162.24.183]
2017/07/12 23:31:57 docker exec -t PostUpgradeTestSuite.TestVolumeLifecycle_container_120652 /bin/sh -c 'echo "Hello World Again!" > /vol/hello1.txt'
2017/07/12 23:31:57 Stopping container [PostUpgradeTestSuite.TestVolumeLifecycle_container_120652] on VM [10.162.24.183]
2017/07/12 23:32:09 Confirming detached status for volume [preUpgradeTestVol]
2017/07/12 23:32:09 Fetching full name for volume [preUpgradeTestVol] from VM [10.162.24.183]
2017/07/12 23:32:10 Full volume name: [preUpgradeTestVol@sharedVmfs-0]
2017/07/12 23:32:11 Starting container [PostUpgradeTestSuite.TestVolumeLifecycle_container_120652] on VM [10.162.24.183]
2017/07/12 23:32:13 Reading from file [hello1.txt] in container [PostUpgradeTestSuite.TestVolumeLifecycle_container_120652] on VM [10.162.24.183]
2017/07/12 23:32:13 docker exec -t PostUpgradeTestSuite.TestVolumeLifecycle_container_120652 /bin/sh -c 'cat /vol/hello1.txt'
2017/07/12 23:32:14 Removing container [PostUpgradeTestSuite.TestVolumeLifecycle_container_120652] on VM [10.162.24.183]
2017/07/12 23:32:15 Confirming detached status for volume [preUpgradeTestVol]
2017/07/12 23:32:15 Fetching full name for volume [preUpgradeTestVol] from VM [10.162.24.183]
2017/07/12 23:32:16 Full volume name: [preUpgradeTestVol@sharedVmfs-0]
2017/07/12 23:32:18 Destroying volume [preUpgradeTestVol]
2017/07/12 23:32:19 Creating volume [postUpgradeTestVol] on VM [10.162.24.183]
2017/07/12 23:32:21 Checking volume [postUpgradeTestVol] availability from VM [10.162.24.183]
2017/07/12 23:32:23 Attaching volume [postUpgradeTestVol] on VM [10.162.24.183]
2017/07/12 23:32:25 Confirming attached status for volume [postUpgradeTestVol]
2017/07/12 23:32:25 Fetching full name for volume [postUpgradeTestVol] from VM [10.162.24.183]
2017/07/12 23:32:25 Full volume name: [postUpgradeTestVol@sharedVmfs-0]
2017/07/12 23:32:28 Writing data to file [hello.txt] in container [PostUpgradeTestSuite.TestVolumeLifecycle_container_688292] on VM [10.162.24.183]
2017/07/12 23:32:28 docker exec -t PostUpgradeTestSuite.TestVolumeLifecycle_container_688292 /bin/sh -c 'echo "Hello World!" > /vol/hello.txt'
2017/07/12 23:32:29 Stopping container [PostUpgradeTestSuite.TestVolumeLifecycle_container_688292] on VM [10.162.24.183]
2017/07/12 23:32:41 Confirming detached status for volume [postUpgradeTestVol]
2017/07/12 23:32:41 Fetching full name for volume [postUpgradeTestVol] from VM [10.162.24.183]
2017/07/12 23:32:41 Full volume name: [postUpgradeTestVol@sharedVmfs-0]
2017/07/12 23:32:44 Starting container [PostUpgradeTestSuite.TestVolumeLifecycle_container_688292] on VM [10.162.24.183]
2017/07/12 23:32:46 Reading from file [hello.txt] in container [PostUpgradeTestSuite.TestVolumeLifecycle_container_688292] on VM [10.162.24.183]
2017/07/12 23:32:46 docker exec -t PostUpgradeTestSuite.TestVolumeLifecycle_container_688292 /bin/sh -c 'cat /vol/hello.txt'
2017/07/12 23:32:46 Removing container [PostUpgradeTestSuite.TestVolumeLifecycle_container_688292] on VM [10.162.24.183]
2017/07/12 23:32:48 Confirming detached status for volume [postUpgradeTestVol]
2017/07/12 23:32:48 Fetching full name for volume [postUpgradeTestVol] from VM [10.162.24.183]
2017/07/12 23:32:49 Full volume name: [postUpgradeTestVol@sharedVmfs-0]
2017/07/12 23:32:51 Destroying volume [postUpgradeTestVol]
OK: 1 passed
--- PASS: Test (70.06s)
PASS
ok  	github.com/vmware/docker-volume-vsphere/tests/e2e	70.062s
make: Leaving directory `/go/src/github.com/vmware/docker-volume-vsphere/client_plugin'
lipingx-m01:auth_r9.liping lipingx$ 

```


