### PR TITLE
Add compile support of new plugin/driver "vsphere-shared"

### DIFF
--- a/Commonvars.mk
+++ b/Commonvars.mk
@@ -54,7 +54,8 @@ EXTRA_TAG ?= -dev
 PLUGIN_TAG := $(VERSION_TAG)$(EXTRA_TAG)
 
 # plugin name - used as a base for full plugin name and container for extracting rootfs
-PLUGIN_NAME=$(DOCKER_HUB_REPO)/docker-volume-vsphere
+PLUGIN_NAME ?= $(DOCKER_HUB_REPO)/docker-volume-vsphere
+SHARED_PLUGIN_NAME = $(DOCKER_HUB_REPO)/vsphere-shared
 
 # Managed plugin alias name
 MANAGED_PLUGIN_NAME := "vsphere:latest"

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,11 @@ build-all: dockerized-build-ui
 	$(MAKE) --directory=client_plugin $@
 	$(MAKE) --directory=plugin_dockerbuild all
 
+# build shared plugin
+build-shared: dockerized-build-ui
+	$(MAKE) $(MAKEFLAGS) --directory=client_plugin dockerbuild-shared
+	$(MAKE) $(MAKEFLAGS) --directory=plugin_dockerbuild shared-all
+
 # clean inside docker run to avoid sudo make clean
 # dev builds are inside docker which creates folders
 # as root.

--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -37,6 +37,7 @@ SCRIPTS     := ../misc/scripts
 
 # Packaging variables
 PLUGNAME  := docker-volume-vsphere
+SHARED_PLUGNAME  := vsphere-shared
 GOPATH_PLUGNAME := $(PLUGNAME)/client_plugin
 GOPATH_ORG :=vmware
 MAINTAINERS := cna-storage@vmware.com
