### PR TITLE
Reduce E2E test time

### DIFF
--- a/tests/constants/esx/govc.go
+++ b/tests/constants/esx/govc.go
@@ -25,7 +25,7 @@ const (
 	// VMInfoByIP refers to govc query to grab VM IP from VM info object
 	VMInfoByIP = VMInfo + "-vm.ip="
 
-	// VMInfoByUuid refers to govc query to grab VM IP from VM info object
+	// VMInfoByUuid refers to govc query to fetch VM infor using the VM UUID
 	VMInfoByUuid = VMInfo + "-waitip=true -vm.uuid="
 
 	// DatastoreInfo get datastore info from govc

--- a/tests/constants/esx/govc.go
+++ b/tests/constants/esx/govc.go
@@ -25,6 +25,9 @@ const (
 	// VMInfoByIP refers to govc query to grab VM IP from VM info object
 	VMInfoByIP = VMInfo + "-vm.ip="
 
+	// VMInfoByUuid refers to govc query to grab VM IP from VM info object
+	VMInfoByUuid = VMInfo + "-waitip=true -vm.uuid="
+
 	// DatastoreInfo get datastore info from govc
 	DatastoreInfo = govcCmd + "datastore.info "
 
@@ -41,6 +44,9 @@ const (
 
 	// VMName JSON object key refers VM name
 	VMName = govcResponseRoot + ".Name"
+
+	// VMUuid JSON object key refers VM name
+	VMUuid = govcResponseRoot + ".Config.Uuid"
 
 	// VMPowerState JSON object key refers VM power state
 	VMPowerState = govcResponseRoot + ".Runtime.PowerState"

--- a/tests/e2e/basic_test.go
+++ b/tests/e2e/basic_test.go
@@ -80,7 +80,7 @@ var _ = Suite(&BasicTestSuite{})
 func (s *BasicTestSuite) TestVolumeLifecycle(c *C) {
 	misc.LogTestStart(c.TestName())
 
-	for _, host := range s.config.DockerHosts {
+	for idx, host := range s.config.DockerHosts {
 		out, err := dockercli.CreateVolume(host, s.volName1)
 		c.Assert(err, IsNil, Commentf(out))
 
@@ -90,7 +90,7 @@ func (s *BasicTestSuite) TestVolumeLifecycle(c *C) {
 		out, err = dockercli.AttachVolume(host, s.volName1, s.containerName)
 		c.Assert(err, IsNil, Commentf(out))
 
-		status := verification.VerifyAttachedStatus(s.volName1, host, s.esx)
+		status := verification.VerifyAttachedStatus(s.volName1, host, s.esx, s.config.DockerHostNames[idx])
 		c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volName1))
 
 		out, err = dockercli.DeleteVolume(host, s.volName1)

--- a/tests/e2e/defaultvmgroup_test.go
+++ b/tests/e2e/defaultvmgroup_test.go
@@ -200,7 +200,7 @@ func (s *DefaultVMGroupTestSuite) TestMoveVMBetweenVmgroup1(c *C) {
 	out, err = dockercli.AttachVolume(s.config.DockerHosts[0], s.volumeNames[0], containerName)
 	c.Assert(err, IsNil, Commentf(out))
 
-	status := verification.VerifyAttachedStatus(s.volumeNames[0], s.config.DockerHosts[0], s.config.EsxHost)
+	status := verification.VerifyAttachedStatus(s.volumeNames[0], s.config.DockerHosts[0], s.config.EsxHost, s.config.DockerHostNames[0])
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeNames[0]))
 
 	// Create a vmgroup - operation should fail
@@ -273,7 +273,7 @@ func (s *DefaultVMGroupTestSuite) TestMoveVMBetweenVmgroup2(c *C) {
 	out, err = dockercli.AttachVolume(s.config.DockerHosts[0], s.volumeNames[0], containerName)
 	c.Assert(err, IsNil, Commentf(out))
 
-	status := verification.VerifyAttachedStatus(s.volumeNames[0], s.config.DockerHosts[0], s.config.EsxHost)
+	status := verification.VerifyAttachedStatus(s.volumeNames[0], s.config.DockerHosts[0], s.config.EsxHost, s.config.DockerHostNames[0])
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeNames[0]))
 
 	// Create a vmgroup - operation should fail

--- a/tests/e2e/post_upgrade_test.go
+++ b/tests/e2e/post_upgrade_test.go
@@ -103,7 +103,7 @@ func (s *PostUpgradeTestSuite) TestVolumeLifecycle(c *C) {
 	out, err := dockercli.AttachVolume(s.vm1, s.volName1, s.containerName1)
 	c.Assert(err, IsNil, Commentf(out))
 
-	status = verification.VerifyAttachedStatus(s.volName1, s.vm1, s.esx)
+	status = verification.VerifyAttachedStatus(s.volName1, s.vm1, s.esx, s.vm1Name)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volName1))
 
 	out, err = dockercli.ReadFromContainer(s.vm1, s.containerName1, volPath, testFile)
@@ -146,7 +146,7 @@ func (s *PostUpgradeTestSuite) TestVolumeLifecycle(c *C) {
 	out, err = dockercli.AttachVolume(s.vm1, s.volName2, s.containerName2)
 	c.Assert(err, IsNil, Commentf(out))
 
-	status = verification.VerifyAttachedStatus(s.volName2, s.vm1, s.esx)
+	status = verification.VerifyAttachedStatus(s.volName2, s.vm1, s.esx, s.vm1Name)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volName2))
 
 	out, err = dockercli.WriteToContainer(s.vm1, s.containerName2, volPath, testFile, testData)

--- a/tests/e2e/pre_upgrade_test.go
+++ b/tests/e2e/pre_upgrade_test.go
@@ -88,7 +88,7 @@ func (s *PreUpgradeTestSuite) TestVolumeLifecycle(c *C) {
 	out, err = dockercli.AttachVolume(s.vm1, s.volName1, s.containerName)
 	c.Assert(err, IsNil, Commentf(out))
 
-	status := verification.VerifyAttachedStatus(s.volName1, s.vm1, s.esx)
+	status := verification.VerifyAttachedStatus(s.volName1, s.vm1, s.esx, s.vm1Name)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volName1))
 
 	out, err = dockercli.WriteToContainer(s.vm1, s.containerName, volPath, testFile, testData)
