### PR TITLE
Updates NpipePluginServer implementation

### DIFF
--- a/client_plugin/drivers/vmdk/vmdk_driver.go
+++ b/client_plugin/drivers/vmdk/vmdk_driver.go
@@ -114,9 +114,8 @@ func (d *VolumeDriver) List(r volume.Request) volume.Response {
 		// volname@Local2, which causes the `docker volume ls` command to hang.
 		// So, we explicitly convert volume names using the platform specific
 		// normalizeVolumeName func.
-		name := normalizeVolumeName(vol.Name)
-		mountpoint := d.GetMountPoint(vol.Name)
-		responseVol := volume.Volume{Name: name, Mountpoint: mountpoint}
+		responseVol := volume.Volume{Name: normalizeVolumeName(vol.Name),
+			Mountpoint: d.GetMountPoint(vol.Name)}
 		responseVolumes = append(responseVolumes, &responseVol)
 	}
 	return volume.Response{Volumes: responseVolumes}

--- a/client_plugin/drivers/vmdk/vmdk_driver_linux.go
+++ b/client_plugin/drivers/vmdk/vmdk_driver_linux.go
@@ -1,0 +1,24 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vmdk
+
+//
+// Supporting functions for the VMware vSphere Docker Volume plugin on Linux.
+//
+
+// normalizeVolumeName returns the volume name as-is.
+func normalizeVolumeName(name string) string {
+	return name
+}

--- a/client_plugin/drivers/vmdk/vmdk_driver_windows.go
+++ b/client_plugin/drivers/vmdk/vmdk_driver_windows.go
@@ -1,0 +1,30 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vmdk
+
+//
+// Supporting functions for the VMware vSphere Docker Volume plugin on Windows.
+//
+
+import "strings"
+
+// normalizeVolumeName returns the volume name in its lower-case form.
+// Paths on Windows are case-insensitive, so Docker explicitly converts volume
+// names to lower-case. The VMDK Ops service returns names like volname@Local2
+// which need to be converted to lower-case before sending it in the API
+// response, and we use this func for that conversion.
+func normalizeVolumeName(name string) string {
+	return strings.ToLower(name)
+}

--- a/client_plugin/utils/fs/fs_windows.go
+++ b/client_plugin/utils/fs/fs_windows.go
@@ -146,10 +146,10 @@ func Mkfs(fstype string, label string, volDev *VolumeDevSpec) error {
 	}
 
 	script := fmt.Sprintf(formatDiskScript, diskNum, diskNum, diskNum, fstype, label)
-	out, err := exec.Command(powershell, script).Output()
+	out, err := exec.Command(powershell, script).CombinedOutput()
 	if err != nil {
 		log.WithFields(log.Fields{"fstype": fstype, "label": label, "volDev": *volDev,
-			"diskNum": diskNum, "err": err}).Error("Format disk script failed ")
+			"diskNum": diskNum, "err": err, "out": string(out)}).Error("Format disk script failed ")
 		return err
 	} else {
 		log.WithFields(log.Fields{"fstype": fstype, "label": label, "volDev": *volDev,
@@ -174,10 +174,10 @@ func Unmount(mountpoint string) error {
 // failing to identify the disk.
 func getDiskNum(volDev *VolumeDevSpec) (string, error) {
 	script := fmt.Sprintf(scsiAddrToDiskNumScript, volDev.ControllerPciSlotNumber, volDev.Unit)
-	out, err := exec.Command(powershell, script).Output()
+	out, err := exec.Command(powershell, script).CombinedOutput()
 	if err != nil {
 		log.WithFields(log.Fields{"volDev": *volDev,
-			"err": err}).Error("Failed to execute the disk mapping script ")
+			"err": err, "out": string(out)}).Error("Failed to execute the disk mapping script ")
 		return "", err
 	}
 	log.WithFields(log.Fields{"volDev": *volDev,

--- a/client_plugin/utils/plugin_server/plugin_server.go
+++ b/client_plugin/utils/plugin_server/plugin_server.go
@@ -15,21 +15,12 @@
 package plugin_server
 
 import (
-	log "github.com/Sirupsen/logrus"
-	"github.com/docker/go-plugins-helpers/volume"
 	"os"
 	"os/signal"
 	"syscall"
-)
 
-const (
-	// Docker plugin handshake endpoint.
-	// Also see https://docs.docker.com/engine/extend/plugin_api/#handshake-api
-	pluginActivatePath = "/Plugin.Activate"
-
-	// Docker volume plugin endpoints.
-	// Also see https://docs.docker.com/engine/extend/plugins_volume/#volume-plugin-protocol
-	volumeDriverCreatePath = "/VolumeDriver.Create"
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/go-plugins-helpers/volume"
 )
 
 // PluginServer responds to HTTP requests from Docker.


### PR DESCRIPTION
## Description
This PR updates the `NpipePluginServer` to use the Docker provided Volume handler for servicing API requests. The `Get` and `List` volume APIs will be fully functional on Windows with this PR.

**Caveat:** Paths are case-insensitive on Windows, so Docker only supports lower case volume names. To handle this, we use the platform specific `normalizeVolumeName` function in the `vmdk_driver`.

* Updates `NpipePluginServer` impl to use Docker Volume handler.
* Updates `NpipePluginServer` unit test.
* Adds handling for case-insensitivity in volume names on Windows.
* Updates logging in the `fs` module.

## Windows Output
The following snippet comes from the Windows `PowerShell`.
```
PS C:\Users\Administrator> docker volume create --driver=vsphere new-VOLUME
new-volume

PS C:\Users\Administrator> docker volume inspect new-volume
[
    {
        "Driver": "vsphere",
        "Labels": {},
        "Mountpoint": "C:\\Users\\Administrator\\AppData\\Local\\docker-volume-vsphere\\mounts\\new-volume",
        "Name": "new-volume",
        "Options": {},
        "Scope": "global",
        "Status": {
            "access": "read-write",
            "attach-as": "independent_persistent",
            "capacity": {
                "allocated": "12MB",
                "size": "100MB"
            },
            "clone-from": "None",
            "created": "Sat Jul 15 04:04:45 2017",
            "created by VM": "win2016-v5-Venil",
            "datastore": "Local2",
            "diskformat": "thin",
            "fstype": "ntfs",
            "status": "detached"
        }
    }
]

PS C:\Users\Administrator> docker volume ls
DRIVER              VOLUME NAME
vsphere             new-volume@local2
```