### PR TITLE
Adds windows specific handling to refcount and plugin_utils

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -53,7 +53,7 @@ echo Found Go.
 :: Verify that MSVC Build Tools are accessible.
 if not exist "%msvcBatPath%" (
 	echo ERROR: Couldn't find Microsoft Visual C++ Build Tools.
-	echo Download URL: https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017
+	echo Download URL: http://landinghub.visualstudio.com/visual-cpp-build-tools
 	exit /B
 )
 echo Found Microsoft Visual C++ Build Tools.

--- a/build.bat
+++ b/build.bat
@@ -35,8 +35,8 @@
 set projectRoot=%cd%
 set winBuildDir=%projectRoot%\build\windows
 set vmciDir=%projectRoot%\esx_service\vmci
-set pluginDir=%projectRoot%\vmdk_plugin
-set refcountDir=%pluginDir%\utils\refcount
+set pluginDir=%projectRoot%\client_plugin\vmdk_plugin
+set vmdkopsDir=%projectRoot%\client_plugin\drivers\vmdk\vmdkops
 set vsphereJsonPath=C:\ProgramData\docker\plugins\vsphere.json
 set msvcBatPath=C:\Program Files (x86)\Microsoft Visual C++ Build Tools\vcbuildtools.bat
 
@@ -79,28 +79,17 @@ cl /D_USRDLL /D_WINDLL vmci_client.c /link /defaultlib:ws2_32.lib /DLL /OUT:vmci
 del vmci_client.exp vmci_client.lib vmci_client.obj
 echo Compiled vmci_client.dll successfully.
 
-:: Move vmci_client.dll to the plugin directory.
-echo Moving vmci_client.dll to the plugin directory.
-move /y vmci_client.dll %pluginDir%
-echo Successfully moved vmci_client.dll to the plugin directory.
-
-:: Remove refcnt.go build tag.
-:: TODO: Remove this section after porting refcnt.go to Windows.
-echo Entering the refcount directory.
-cd %refcountDir%
-
-echo Removing refcnt.go build tag.
-findstr /v "+build linux" refcnt.go > refcnt.go.tmp
-del refcnt.go
-rename refcnt.go.tmp refcnt.go
-echo Successfully removed refcnt.go build tag.
+:: Move vmci_client.dll to the vmdkops directory.
+echo Moving vmci_client.dll to the vmdkops directory.
+move /y vmci_client.dll %vmdkopsDir%
+echo Successfully moved vmci_client.dll to the vmdkops directory.
 
 :: Build vdvs.exe.
 echo Entering the plugin directory.
 cd %pluginDir%
 
 echo Building vdvs.exe.
-go build -v -o vdvs.exe main.go main_windows.go constants.go log_formatter.go
+go build -v -o vdvs.exe main.go
 echo Successfully built vdvs.exe.
 
 :: Write vsphere.json to the docker plugin config directory.
@@ -108,7 +97,7 @@ echo Writing vsphere.json to the docker plugin config directory.
 del %vsphereJsonPath%
 (
 echo {
-echo   "Name": "vsphere"
+echo   "Name": "vsphere",
 echo   "Addr": "npipe:////./pipe/vsphere-dvs"
 echo }
 ) > %vsphereJsonPath%
@@ -117,7 +106,7 @@ echo Successfully wrote vsphere.json to the docker plugin config directory.
 :: Move binaries to build directory.
 echo Moving binaries to the build directory.
 if not exist %winBuildDir% mkdir %winBuildDir%
-move /y vmci_client.dll %winBuildDir%
+move /y %vmdkopsDir%\vmci_client.dll %winBuildDir%
 move /y vdvs.exe %winBuildDir%
 echo Successfully moved binaries to the build directory.
 

--- a/build.bat
+++ b/build.bat
@@ -110,5 +110,6 @@ move /y %vmdkopsDir%\vmci_client.dll %winBuildDir%
 move /y vdvs.exe %winBuildDir%
 echo Successfully moved binaries to the build directory.
 
+cd %projectRoot%
 echo vDVS build complete.
 echo Binaries are available under %winBuildDir%.