@@ -113,7 +113,7 @@ func (s *PreUpgradeTestSuite) TestVolumeLifecycle(c *C) {
 	c.Assert(out, Equals, testData, Commentf("Data read from volume[%s] does not match written previously[%s]",
 		out, testData))
 
-	status = verification.VerifyAttachedStatus(s.volName1, s.vm1, s.esx)
+	status = verification.VerifyAttachedStatus(s.volName1, s.vm1, s.esx, s.vm1Name)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volName1))
 
 	out, err = dockercli.RemoveContainer(s.vm1, s.containerName)

--- a/tests/e2e/refcount_test.go
+++ b/tests/e2e/refcount_test.go
@@ -100,7 +100,7 @@ func (s *RefcountTestSuite) TestRefcountingRecovery(c *C) {
 
 		s.containerNameList = append(s.containerNameList, cName)
 
-		status := verification.VerifyAttachedStatus(s.volumeName, s.config.DockerHosts[0], s.config.EsxHost)
+		status := verification.VerifyAttachedStatus(s.volumeName, s.config.DockerHosts[0], s.config.EsxHost, s.config.DockerHostNames[0])
 		c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 	}
 

--- a/tests/e2e/restart_test.go
+++ b/tests/e2e/restart_test.go
@@ -121,7 +121,7 @@ func (s *RestartTestData) TestVolumeDetached(c *C) {
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 2. Verify attached status
-	status := verification.VerifyAttachedStatus(s.volumeName, s.config.DockerHosts[1], s.config.EsxHost)
+	status := verification.VerifyAttachedStatus(s.volumeName, s.config.DockerHosts[1], s.config.EsxHost, s.config.DockerHostNames[1])
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	// 3. Restart docker
@@ -174,7 +174,7 @@ func (s *RestartTestData) TestPluginKill(c *C) {
 	c.Assert(err, IsNil, Commentf(out))
 
 	// 2. Verify volume attached status
-	status := verification.VerifyAttachedStatus(s.volumeName, s.config.DockerHosts[1], s.config.EsxHost)
+	status := verification.VerifyAttachedStatus(s.volumeName, s.config.DockerHosts[1], s.config.EsxHost, s.config.DockerHostNames[1])
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	// 3. Kill vDVS plugin
@@ -230,7 +230,7 @@ func (s *RestartTestData) TestRecoverMountsAfterRestart(c *C) {
 	misc.SleepForSec(20)
 
 	// 3. Verify the volume is attached to the VM
-	status := verification.VerifyAttachedStatus(s.volumeName, s.config.DockerHosts[1], s.config.EsxHost)
+	status := verification.VerifyAttachedStatus(s.volumeName, s.config.DockerHosts[1], s.config.EsxHost, s.config.DockerHostNames[1])
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	// 4. Run third container

--- a/tests/e2e/swarm_test.go
+++ b/tests/e2e/swarm_test.go
@@ -114,7 +114,7 @@ func (s *SwarmTestSuite) TestFailoverAcrossSwarmNodes(c *C) {
 	status, host := verification.IsDockerContainerRunning(s.swarmNodes, s.serviceName, 1)
 	c.Assert(status, Equals, true, Commentf("Container %s is not running", s.serviceName))
 
-	status = verification.VerifyAttachedStatus(s.volumeName, host, s.esxName)
+	status = verification.VerifyAttachedStatusByIP(s.volumeName, host, s.esxName)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	containerName, err := dockercli.GetContainerName(host, s.serviceName)
@@ -148,7 +148,7 @@ func (s *SwarmTestSuite) TestFailoverAcrossSwarmNodes(c *C) {
 	status, host = verification.IsDockerContainerRunning([]string{otherWorker}, s.serviceName, 1)
 	c.Assert(status, Equals, true, Commentf("Container %s is not running", s.serviceName))
 
-	status = verification.VerifyAttachedStatus(s.volumeName, host, s.esxName)
+	status = verification.VerifyAttachedStatusByIP(s.volumeName, host, s.esxName)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	containerName, err = dockercli.GetContainerName(host, s.serviceName)
@@ -212,7 +212,7 @@ func (s *SwarmTestSuite) TestFailoverAcrossReplicas(c *C) {
 	status, host := verification.IsDockerContainerRunning(s.swarmNodes, s.serviceName, 1)
 	c.Assert(status, Equals, true, Commentf("Container %s is not running", s.serviceName))
 
-	status = verification.VerifyAttachedStatus(s.volumeName, host, s.esxName)
+	status = verification.VerifyAttachedStatusByIP(s.volumeName, host, s.esxName)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	out, err = dockercli.ScaleService(s.master, s.serviceName, 2)
@@ -235,7 +235,7 @@ func (s *SwarmTestSuite) TestFailoverAcrossReplicas(c *C) {
 	status, host = verification.IsDockerContainerRunning(s.swarmNodes, s.serviceName, 2)
 	c.Assert(status, Equals, true, Commentf("Container %s is not running", s.serviceName))
 
-	status = verification.VerifyAttachedStatus(s.volumeName, host, s.esxName)
+	status = verification.VerifyAttachedStatusByIP(s.volumeName, host, s.esxName)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	out, err = dockercli.DeleteVolume(s.master, s.volumeName)

--- a/tests/e2e/vmgroupmisc_test.go
+++ b/tests/e2e/vmgroupmisc_test.go
@@ -255,7 +255,6 @@ func (s *vgBasicSuite) TestDeleteVMFromVmgroup(c *C) {
 
 	// Destroy the vm
 	esx.DestroyVM(vmName)
-	c.Assert(esx.IsVMExist(vmName), Equals, false, Commentf("Failed to delete VM - %s .", vmName, vgName))
 
 	// Check vmgroup ls
 	isVmgroupAvailable = admincli.IsVmgroupPresent(s.config.EsxHost, vgName)

--- a/tests/e2e/vmlistener_test.go
+++ b/tests/e2e/vmlistener_test.go
@@ -423,15 +423,12 @@ func (s *VMListenerTestParams) TestVolumeAttachedForVMSuspend(c *C) {
 	out, err = esxutil.SuspendResumeVM(s.esx, s.vm1Name)
 	c.Assert(err, IsNil, Commentf(out))
 
-	// After suspend/resume, fetching the VM name fails via govc, hence this delay
-	misc.SleepForSec(15)
-
 	// 2. Resume is like a power-on and so include the same checks
 	isVDVSRunning := esxutil.IsVDVSRunningAfterVMRestart(s.vm1, s.vm1Name)
 	c.Assert(isVDVSRunning, Equals, true, Commentf("vDVS is not running after VM [%s] being restarted", s.vm1Name))
 
 	// 3. Verify volume stays attached
-	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx)
+	status := verification.VerifyAttachedStatusByUuid(s.volumeName, s.vm1, s.esx, s.config.DockerHostUuids[0])
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	// 4. Remove the container if it still exists

--- a/tests/e2e/vmlistener_test.go
+++ b/tests/e2e/vmlistener_test.go
@@ -428,7 +428,7 @@ func (s *VMListenerTestParams) TestVolumeAttachedForVMSuspend(c *C) {
 	c.Assert(isVDVSRunning, Equals, true, Commentf("vDVS is not running after VM [%s] being restarted", s.vm1Name))
 
 	// 3. Verify volume stays attached
-	status := verification.VerifyAttachedStatusByUuid(s.volumeName, s.vm1, s.esx, s.config.DockerHostUuids[0])
+	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	// 4. Remove the container if it still exists

--- a/tests/e2e/vmlistener_test.go
+++ b/tests/e2e/vmlistener_test.go
@@ -94,7 +94,7 @@ func (s *VMListenerTestParams) TestServiceRestart(c *C) {
 	c.Assert(err, IsNil, Commentf(out))
 
 	// Verify the volume is in attached status
-	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx)
+	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx, s.vm1Name)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	// Restart vmdkops service
@@ -102,7 +102,7 @@ func (s *VMListenerTestParams) TestServiceRestart(c *C) {
 	c.Assert(err, IsNil, Commentf(out))
 
 	// Make sure volume stays attached after vmdkopsd restart
-	status = verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx)
+	status = verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx, s.vm1Name)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	// Remove the container
@@ -138,7 +138,7 @@ func (s *VMListenerTestParams) TestBasicFailover(c *C) {
 	c.Assert(err, IsNil, Commentf(out))
 
 	// Verify the volume is in attached status
-	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx)
+	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx, s.vm1Name)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	// Kill the VM
@@ -199,7 +199,7 @@ func (s *VMListenerTestParams) TestFailoverAcrossVmOnVmfs(c *C) {
 	c.Assert(err, IsNil, Commentf(out))
 
 	// Verify the volume is in attached status
-	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx)
+	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx, s.vm1Name)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	// Kill VM1
@@ -215,7 +215,7 @@ func (s *VMListenerTestParams) TestFailoverAcrossVmOnVmfs(c *C) {
 	c.Assert(err, IsNil, Commentf(out))
 
 	// Status should be attached
-	status = verification.VerifyAttachedStatus(s.volumeName, s.vm2, s.esx)
+	status = verification.VerifyAttachedStatus(s.volumeName, s.vm2, s.esx, s.vm2Name)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	// Remove the container from VM2
@@ -285,7 +285,7 @@ func (s *VMListenerTestParams) TestFailoverAcrossVmOnVsan(c *C) {
 	c.Assert(err, IsNil, Commentf(out))
 
 	// Verify the volume is in attached status
-	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx)
+	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx, s.vm1Name)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	// Kill VM1
@@ -301,7 +301,7 @@ func (s *VMListenerTestParams) TestFailoverAcrossVmOnVsan(c *C) {
 	c.Assert(err, IsNil, Commentf(out))
 
 	// Status should be attached
-	status = verification.VerifyAttachedStatus(s.volumeName, s.vm2, s.esx)
+	status = verification.VerifyAttachedStatus(s.volumeName, s.vm2, s.esx, s.vm2Name)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	// Remove the container from VM2
@@ -365,7 +365,7 @@ func (s *VMListenerTestParams) TestVolumeAttachedForHostdRestart(c *C) {
 	misc.SleepForSec(15)
 
 	// 2. Verify volume stays attached
-	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx)
+	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx, s.vm1Name)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	// 3. Kill this VM
@@ -428,7 +428,7 @@ func (s *VMListenerTestParams) TestVolumeAttachedForVMSuspend(c *C) {
 	c.Assert(isVDVSRunning, Equals, true, Commentf("vDVS is not running after VM [%s] being restarted", s.vm1Name))
 
 	// 3. Verify volume stays attached
-	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx)
+	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx, s.vm1Name)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	// 4. Remove the container if it still exists
@@ -470,7 +470,7 @@ func (s *VMListenerTestParams) TestVolumeAttachedWhenHostdKilled(c *C) {
 	misc.SleepForSec(15)
 
 	// 2. Verify volume stays attached
-	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx)
+	status := verification.VerifyAttachedStatus(s.volumeName, s.vm1, s.esx, s.vm1Name)
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volumeName))
 
 	// 3. Kill this VM

--- a/tests/e2e/vmops_test.go
+++ b/tests/e2e/vmops_test.go
@@ -86,7 +86,7 @@ func (vm *VMOpsTest) TestVMSnapWithPersistentDisk(c *C) {
 	_, err := dockercli.AttachVolume(vm.config.DockerHosts[0], vm.volName1, vm.testContainer)
 	c.Assert(err, IsNil, Commentf("Failed running container %s with volume %s attached as persistent\n", vm.testContainer, vm.volName1))
 
-	status := verification.VerifyAttachedStatus(vm.volName1, vm.config.DockerHosts[0], vm.config.EsxHost)
+	status := verification.VerifyAttachedStatus(vm.volName1, vm.config.DockerHosts[0], vm.config.EsxHost, vm.config.DockerHostNames[0])
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", vm.volName1))
 
 	// 2. Snapshot VM and verify attached state of volume
@@ -97,7 +97,7 @@ func (vm *VMOpsTest) TestVMSnapWithPersistentDisk(c *C) {
 	out, err = esx.RemoveSnapshot(vm.config.DockerHostNames[0], "snap1")
 	c.Assert(err, IsNil, Commentf(out))
 
-	status = verification.VerifyAttachedStatus(vm.volName1, vm.config.DockerHosts[0], vm.config.EsxHost)
+	status = verification.VerifyAttachedStatus(vm.volName1, vm.config.DockerHosts[0], vm.config.EsxHost, vm.config.DockerHostNames[0])
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", vm.volName1))
 
 	// 4. Stop container and verify volume is detached
@@ -126,7 +126,7 @@ func (vm *VMOpsTest) TestVMSnapWithIndependentDisk(c *C) {
 	out, err := esx.TakeSnapshot(vm.config.DockerHostNames[0], "snap1")
 	c.Assert(err, Not(IsNil), Commentf(out))
 
-	status := verification.VerifyAttachedStatus(vm.volName2, vm.config.DockerHosts[0], vm.config.EsxHost)
+	status := verification.VerifyAttachedStatus(vm.volName2, vm.config.DockerHosts[0], vm.config.EsxHost, vm.config.DockerHostNames[0])
 	c.Assert(status, Equals, true, Commentf("Volume %s is not attached", vm.volName2))
 
 	// 3. Stop container and verify volume is detached

--- a/tests/utils/esx/esxcli.go
+++ b/tests/utils/esx/esxcli.go
@@ -69,11 +69,11 @@ func WaitForExpectedState(fn getVMPowerStatus, vmName, expectedState string) boo
 	maxAttempt := 20
 	waitTime := 5
 	for attempt := 0; attempt < maxAttempt; attempt++ {
-		misc.SleepForSec(waitTime)
 		status := fn(vmName)
 		if status == expectedState {
 			return true
 		}
+		misc.SleepForSec(waitTime)
 	}
 	log.Printf("Timed out to poll status\n")
 	return false

--- a/tests/utils/esx/esxcli.go
+++ b/tests/utils/esx/esxcli.go
@@ -67,7 +67,7 @@ func KillVM(esxHostIP, vmName string) bool {
 func WaitForExpectedState(fn getVMPowerStatus, vmName, expectedState string) bool {
 	// log.Printf("Confirming [%s] power status for vm [%s]\n", expectedState, vmName)
 	maxAttempt := 20
-	waitTime := 5
+	waitTime := 3
 	for attempt := 0; attempt < maxAttempt; attempt++ {
 		status := fn(vmName)
 		if status == expectedState {

--- a/tests/utils/esx/govc.go
+++ b/tests/utils/esx/govc.go
@@ -47,7 +47,7 @@ func RetrieveVMNameFromIP(ip string) string {
 	return out
 }
 
-// RetrieveVMUuidFromIP retrieves VM UUID passed VM IP
+// RetrieveVMUuidFromIP retrieves VM UUID from passed VM IP
 //govc vm.info -vm.ip=<vm IP> -json | jq -r .VirtualMachines[].Config.Uuid
 func RetrieveVMUuidFromIP(ip string) string {
 	// log.Printf("Finding VM uuid with IP [%s]\n", ip)
@@ -56,7 +56,7 @@ func RetrieveVMUuidFromIP(ip string) string {
 	return out
 }
 
-// RetrieveVMWithUuid retrieves VM IP passed VM uuid
+// RetrieveVMWithUuid retrieves VM name from passed VM UUID
 //govc vm.info -vm.uuid=<vm uuid> -json | jq -r .VirtualMachines[].Config.Uuid
 func RetrieveVMNameFromUuid(uuid string) string {
 	// log.Printf("Finding VM name with uuid [%s]\n", uuid)

--- a/tests/utils/esx/govc.go
+++ b/tests/utils/esx/govc.go
@@ -30,7 +30,6 @@ import (
 	"fmt"
 
 	"github.com/vmware/docker-volume-vsphere/tests/constants/esx"
-	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/ssh"
 )
 
@@ -127,14 +126,9 @@ func DestroyVM(vmName string) string {
 // IsVMExist returns true/false based on vm existence
 func IsVMExist(vmName string) bool {
 	log.Printf("Verifying if vm - %s exists \n", vmName)
-	maxAttempt := 15
-	waitTime := 2
-	for attempt := 0; attempt < maxAttempt; attempt++ {
-		vmList, _ := ssh.InvokeCommandLocally(esx.ListVMs + " /ha-datacenter/vm")
-		if strings.Contains(vmList, vmName) {
-			return true
-		}
-		misc.SleepForSec(waitTime)
+	vmList, _ := ssh.InvokeCommandLocally(esx.ListVMs + " /ha-datacenter/vm")
+	if strings.Contains(vmList, vmName) {
+		return true
 	}
 	return false
 }

--- a/tests/utils/esx/govc.go
+++ b/tests/utils/esx/govc.go
@@ -49,7 +49,7 @@ func RetrieveVMNameFromIP(ip string) string {
 
 // RetrieveVMUuidFromIP retrieves VM UUID passed VM IP
 //govc vm.info -vm.ip=<vm IP> -json | jq -r .VirtualMachines[].Config.Uuid
-funci RetrieveVMUuidFromIP(ip string) string {
+func RetrieveVMUuidFromIP(ip string) string {
 	// log.Printf("Finding VM uuid with IP [%s]\n", ip)
 	cmd := esx.VMInfoByIP + ip + esxcliJSON + esx.VMUuid
 	out, _ := ssh.InvokeCommandLocally(cmd)
@@ -58,7 +58,7 @@ funci RetrieveVMUuidFromIP(ip string) string {
 
 // RetrieveVMWithUuid retrieves VM IP passed VM uuid
 //govc vm.info -vm.uuid=<vm uuid> -json | jq -r .VirtualMachines[].Config.Uuid
-funci RetrieveVMNameFromUuid(uuid string) string {
+func RetrieveVMNameFromUuid(uuid string) string {
 	// log.Printf("Finding VM name with uuid [%s]\n", uuid)
 	cmd := esx.VMInfoByUuid + uuid + esxcliJSON + esx.VMName
 	out, _ := ssh.InvokeCommandLocally(cmd)

--- a/tests/utils/esx/govc.go
+++ b/tests/utils/esx/govc.go
@@ -55,15 +55,6 @@ func RetrieveVMUuidFromIP(ip string) string {
 	return out
 }
 
-// RetrieveVMWithUuid retrieves VM name from passed VM UUID
-//govc vm.info -vm.uuid=<vm uuid> -json | jq -r .VirtualMachines[].Config.Uuid
-func RetrieveVMNameFromUuid(uuid string) string {
-	// log.Printf("Finding VM name with uuid [%s]\n", uuid)
-	cmd := esx.VMInfoByUuid + uuid + esxcliJSON + esx.VMName
-	out, _ := ssh.InvokeCommandLocally(cmd)
-	return out
-}
-
 // GetVMPowerState util retrieves VM's current power state
 // GetVMPowerState util retrieves VM's current power state
 // govc vm.info -json photon1 | jq -r .VirtualMachines[].Runtime.PowerState

--- a/tests/utils/esx/govc.go
+++ b/tests/utils/esx/govc.go
@@ -39,7 +39,7 @@ const (
 )
 
 // RetrieveVMNameFromIP util retrieves VM  name from passed VM IP
-//govc vm.info -vm.ip=10.20.104.62 -json | jq -r .VirtualMachines[].Name
+//govc vm.info -vm.ip=<vm IP> -json | jq -r .VirtualMachines[].Name
 func RetrieveVMNameFromIP(ip string) string {
 	// log.Printf("Finding VM name from IP Address [%s]\n", ip)
 	cmd := esx.VMInfoByIP + ip + esxcliJSON + esx.VMName
@@ -47,6 +47,25 @@ func RetrieveVMNameFromIP(ip string) string {
 	return out
 }
 
+// RetrieveVMUuidFromIP retrieves VM UUID passed VM IP
+//govc vm.info -vm.ip=<vm IP> -json | jq -r .VirtualMachines[].Config.Uuid
+funci RetrieveVMUuidFromIP(ip string) string {
+	// log.Printf("Finding VM uuid with IP [%s]\n", ip)
+	cmd := esx.VMInfoByIP + ip + esxcliJSON + esx.VMUuid
+	out, _ := ssh.InvokeCommandLocally(cmd)
+	return out
+}
+
+// RetrieveVMWithUuid retrieves VM IP passed VM uuid
+//govc vm.info -vm.uuid=<vm uuid> -json | jq -r .VirtualMachines[].Config.Uuid
+funci RetrieveVMNameFromUuid(uuid string) string {
+	// log.Printf("Finding VM name with uuid [%s]\n", uuid)
+	cmd := esx.VMInfoByUuid + uuid + esxcliJSON + esx.VMName
+	out, _ := ssh.InvokeCommandLocally(cmd)
+	return out
+}
+
+// GetVMPowerState util retrieves VM's current power state
 // GetVMPowerState util retrieves VM's current power state
 // govc vm.info -json photon1 | jq -r .VirtualMachines[].Runtime.PowerState
 func GetVMPowerState(vmName string) string {

--- a/tests/utils/esx/vdvs.go
+++ b/tests/utils/esx/vdvs.go
@@ -32,12 +32,12 @@ func IsVDVSRunning(ip string) bool {
 	maxAttempt := 30
 	waitTime := 3
 	for attempt := 0; attempt < maxAttempt; attempt++ {
-		misc.SleepForSec(waitTime)
 		pid, _ := ssh.InvokeCommand(ip, "pidof docker-volume-vsphere")
 		if pid != "" {
 			log.Printf("Process ID of docker-volume-vsphere is: %s", pid)
 			return true
 		}
+		misc.SleepForSec(waitTime)
 	}
 	log.Printf("vDVS is not running on VM: %s", ip)
 	return false

--- a/tests/utils/inputparams/testparams.go
+++ b/tests/utils/inputparams/testparams.go
@@ -35,6 +35,7 @@ type TestConfig struct {
 	EsxHost         string
 	DockerHosts     []string
 	DockerHostNames []string
+	DockerHostUuids []string
 	Datastores      []string
 }
 
@@ -150,6 +151,9 @@ func getInstance() *TestConfig {
 	if config.DockerHostNames[0] == noVMName || config.DockerHostNames[1] == noVMName {
 		log.Fatalf("Failed to find vm name for docker hosts - %s , %s ", config.DockerHosts[0], config.DockerHosts[1])
 	}
+	config.DockerHostUuids = append(config.DockerHostUuids, esx.RetrieveVMUuidFromIP(config.DockerHosts[0]))
+	config.DockerHostUuids = append(config.DockerHostUuids, esx.RetrieveVMUuidFromIP(config.DockerHosts[1]))
+
 	config.Datastores = esx.GetDatastoreList()
 	if len(config.Datastores) < 1 {
 		log.Fatalf("No datastores found. At least one datastore is needed to run tests.")

--- a/tests/utils/verification/dockercontainer.go
+++ b/tests/utils/verification/dockercontainer.go
@@ -55,7 +55,7 @@ func IsDockerContainerRunning(dockerHosts []string, serviceName string, replicas
 		if status {
 			return status, host
 		}
-		misc.SleepForSec(5)
+		misc.SleepForSec(3)
 	}
 	return false, ""
 }

--- a/tests/utils/verification/dockercontainer.go
+++ b/tests/utils/verification/dockercontainer.go
@@ -55,7 +55,7 @@ func IsDockerContainerRunning(dockerHosts []string, serviceName string, replicas
 		if status {
 			return status, host
 		}
-		misc.SleepForSec(3)
+		misc.SleepForSec(5)
 	}
 	return false, ""
 }

--- a/tests/utils/verification/volumeproperties.go
+++ b/tests/utils/verification/volumeproperties.go
@@ -109,16 +109,26 @@ func GetFullVolumeName(hostName string, volumeName string) string {
 // shorter name without @datastore suffix.
 func VerifyAttachedStatus(name, hostName, esxName string) bool {
 	log.Printf("Confirming attached status for volume [%s]\n", name)
+	return testAttachedStatus(name, hostName, esxName, esx.RetrieveVMNameFromIP(hostName))
+}
 
+// VerifyAttachedStatus - verify volume is attached and name of the VM attached
+// is consistent on both docker host and ESX. The name of the volume MUST be a
+// shorter name without @datastore suffix.
+func VerifyAttachedStatusWithUuid(name, hostName, esxName, uuid string) bool {
+	log.Printf("Confirming attached status for volume [%s]\n", name)
+	return testAttachedStatus(name, hostName, esxName, esx.RetrieveVMNameFromUuid(Uuid))
+}
+
+// testAttachedStatus - verify if the volume is attached to the VM of the given name
+// confirmed by other sources that return the attached status of the volume
+fundc testAttachedStatus(name, hostName, esxName, expectedVMName string) bool{
 	// Use full name to check volume status on docker host
 	fullName := GetFullVolumeName(hostName, name)
 	vmAttachedHost := GetVMAttachedToVolUsingDockerCli(fullName, hostName)
 
 	// Use short name to check volume status on ESX
 	vmAttachedESX := GetVMAttachedToVolUsingAdminCli(name, esxName)
-
-	// Get VM name based on the host IP
-	expectedVMName := esx.RetrieveVMNameFromIP(hostName)
 
 	// Check if volume attached VM info matches between ESX and docker host
 	isMatching := ((vmAttachedHost == expectedVMName) && (vmAttachedHost == vmAttachedESX))

--- a/tests/utils/verification/volumeproperties.go
+++ b/tests/utils/verification/volumeproperties.go
@@ -96,7 +96,7 @@ func GetFullVolumeName(hostName string, volumeName string) string {
 //	cmd := dockercli.InspectVolume + "-f '{{.Name}}@{{.Status.datastore}}' " + volumeName
 	cmd := dockercli.ListVolumes + "--filter name='" + volumeName + "' --format '{{.Name}}'"
 	fullName, err := ssh.InvokeCommand(hostName, cmd)
-	log.Printf("RUn cmd - %s\n", cmd)
+	//log.Printf("Run cmd - %s\n", cmd)
 	if err != nil {
 		log.Printf("Error: %s\n", err)
 		return volumeName

--- a/tests/utils/verification/volumeproperties.go
+++ b/tests/utils/verification/volumeproperties.go
@@ -93,7 +93,8 @@ func CheckVolumeListAvailability(hostName string, reqVolList []string) bool {
 func GetFullVolumeName(hostName string, volumeName string) string {
 	log.Printf("Fetching full name for volume [%s] from VM [%s]\n", volumeName, hostName)
 
-	cmd := dockercli.InspectVolume + "-f \"{{.Name}}@{{.Status.datastore}}\" " + volumeName
+//	cmd := dockercli.InspectVolume + "-f '{{.Name}}@{{.Status.datastore}}' " + volumeName
+	cmd := dockercli.ListVolumes + "--filter name='" + volumeName + "' --format '{{.Name}}'"
 	fullName, err := ssh.InvokeCommand(hostName, cmd)
 	log.Printf("RUn cmd - %s\n", cmd)
 	if err != nil {

--- a/tests/utils/verification/volumeproperties.go
+++ b/tests/utils/verification/volumeproperties.go
@@ -112,9 +112,10 @@ func VerifyAttachedStatus(name, hostName, esxName string) bool {
 	return testAttachedStatus(name, hostName, esxName, esx.RetrieveVMNameFromIP(hostName))
 }
 
-// VerifyAttachedStatus - verify volume is attached and name of the VM attached
-// is consistent on both docker host and ESX. The name of the volume MUST be a
-// shorter name without @datastore suffix.
+// VerifyAttachedStatusByUuid - verify volume is attached and name (fetched by referencing
+// the VM with its UUID) of the VM attached is consistent on both docker host and ESX.
+// The name of the volume MUST be a shorter name without @datastore suffix.
+// This function should be used when checking attached status after a VM is restarted.
 func VerifyAttachedStatusByUuid(name, hostName, esxName, uuid string) bool {
 	log.Printf("Confirming attached status for volume [%s]\n", name)
 	return testAttachedStatus(name, hostName, esxName, esx.RetrieveVMNameFromUuid(uuid))

--- a/tests/utils/verification/volumeproperties.go
+++ b/tests/utils/verification/volumeproperties.go
@@ -115,14 +115,14 @@ func VerifyAttachedStatus(name, hostName, esxName string) bool {
 // VerifyAttachedStatus - verify volume is attached and name of the VM attached
 // is consistent on both docker host and ESX. The name of the volume MUST be a
 // shorter name without @datastore suffix.
-func VerifyAttachedStatusWithUuid(name, hostName, esxName, uuid string) bool {
+func VerifyAttachedStatusByUuid(name, hostName, esxName, uuid string) bool {
 	log.Printf("Confirming attached status for volume [%s]\n", name)
-	return testAttachedStatus(name, hostName, esxName, esx.RetrieveVMNameFromUuid(Uuid))
+	return testAttachedStatus(name, hostName, esxName, esx.RetrieveVMNameFromUuid(uuid))
 }
 
 // testAttachedStatus - verify if the volume is attached to the VM of the given name
 // confirmed by other sources that return the attached status of the volume
-fundc testAttachedStatus(name, hostName, esxName, expectedVMName string) bool{
+func testAttachedStatus(name, hostName, esxName, expectedVMName string) bool{
 	// Use full name to check volume status on docker host
 	fullName := GetFullVolumeName(hostName, name)
 	vmAttachedHost := GetVMAttachedToVolUsingDockerCli(fullName, hostName)


### PR DESCRIPTION
1. Added a VerifyAttachedStatusByUuid() to allow verifying attached state without needing VM to be identified by govc (no sleep wait).
1. Moved the sleep in a couple of functions to after checking the status, avoid sleeping first and then making the check.