@@ -67,9 +68,11 @@ VMCI_SRC    := $(ESX_SRC)/vmci/*.h $(ESX_SRC)/vmci/vmci_client.c
 
 #  binaries location
 PLUGIN_BIN = $(BIN)/$(PLUGNAME)
+SHARED_PLUGIN_BIN = $(BIN)/$(SHARED_PLUGNAME)
 
 # all binaries for VMs - plugin and tests
 VM_BINS = $(PLUGIN_BIN) $(BIN)/$(VMDKOPS_TEST_MODULE).test $(BIN)/$(PLUGNAME).test
+SHARED_VM_BINS = $(SHARED_PLUGIN_BIN)
 
 VIBFILE := vmware-esx-vmdkops-$(PKG_VERSION).vib
 VIB_BIN := $(BIN)/$(VIBFILE)
@@ -89,10 +92,15 @@ VMDKOPS_TEST_MODULE := vmdkops
 VMDKOPS_MODULE_SRC = $(VMDKOPS_MODULE)/*.go $(VMCI_SRC)
 
 # All sources. We rebuild if anything changes here
-SRC = vmdk_plugin/main.go utils/log_formatter/log_formatter.go \
+COMMON_SRC = utils/log_formatter/log_formatter.go \
 	utils/refcount/refcnt.go utils/plugin_server/plugin_server.go \
-	utils/fs/fs.go utils/config/config.go utils/plugin_utils/plugin_utils.go\
+	utils/fs/fs.go utils/config/config.go utils/plugin_utils/plugin_utils.go \
+	drivers/utils/pluginDriver.go
+
+VMDK_PLUGIN_SRC = vmdk_plugin/main.go \
 	drivers/photon/photon_driver.go drivers/vmdk/vmdk_driver.go
+
+SHARED_PLUGIN_SRC = shared_plugin/main.go drivers/shared/shared_driver.go
 
 TEST_SRC = ../tests/utils/inputparams/testparams.go
 
@@ -104,7 +112,7 @@ define log_target
 endef
 
 # The default build is using a prebuilt docker image that has all dependencies.
-.PHONY: dockerbuild build-all
+.PHONY: dockerbuild build-all dockerbuild-shared
 build-all: dockerbuild package
 
 dockerbuild:
@@ -112,6 +120,9 @@ dockerbuild:
 	$(BUILD) pylint
 	$(BUILD) build
 
+dockerbuild-shared:
+	@$(CHECK) dockerbuild
+	$(BUILD) build-shared
 
 # The non docker build.
 .PHONY: build pylint
@@ -119,6 +130,7 @@ build: prereqs .code_verify $(VM_BINS)
 	$(MAKE)  --directory=$(ESX_SRC) $@
 pylint:
 	$(MAKE)  --directory=$(ESX_SRC) $@
+build-shared: prereqs .code_verify $(SHARED_VM_BINS)
 
 .PHONY: gvt
 gvt:
@@ -132,15 +144,19 @@ documentation:
 prereqs:
 	@$(CHECK)
 
-$(PLUGIN_BIN): $(SRC) $(VMDKOPS_MODULE_SRC)
+$(PLUGIN_BIN): $(COMMON_SRC) $(VMDK_PLUGIN_SRC) $(VMDKOPS_MODULE_SRC)
 	@-mkdir -p $(BIN) && chmod a+w $(BIN)
 	$(GO) build --ldflags '-extldflags "-static"' -o $(PLUGIN_BIN) $(PLUGIN)/vmdk_plugin
 
 $(BIN)/$(VMDKOPS_TEST_MODULE).test: $(VMDKOPS_MODULE_SRC) $(TEST_SRC) $(VMDKOPS_MODULE)/*_test.go
 	$(GO) test -c -o $@ $(PLUGIN)/$(VMDKOPS_MODULE) -cover
 
-$(BIN)/$(PLUGNAME).test: $(SRC) $(TEST_SRC) ./vmdk_plugin/*_test.go
+$(BIN)/$(PLUGNAME).test: $(COMMON_SRC) $(VMDK_PLUGIN_SRC) $(TEST_SRC) ./vmdk_plugin/*_test.go
 	$(GO) test -c -o $@ $(PLUGIN)/vmdk_plugin -cover
+
+$(SHARED_PLUGIN_BIN): $(COMMON_SRC) $(SHARED_PLUGIN_SRC)
+	@-mkdir -p $(BIN) && chmod a+w $(BIN)
+	$(GO) build --ldflags '-extldflags "-static"' -o $(SHARED_PLUGIN_BIN) $(PLUGIN)/shared_plugin
 
 .PHONY: clean
 clean:
@@ -153,7 +169,8 @@ clean-as-root: pkg-post
 
 # GO Code quality checks.
 
-DIRS_TO_VERIFY := vmdk_plugin utils/fs utils/config drivers/photon drivers/vmdk drivers/vmdk/vmdkops ../tests/e2e \
+DIRS_TO_VERIFY := vmdk_plugin shared_plugin \
+	utils/fs utils/config drivers/photon drivers/vmdk drivers/shared drivers/vmdk/vmdkops ../tests/e2e \
 	../tests/utils/dockercli ../tests/utils/inputparams ../tests/utils/verification ../tests/constants/admincli \
 	../tests/constants/dockercli ../tests/utils/ssh ../tests/utils/misc ../tests/constants/vm
 

--- a/client_plugin/drivers/shared/shared_driver.go
+++ b/client_plugin/drivers/shared/shared_driver.go
@@ -1,0 +1,136 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+//
+// VMWare vSphere Shared Docker Data Volume plugin version.
+//
+// Provide support for --driver=shared in Docker, when Docker VM is running under ESX.
+//
+// Serves requests from Docker Engine related to vsphere shared volume operations.
+///
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/go-plugins-helpers/volume"
+	"github.com/vmware/docker-volume-vsphere/client_plugin/drivers/utils"
+	"github.com/vmware/docker-volume-vsphere/client_plugin/utils/config"
+	"github.com/vmware/docker-volume-vsphere/client_plugin/utils/refcount"
+)
+
+const (
+	version = "vSphere Shared Volume Driver v0.2"
+)
+
+// VolumeDriver - vsphere shared plugin volume driver struct
+type VolumeDriver struct {
+	utils.PluginDriver
+}
+
+// NewVolumeDriver creates driver instance
+func NewVolumeDriver(cfg config.Config, mountDir string) *VolumeDriver {
+	var d VolumeDriver
+
+	d.RefCounts = refcount.NewRefCountsMap()
+	d.RefCounts.Init(&d, mountDir, cfg.Driver)
+	d.MountIDtoName = make(map[string]string)
+	d.MountRoot = mountDir
+
+	log.WithFields(log.Fields{
+		"version": version,
+	}).Info("vSphere shared plugin started ")
+
+	return &d
+}
+
+// Get info about a single volume
+func (d *VolumeDriver) Get(r volume.Request) volume.Response {
+	log.Errorf("VolumeDriver Get to be implemented")
+	return volume.Response{Err: ""}
+}
+
+// List volumes known to the driver
+func (d *VolumeDriver) List(r volume.Request) volume.Response {
+	log.Errorf("VolumeDriver List to be implemented")
+	return volume.Response{Err: ""}
+}
+
+// GetVolume - return volume meta-data.
+func (d *VolumeDriver) GetVolume(name string) (map[string]interface{}, error) {
+	var statusMap map[string]interface{}
+	statusMap = make(map[string]interface{})
+	log.Errorf("VolumeDriver GetVolume to be implemented")
+	return statusMap, nil
+}
+
+// MountVolume - Request attach and them mounts the volume.
+func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isReadOnly bool, skipAttach bool) (string, error) {
+	log.Errorf("VolumeDriver MountVolume to be implemented")
+	mountpoint := d.GetMountPoint(name)
+	return mountpoint, nil
+}
+
+// UnmountVolume - Unmounts the volume and then requests detach
+func (d *VolumeDriver) UnmountVolume(name string) error {
+	log.Errorf("VolumeDriver UnmountVolume to be implemented")
+	return nil
+}
+
+// Create - create a volume.
+func (d *VolumeDriver) Create(r volume.Request) volume.Response {
+	log.Errorf("VolumeDriver Create to be implemented")
+	return volume.Response{Err: ""}
+}
+
+// Remove - removes individual volume. Docker would call it only if is not using it anymore
+func (d *VolumeDriver) Remove(r volume.Request) volume.Response {
+	log.WithFields(log.Fields{"name": r.Name}).Info("Removing volume ")
+
+	log.Errorf("VolumeDriver Remove to be implemented")
+	return volume.Response{Err: ""}
+}
+
+// Path - give docker a reminder of the volume mount path
+func (d *VolumeDriver) Path(r volume.Request) volume.Response {
+	return volume.Response{Mountpoint: d.GetMountPoint(r.Name)}
+}
+
+// Mount - Provide a volume to docker container - called once per container start.
+// We need to keep refcount and unmount on refcount drop to 0
+//
+// The serialization of operations per volume is assured by the volume/store
+// of the docker daemon.
+// As long as the refCountsMap is protected is unnecessary to do any locking
+// at this level during create/mount/umount/remove.
+//
+func (d *VolumeDriver) Mount(r volume.MountRequest) volume.Response {
+	log.WithFields(log.Fields{"name": r.Name}).Info("Mounting volume ")
+
+	log.Errorf("VolumeDriver Mount to be implemented")
+	return volume.Response{Err: ""}
+}
+
+// Unmount request from Docker. If mount refcount is drop to 0.
+func (d *VolumeDriver) Unmount(r volume.UnmountRequest) volume.Response {
+	log.WithFields(log.Fields{"name": r.Name}).Info("Unmounting Volume ")
+
+	log.Errorf("VolumeDriver Unmount to be implemented")
+	return volume.Response{Err: ""}
+}
+
+// Capabilities - Report plugin scope to Docker
+func (d *VolumeDriver) Capabilities(r volume.Request) volume.Response {
+	return volume.Response{Capabilities: volume.Capability{Scope: "global"}}
+}

--- a/client_plugin/drivers/utils/pluginDriver.go
+++ b/client_plugin/drivers/utils/pluginDriver.go
@@ -1,0 +1,63 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+//
+// Common Utility for driver interface.
+//
+
+import (
+	"github.com/vmware/docker-volume-vsphere/client_plugin/utils/refcount"
+	"path/filepath"
+)
+
+// PluginDriver - helper struct to hold common utilities for driver interface
+type PluginDriver struct {
+	RefCounts     *refcount.RefCountsMap
+	MountIDtoName map[string]string // map of mountID -> full volume name
+	MountRoot     string
+}
+
+// GetMountPoint returns the mount point based on MountRoot and volume name
+func (u *PluginDriver) GetMountPoint(volName string) string {
+	return filepath.Join(u.MountRoot, volName)
+}
+
+// In following three operations on refcount, if refcount
+// map hasn't been initialized, return 1 to prevent detach and remove.
+
+// Return the number of references for the given volume
+func (u *PluginDriver) GetRefCount(vol string) uint {
+	if u.RefCounts.IsInitialized() != true {
+		return 1
+	}
+	return u.RefCounts.GetCount(vol)
+}
+
+// Increment the reference count for the given volume
+func (u *PluginDriver) IncrRefCount(vol string) uint {
+	if u.RefCounts.IsInitialized() != true {
+		return 1
+	}
+	return u.RefCounts.Incr(vol)
+}
+
+// Decrement the reference count for the given volume
+func (u *PluginDriver) DecrRefCount(vol string) (uint, error) {
+	if u.RefCounts.IsInitialized() != true {
+		return 1, nil
+	}
+	return u.RefCounts.Decr(vol)
+}

--- a/client_plugin/shared_plugin/main.go
+++ b/client_plugin/shared_plugin/main.go
@@ -14,7 +14,7 @@
 
 package main
 
-// A VMDK Docker Data Volume plugin - main
+// A vSphere Shared Docker Data Volume plugin - main
 
 import (
 	"os"
@@ -22,8 +22,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/go-plugins-helpers/volume"
-	"github.com/vmware/docker-volume-vsphere/client_plugin/drivers/photon"
-	"github.com/vmware/docker-volume-vsphere/client_plugin/drivers/vmdk"
+	"github.com/vmware/docker-volume-vsphere/client_plugin/drivers/shared"
 	"github.com/vmware/docker-volume-vsphere/client_plugin/utils/config"
 	"github.com/vmware/docker-volume-vsphere/client_plugin/utils/plugin_server"
 )
@@ -33,23 +32,16 @@ import (
 func main() {
 	var driver volume.Driver
 
-	cfg, err := config.InitConfig(config.DefaultVMDKPluginConfigPath, config.DefaultVMDKPluginLogPath,
-		config.VSphereDriver, config.VSphereDriver)
+	cfg, err := config.InitConfig(config.DefaultSharedPluginConfigPath, config.DefaultSharedPluginLogPath,
+		config.SharedDriver, "")
 	if err != nil {
-		log.Warning("Failed to initialize config variables for vmdk plugin")
+		log.Warning("Failed to initialize config variables for shared plugin")
 		os.Exit(1)
 	}
 
-	switch {
-	case cfg.Driver == config.PhotonDriver:
-		driver = photon.NewVolumeDriver(cfg, config.MountRoot)
-	case cfg.Driver == config.VSphereDriver:
-		driver = vmdk.NewVolumeDriver(cfg, config.MountRoot)
-	case cfg.Driver == config.VMDKDriver:
-		log.Warning("Using deprecated \"vmdk\" driver, use \"vsphere\" driver instead - continuing...")
-		cfg.Driver = config.VSphereDriver
-		driver = vmdk.NewVolumeDriver(cfg, config.MountRoot)
-	default:
+	if cfg.Driver == config.SharedDriver {
+		driver = shared.NewVolumeDriver(cfg, config.MountRoot)
+	} else {
 		log.Warning("Unknown driver or invalid/missing driver options, exiting - ", cfg.Driver)
 		os.Exit(1)
 	}

--- a/client_plugin/utils/config/config.go
+++ b/client_plugin/utils/config/config.go
@@ -36,6 +36,8 @@ const (
 	VMDKDriver = "vmdk"
 	// VSphereDriver is the driver to handle single attach vmdk-based in vSphere/vCenter 6.0+
 	VSphereDriver = "vsphere"
+	// SharedDriver is a shared plugin driver
+	SharedDriver = "shared"
 
 	// DefaultPort is the default ESX service port.
 	DefaultPort = 1019

--- a/client_plugin/utils/config/config_linux.go
+++ b/client_plugin/utils/config/config_linux.go
@@ -17,10 +17,14 @@ package config
 const (
 	// Default paths - used in log init in main() and test:
 
-	// DefaultConfigPath is the default location of Log configuration file
-	DefaultConfigPath = "/etc/docker-volume-vsphere.conf"
-	// DefaultLogPath is the default location of log (trace) file
-	DefaultLogPath = "/var/log/docker-volume-vsphere.log"
+	// DefaultVMDKPluginConfigPath is the default location of Log configuration file
+	DefaultVMDKPluginConfigPath = "/etc/docker-volume-vsphere.conf"
+	// DefaultVMDKPluginLogPath is the default location of log (trace) file
+	DefaultVMDKPluginLogPath = "/var/log/docker-volume-vsphere.log"
+	// DefaultSharedPluginConfigPath is the default location of Log configuration file for shared plugin
+	DefaultSharedPluginConfigPath = "/etc/vsphere-shared.conf"
+	// DefaultSharedPluginLogPath is the default location of log (trace) file for shared plugin
+	DefaultSharedPluginLogPath = "/var/log/vsphere-shared.log"
 
 	// MountRoot is the path where VMDK and photon volumes are mounted
 	MountRoot = "/mnt/vmdk"

--- a/client_plugin/utils/config/config_windows.go
+++ b/client_plugin/utils/config/config_windows.go
@@ -20,10 +20,10 @@ import (
 )
 
 var (
-	// DefaultConfigPath is the default location of the config file.
-	DefaultConfigPath = filepath.Join(os.Getenv("PROGRAMDATA"), "docker-volume-vsphere", "docker-volume-vsphere.conf")
-	// DefaultLogPath is the default location of the log (trace) file.
-	DefaultLogPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "docker-volume-vsphere", "logs", "docker-volume-vsphere.log")
+	// DefaultVMDKPluginConfigPath is the default location of the vmdk plugin config file.
+	DefaultVMDKPluginConfigPath = filepath.Join(os.Getenv("PROGRAMDATA"), "docker-volume-vsphere", "docker-volume-vsphere.conf")
+	// DefaultVMDKPluginLogPath is the default location of the vmdk plugin log (trace) file.
+	DefaultVMDKPluginLogPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "docker-volume-vsphere", "logs", "docker-volume-vsphere.log")
 
 	// VMDK volumes are mounted here
 	MountRoot = filepath.Join(os.Getenv("LOCALAPPDATA"), "docker-volume-vsphere", "mounts")

--- a/client_plugin/vmdk_plugin/sanity_test.go
+++ b/client_plugin/vmdk_plugin/sanity_test.go
@@ -67,8 +67,8 @@ type testClient struct {
 // so do not expect ALL inits from other tests (if any) to compete by now.
 func init() {
 	logLevel := flag.String("log_level", "debug", "Logging Level")
-	logFile := flag.String("log_file", config.DefaultLogPath, "Log file path")
-	configFile := flag.String("config", config.DefaultConfigPath, "Configuration file path")
+	logFile := flag.String("log_file", config.DefaultVMDKPluginLogPath, "Log file path")
+	configFile := flag.String("config", config.DefaultVMDKPluginConfigPath, "Configuration file path")
 
 	flag.BoolVar(&removeContainers, "rm", true, "rm container after run")
 	flag.StringVar(&driverName, "d", "vsphere:latest", "Driver name. We refcount volumes on this driver")
@@ -79,7 +79,7 @@ func init() {
 	logInfo := &config.LogInfo{
 		LogLevel:       logLevel,
 		LogFile:        logFile,
-		DefaultLogFile: config.DefaultLogPath,
+		DefaultLogFile: config.DefaultVMDKPluginLogPath,
 		ConfigFile:     configFile,
 	}
 	usingConfigFileDefaults := config.LogInit(logInfo)

--- a/plugin_dockerbuild/.gitignore
+++ b/plugin_dockerbuild/.gitignore
@@ -1,2 +1,5 @@
 docker-volume-vsphere
+vsphere-shared
+Dockerfile
+config.json
 rootfs/

--- a/plugin_dockerbuild/Dockerfile-template
+++ b/plugin_dockerbuild/Dockerfile-template
@@ -11,5 +11,5 @@ FROM alpine:3.5
 
 RUN apk update ; apk add e2fsprogs xfsprogs
 RUN mkdir -p /mnt/vmdk
-COPY docker-volume-vsphere /usr/bin
-CMD ["/usr/bin/docker-volume-vsphere"]
+COPY %BINARY% /usr/bin
+CMD ["/usr/bin/%BINARY%"]

--- a/plugin_dockerbuild/Makefile
+++ b/plugin_dockerbuild/Makefile
@@ -30,7 +30,8 @@
 -include ../Commonvars.mk
 
 # Binaries we want to pick up from the actual build
-BINARY := docker-volume-vsphere
+BINARY ?= docker-volume-vsphere
+SHARED_BINARY := vsphere-shared
 
 # Tmp docker image used to construct rootfs + our binaries
 TMP_IMAGE = $(PLUGIN_NAME):rootfs
@@ -41,25 +42,34 @@ TMP_LOC := /tmp/plugin
 
 # default target
 all: info plugin push
+shared-all: shared-info shared-plugin shared-push
 
 # unconditionally run those
-.PHONY: all clean info plugin
+.PHONY: all clean info plugin shared-all shared-info shared-plugin shared-push
 
 info:
 	@echo Using the following config:
 	@echo DOCKER_HUB_REPO $(DOCKER_HUB_REPO) EXTRA_TAG $(EXTRA_TAG) VERSION_TAG $(VERSION_TAG)
 	@echo PLUGIN_NAME $(PLUGIN_NAME):$(PLUGIN_TAG)
+shared-info:
+	PLUGIN_NAME=$(SHARED_PLUGIN_NAME) $(MAKE) info
 
 clean:
 	@echo "=== Cleaning work files, images and plugin(s)..."
 	rm -rf $(TMP_LOC)
 	rm -f $(BINARY)
+	rm -f Dockerfile
+	rm -f config.json
 	-docker plugin rm $(PLUGIN_NAME):$(PLUGIN_TAG) -f
 	-docker rm -vf $(TMP_CONTAINER)
 	-docker rmi $(TMP_IMAGE)
+shared-clean:
+	PLUGIN_NAME=$(SHARED_PLUGIN_NAME) BINARY=$(SHARED_BINARY) $(MAKE) clean
 
 plugin: clean
 	@echo "== building Docker image, unpacking to ./rootfs and creating plugin..."
+	sed "s/\%BINARY\%/$(BINARY)/g" Dockerfile-template > Dockerfile
+	sed 's/\%BINARY\%/$(BINARY)/g' config.json-template > config.json
 	cp $(BIN)/$(BINARY) .
 	docker build -q -t $(TMP_IMAGE) .
 	docker create --name $(TMP_CONTAINER) $(TMP_IMAGE)
@@ -68,8 +78,12 @@ plugin: clean
 	cp config.json $(BINARY) $(TMP_LOC)
 	@echo "-- Creating  plugin $(PLUGIN_NAME):$(PLUGIN_TAG) ..."
 	docker plugin create $(PLUGIN_NAME):$(PLUGIN_TAG) $(TMP_LOC)
+shared-plugin: shared-clean
+	PLUGIN_NAME=$(SHARED_PLUGIN_NAME) BINARY=$(SHARED_BINARY) $(MAKE) plugin
 
 push:
 	@echo Pushing $(PLUGIN_NAME):$(PLUGIN_TAG)  to dockerhub.io...
 	@docker plugin push $(PLUGIN_NAME):$(PLUGIN_TAG) || \
 			echo 'Please make sure the plugin is built ("make clean plugin") and you have logged in to docker hub first ("docker login -u $(DOCKER_HUB_REPO)")'
+shared-push:
+	PLUGIN_NAME=$(SHARED_PLUGIN_NAME) $(MAKE) push

--- a/plugin_dockerbuild/config.json-template
+++ b/plugin_dockerbuild/config.json-template
@@ -1,8 +1,8 @@
 {
 	"Description": "VMWare vSphere Docker Volume plugin",
 	"Documentation": "http://vmware.github.io/docker-volume-vsphere/documentation",
-	"Entrypoint": ["/usr/bin/docker-volume-vsphere",
-					"--config", "/etc/docker-volume-vsphere.conf"
+	"Entrypoint": ["/usr/bin/%BINARY%",
+					"--config", "/etc/%BINARY%.conf"
 	],
 	"PropagatedMount": "/mnt/vmdk",
 	"Mounts": [
@@ -21,7 +21,7 @@
 			"Options": ["rbind"]
 		},
 		{
-			"Description" : "Location to look for config file (/etc/docker-volume-vsphere.conf)",
+			"Description" : "Location to look for config file (/etc/%BINARY%.conf)",
 			"Source" : "/etc",
 			"Destination" : "/etc",
 			"Type": "bind",
@@ -46,19 +46,18 @@
 		"AllowAllDevices": true,
 		"Capabilities": ["CAP_SYS_ADMIN"],
 		"Devices": null
-
 	},
 	"Env": [ {
-      "name": "VDVS_LOG_LEVEL",
-      "description": "Log level - info, warn, error or debug",
-      "value": "info",
-      "Settable": [ "value"]
+		"name": "VDVS_LOG_LEVEL",
+		"description": "Log level - info, warn, error or debug",
+		"value": "info",
+		"Settable": [ "value"]
 	},
 	{
-      "name": "VDVS_TEST_PROTOCOL_VERSION",
-      "description": "Client protocol version used in test",
-      "value": "",
-      "Settable": [ "value"]
+		"name": "VDVS_TEST_PROTOCOL_VERSION",
+		"description": "Client protocol version used in test",
+		"value": "",
+		"Settable": [ "value"]
 	}
 	]
 }


### PR DESCRIPTION
New plugin: client_plugin/shared_plugin
New driver: client_plugin/drivers/shared
To build the new plugin: make shared-all
Plugin is pushed into: [DOCKER_HUB_REPO]/vsphere-shared:[VERSION_TAG][EXTRA_TAG]
Functions in the new shared_driver are to be implemented.

There are a few layout change in drivers directory.
Common utility functions are grouped under drivers/commonUtilDriver.

The new plugin shares the same plugin_dockerbuild Makefile with original vmdk plugin.
Thus the Dockerfile and config.json are replaced by Dockerfile-template and config.json-template in order to be generic.


Testing result:
test-e2e runalways passed.
Skipped local run of test-e2e runonce due to testbed requirements not ideal, and will use CI for final check.