--- a/client_plugin/drivers/vmdk/vmdkops/esx_vmdkcmd.go
+++ b/client_plugin/drivers/vmdk/vmdkops/esx_vmdkcmd.go
@@ -34,7 +34,7 @@ import (
 
 /*
 #cgo CFLAGS: -I ../../../../esx_service/vmci
-#cgo windows LDFLAGS: -L${SRCDIR}/../../../ -lvmci_client
+#cgo windows LDFLAGS: -L${SRCDIR} -lvmci_client
 #include "vmci_client.h"
 #include "vmci_client_proxy.c"
 */

--- a/client_plugin/utils/fs/device_watcher_windows.go
+++ b/client_plugin/utils/fs/device_watcher_windows.go
@@ -74,14 +74,14 @@ func (w *DeviceWatcher) Init() {
 // awaitEventAndEmit awaits and emits a device change event or an error.
 func (w *DeviceWatcher) awaitEventAndEmit() {
 	script := fmt.Sprintf(devChangeWaitScript, devChangeTimeoutSec)
-	out, err := exec.Command(powershell, script).Output()
+	out, err := exec.Command(powershell, script).CombinedOutput()
 	if err != nil {
-		log.WithFields(log.Fields{"err": err}).Error("Failed to watch device event ")
+		log.WithFields(log.Fields{"err": err, "out": string(out)}).Error("Failed to watch device event ")
 		select {
 		case w.Error <- err:
-			log.WithFields(log.Fields{"err": err}).Info("Successfully emitted error ")
+			log.WithFields(log.Fields{"err": err, "out": string(out)}).Info("Successfully emitted error ")
 		default:
-			log.WithFields(log.Fields{"err": err}).Warn("Couldn't emit error, continuing.. ")
+			log.WithFields(log.Fields{"err": err, "out": string(out)}).Warn("Couldn't emit error, continuing.. ")
 		}
 		return
 	}

--- a/client_plugin/utils/fs/fs_linux.go
+++ b/client_plugin/utils/fs/fs_linux.go
@@ -360,12 +360,13 @@ func getDevicePath(volDev *VolumeDevSpec) (string, error) {
 // GetMountInfo returns a map of mounted volumes and devices.
 func GetMountInfo(mountRoot string) (map[string]string, error) {
 	volumeMountMap := make(map[string]string) // map [volume mount path] -> device
-	data, err := ioutil.ReadFile(linuxMountsFile)
 
+	data, err := ioutil.ReadFile(linuxMountsFile)
 	if err != nil {
 		log.Errorf("Can't get info from %s (%v)", linuxMountsFile, err)
 		return volumeMountMap, err
 	}
+	log.WithFields(log.Fields{"data": string(data)}).Info("Mounts read successfully")
 
 	for _, line := range strings.Split(string(data), lf) {
 		field := strings.Fields(line)
@@ -378,5 +379,7 @@ func GetMountInfo(mountRoot string) (map[string]string, error) {
 		}
 		volumeMountMap[filepath.Base(field[1])] = field[0]
 	}
+
+	log.WithFields(log.Fields{"map": volumeMountMap}).Info("Successfully retrieved mounts")
 	return volumeMountMap, nil
 }

--- a/client_plugin/utils/fs/fs_linux.go
+++ b/client_plugin/utils/fs/fs_linux.go
@@ -19,8 +19,6 @@ package fs
 import (
 	"errors"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
-	"golang.org/x/exp/inotify"
 	"io"
 	"io/ioutil"
 	"os"
@@ -29,6 +27,9 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"golang.org/x/exp/inotify"
 )
 
 const (
@@ -46,6 +47,7 @@ const (
 	deleteFile       = "/device/delete"
 	watchPath        = "/dev/disk/by-id"
 	diskWatchPath    = "/dev/disk/by-path"
+	linuxMountsFile  = "/proc/mounts" // Path of file containing linux mounts information
 )
 
 // BinSearchPath contains search paths for host binaries
@@ -353,4 +355,28 @@ func getDevicePath(volDev *VolumeDevSpec) (string, error) {
 		return "", fmt.Errorf("Device not found")
 	}
 	return fmt.Sprintf("/dev/disk/by-path/pci-%s.0-scsi-0:0:%s:0", string(buf), volDev.Unit), nil
+}
+
+// GetMountInfo returns a map of mounted volumes and devices.
+func GetMountInfo(mountRoot string) (map[string]string, error) {
+	volumeMountMap := make(map[string]string) // map [volume mount path] -> device
+	data, err := ioutil.ReadFile(linuxMountsFile)
+
+	if err != nil {
+		log.Errorf("Can't get info from %s (%v)", linuxMountsFile, err)
+		return volumeMountMap, err
+	}
+
+	for _, line := range strings.Split(string(data), lf) {
+		field := strings.Fields(line)
+		if len(field) < 2 {
+			continue // skip empty line and lines too short to have our mount
+		}
+		// fields format: [/dev/sdb /mnt/vmdk/vol1 ext2 rw,relatime 0 0]
+		if filepath.Dir(field[1]) != mountRoot {
+			continue
+		}
+		volumeMountMap[filepath.Base(field[1])] = field[0]
+	}
+	return volumeMountMap, nil
 }

--- a/client_plugin/utils/refcount/refcnt_linux.go
+++ b/client_plugin/utils/refcount/refcnt_linux.go
@@ -1,0 +1,19 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Support for refcount on Linux.
+
+package refcount
+
+const DockerHostAddr = "unix:///var/run/docker.sock"

--- a/client_plugin/utils/refcount/refcnt_linux.go
+++ b/client_plugin/utils/refcount/refcnt_linux.go
@@ -16,4 +16,5 @@
 
 package refcount
 
+// DockerHostAddr is the docker engine sock path on Linux.
 const DockerHostAddr = "unix:///var/run/docker.sock"

--- a/client_plugin/utils/refcount/refcnt_windows.go
+++ b/client_plugin/utils/refcount/refcnt_windows.go
@@ -1,0 +1,19 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Support for refcount on Windows.
+
+package refcount
+
+const DockerHostAddr = "npipe:////./pipe/docker_engine"

--- a/client_plugin/utils/refcount/refcnt_windows.go
+++ b/client_plugin/utils/refcount/refcnt_windows.go
@@ -16,4 +16,5 @@
 
 package refcount
 
+// DockerHostAddr is the docker engine npipe address on Windows.
 const DockerHostAddr = "npipe:////./pipe/docker_engine"


### PR DESCRIPTION
## Description
This PR enables the `refcount` module to connect to the Docker host under a Windows environment, and it also enables listing of mounts.

* Moves `GetMountInfo` from `plugin_utils` to the `fs` module.
* Adds `PowerShell` based `GetMountInfo` implementation for Windows.
* Updates build script.

## Test Results
The `test-all` target passes locally and following is the tail'd output.
```
2017-07-17T23:06:29-07:00 END: Running TestSanity on  tcp://10.192.122.236:2375 (may take a while)...
--- PASS: TestSanity (6.50s)
	sanity_test.go:207: Successfully connected to tcp://10.192.122.236:2375
	sanity_test.go:207: Successfully connected to tcp://10.192.108.211:2375
	sanity_test.go:225: Creating vol=DefaultTestVol on client tcp://10.192.122.236:2375.
	sanity_test.go:111: Running cmd=&[touch /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.192.122.236:2375
	sanity_test.go:111: Running cmd=&[stat /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.192.122.236:2375
=== RUN   TestConcurrency
2017-07-17T23:06:29-07:00 Running concurrent tests on tcp://10.192.122.236:2375 and tcp://10.192.108.211:2375 (may take a while)...
2017-07-17T23:06:29-07:00 START: Running create/delete multi-host concurrent test ...
2017-07-17T23:06:39-07:00 END: Running create/delete multi-host concurrent test ...
Running same docker host concurrent create/delete test on tcp://10.192.122.236:2375...
2017-07-17T23:06:45-07:00 START: Running clone concurrent test...
2017-07-17T23:06:56-07:00 END: Running clone concurrent test...
--- PASS: TestConcurrency (26.94s)
	sanity_test.go:207: Successfully connected to tcp://10.192.122.236:2375
	sanity_test.go:207: Successfully connected to tcp://10.192.108.211:2375
PASS
coverage: 0.0% of statements
```