### PR TITLE
Shared plugin: etcd starting up functions.

### DIFF
--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -101,7 +101,7 @@ COMMON_SRC = utils/log_formatter/log_formatter.go \
 VMDK_PLUGIN_SRC = vmdk_plugin/main.go vmdk_plugin/main_linux.go \
 	drivers/photon/photon_driver.go drivers/vmdk/vmdk_driver.go
 
-SHARED_PLUGIN_SRC = shared_plugin/main.go drivers/shared/shared_driver.go
+SHARED_PLUGIN_SRC = shared_plugin/main.go drivers/shared/shared_driver.go drivers/shared/etcdops.go
 
 TEST_SRC = ../tests/utils/inputparams/testparams.go
 

--- a/client_plugin/drivers/shared/etcdops.go
+++ b/client_plugin/drivers/shared/etcdops.go
@@ -1,0 +1,282 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	etcdClient "github.com/coreos/etcd/clientv3"
+	"github.com/docker/engine-api/types"
+)
+
+const (
+	etcdClientPort           = ":2379"
+	etcdPeerPort             = ":2380"
+	etcdClusterToken         = "vsphere-shared-etcd-cluster"
+	etcdListenURL            = "0.0.0.0"
+	etcdScheme               = "http://"
+	etcdClusterStateNew      = "new"
+	etcdClusterStateExisting = "existing"
+)
+
+// initEtcd start or join ETCD cluster depending on the role of the node
+func (d *VolumeDriver) initEtcd() error {
+	ctx := context.Background()
+	cli := d.dockerd
+
+	// get NodeID from docker client
+	info, err := cli.Info(ctx)
+	if err != nil {
+		log.WithFields(
+			log.Fields{"error": err},
+		).Error("Failed to get Info from docker client ")
+		return err
+	}
+
+	// worker just returns
+	nodeID := info.Swarm.NodeID
+	if info.Swarm.ControlAvailable == false {
+		log.WithFields(
+			log.Fields{"nodeID": nodeID},
+		).Info("Swarm node role: worker. Action: return from InitEtcd ")
+		return nil
+	}
+
+	// check my local role
+	node, _, err := cli.NodeInspectWithRaw(ctx, nodeID)
+	if err != nil {
+		log.WithFields(log.Fields{"nodeID": nodeID,
+			"error": err}).Error("Failed to inspect node ")
+		return err
+	}
+
+	// get the IP address of current node
+	addr := info.Swarm.NodeAddr
+
+	// if leader, proceed to start ETCD cluster
+	if node.ManagerStatus.Leader {
+		log.WithFields(
+			log.Fields{"nodeID": nodeID},
+		).Info("Swarm node role: leader, start etcd cluster")
+		err = startEtcdCluster(addr, nodeID)
+		if err != nil {
+			log.WithFields(log.Fields{"nodeID": nodeID,
+				"error": err}).Error("Failed to start ETCD Cluster")
+			return err
+		}
+		return nil
+	}
+
+	// if manager, first find out who's leader, then proceed to join ETCD cluster
+	nodes, err := cli.NodeList(ctx, types.NodeListOptions{})
+	if err != nil {
+		log.WithFields(log.Fields{"nodeID": nodeID,
+			"error": err}).Error("Failed to get NodeList from swarm manager")
+		return err
+	}
+	for _, n := range nodes {
+		if n.ManagerStatus != nil && n.ManagerStatus.Leader == true {
+			log.WithFields(
+				log.Fields{"leader ID": n.ID,
+					"manager ID": nodeID},
+			).Info("Swarm node role: manager. Action: find leader ")
+
+			joinEtcdCluster(addr, n.ManagerStatus.Addr, nodeID)
+			return nil
+		}
+	}
+
+	err = fmt.Errorf("Failed to get leader for swarm manager %s", nodeID)
+	return err
+}
+
+// startEtcdCluster function is called by swarm leader to start a ETCD cluster
+func startEtcdCluster(nodeAddr string, nodeID string) error {
+	lines := []string{
+		"--name", nodeID,
+		"--advertise-client-urls", etcdScheme + nodeAddr + etcdClientPort,
+		"--initial-advertise-peer-urls", etcdScheme + nodeAddr + etcdPeerPort,
+		"--listen-client-urls", etcdScheme + etcdListenURL + etcdClientPort,
+		"--listen-peer-urls", etcdScheme + etcdListenURL + etcdPeerPort,
+		"--initial-cluster-token", etcdClusterToken,
+		"--initial-cluster", nodeID + "=" + etcdScheme + nodeAddr + etcdPeerPort,
+		"--initial-cluster-state", etcdClusterStateNew,
+	}
+	go etcdService(lines)
+
+	return nil
+}
+
+// joinEtcdCluster function is called by a non-leader swarm manager to join a ETCD cluster
+func joinEtcdCluster(nodeAddr string, leaderAddr string, nodeID string) error {
+	cli, err := addrToEtcdClient(leaderAddr)
+	if err != nil {
+		log.WithFields(
+			log.Fields{"nodeAddr": nodeAddr,
+				"leaderAddr": leaderAddr,
+				"nodeID":     nodeID},
+		).Error("Failed to join ETCD cluster on manager ")
+	}
+
+	// list all current ETCD members, check if this node is already added as a member
+	lresp, err := cli.MemberList(context.Background())
+	if err != nil {
+		log.WithFields(
+			log.Fields{"leaderAddr": leaderAddr,
+				"error":       err,
+				"members len": len(lresp.Members)},
+		).Error("Failed to list member for ETCD")
+		return err
+	}
+
+	peerAddr := etcdScheme + nodeAddr + etcdPeerPort
+	existing := false
+	for _, member := range lresp.Members {
+		// loop all current etcd members to find if there is already a member with the same peerAddr
+		if member.PeerURLs[0] == peerAddr {
+			if member.Name == "" {
+				// same peerAddr already existing
+				// empty name indicates this member is not started, continue the join process
+				log.WithFields(
+					log.Fields{"nodeID": nodeID,
+						"peerAddr": peerAddr},
+				).Info("Already joined as etcd member but not started. ")
+
+				existing = true
+			} else {
+				// same peerAddr already existing and started, need to remove before re-join
+				// we need the remove since etcd data directory is not persistent
+				// thus the node cannot re-join as the same member as before
+				log.WithFields(
+					log.Fields{"nodeID": nodeID,
+						"peerAddr": peerAddr},
+				).Info("Already joined as a etcd member and started. Action: remove self before re-join ")
+
+				_, err = cli.MemberRemove(context.Background(), member.ID)
+				if err != nil {
+					log.WithFields(
+						log.Fields{"peerAddr": peerAddr,
+							"member.ID": member.ID},
+					).Error("Failed to remove member for ETCD")
+					return err
+				}
+			}
+			// the same peerAddr can only join at once. no need to continue.
+			break
+		}
+	}
+
+	initCluster := ""
+	if !existing {
+		peerAddrs := []string{peerAddr}
+		aresp, err := cli.MemberAdd(context.Background(), peerAddrs)
+		if err != nil {
+			log.WithFields(
+				log.Fields{"leaderAddr": leaderAddr,
+					"error":       err,
+					"members len": len(aresp.Members)},
+			).Error("Failed to add member for ETCD")
+			return err
+		}
+		for _, member := range aresp.Members {
+			if member.Name != "" {
+				initCluster += member.Name + "=" + member.PeerURLs[0] + ","
+			}
+		}
+	} else {
+		for _, member := range lresp.Members {
+			if member.Name != "" {
+				initCluster += member.Name + "=" + member.PeerURLs[0] + ","
+			}
+		}
+	}
+
+	lines := []string{
+		"--name", nodeID,
+		"--advertise-client-urls", etcdScheme + nodeAddr + etcdClientPort,
+		"--initial-advertise-peer-urls", etcdScheme + nodeAddr + etcdPeerPort,
+		"--listen-client-urls", etcdScheme + etcdListenURL + etcdClientPort,
+		"--listen-peer-urls", etcdScheme + etcdListenURL + etcdPeerPort,
+		"--initial-cluster-token", etcdClusterToken,
+		"--initial-cluster", initCluster + nodeID + "=" + etcdScheme + nodeAddr + etcdPeerPort,
+		"--initial-cluster-state", etcdClusterStateExisting,
+	}
+
+	go etcdService(lines)
+
+	return nil
+}
+
+func etcdService(cmd []string) {
+	_, err := exec.Command("/bin/etcd", cmd...).Output()
+	if err != nil {
+		log.WithFields(
+			log.Fields{"error": err, "cmd": cmd},
+		).Error("Failed to start etcd command ")
+	}
+}
+
+func (d *VolumeDriver) createEtcdClient() *etcdClient.Client {
+	dclient := d.dockerd
+
+	info, err := dclient.Info(context.Background())
+	if err != nil {
+		log.WithFields(
+			log.Fields{"error": err},
+		).Error("Failed to get Info from docker client ")
+		return nil
+	}
+
+	for _, manager := range info.Swarm.RemoteManagers {
+		cli, err := addrToEtcdClient(manager.Addr)
+		if err == nil {
+			return cli
+		}
+	}
+
+	log.WithFields(
+		log.Fields{"Swarm ID": info.Swarm.NodeID,
+			"IP Addr": info.Swarm.NodeAddr},
+	).Error("Failed to create etcd client according to manager info ")
+	return nil
+}
+
+// addrToEtcdClient function create a new Etcd client according to the input docker address
+// it can be used by swarm worker to get a Etcd client on swarm manager
+// or it can be used by swarm manager to get a Etcd client on swarm leader
+func addrToEtcdClient(addr string) (*etcdClient.Client, error) {
+	// input address are RemoteManagers from docker info or ManagerStatus.Addr from docker inspect
+	// in the format of [host]:[docker manager port]
+	s := strings.Split(addr, ":")
+	endpoint := s[0] + etcdClientPort
+	cfg := etcdClient.Config{
+		Endpoints: []string{endpoint},
+	}
+
+	cli, err := etcdClient.New(cfg)
+	if err != nil {
+		log.WithFields(
+			log.Fields{"endpoint": endpoint,
+				"error": err},
+		).Error("Failed to create ETCD Client ")
+		return nil, err
+	}
+
+	return cli, nil
+}

--- a/plugin_dockerbuild/Dockerfile.shared
+++ b/plugin_dockerbuild/Dockerfile.shared
@@ -1,0 +1,21 @@
+# Dockerile for packaging https://github.com/vmware/docker-volume-vsphere as
+# Docker managed plugin.
+#
+# Image created with this file is used to unpack to plugin rootfs and then build
+# plugin image
+#
+# We need <fs>progs to allow formatting fresh disks from within the plugin
+
+
+FROM alpine:3.5
+
+RUN apk update ; apk add e2fsprogs xfsprogs
+RUN apk add --update ca-certificates openssl tar && \
+wget https://storage.googleapis.com/etcd/v3.2.3/etcd-v3.2.3-linux-amd64.tar.gz && \
+tar zxvf etcd-v3.2.3-linux-amd64.tar.gz && \
+mv etcd-v3.2.3-linux-amd64/etcd* /bin/ && \
+apk del --purge tar openssl && \
+rm -Rf etcd-v3.2.3-linux-amd64* /var/cache/apk/*
+RUN mkdir -p /mnt/vmdk
+COPY vsphere-shared /usr/bin
+CMD ["/usr/bin/vsphere-shared"]

--- a/plugin_dockerbuild/Dockerfile.vmdk
+++ b/plugin_dockerbuild/Dockerfile.vmdk
@@ -11,5 +11,5 @@ FROM alpine:3.5
 
 RUN apk update ; apk add e2fsprogs xfsprogs
 RUN mkdir -p /mnt/vmdk
-COPY %BINARY% /usr/bin
-CMD ["/usr/bin/%BINARY%"]
+COPY docker-volume-vsphere /usr/bin
+CMD ["/usr/bin/docker-volume-vsphere"]

--- a/plugin_dockerbuild/Makefile
+++ b/plugin_dockerbuild/Makefile
@@ -33,6 +33,18 @@
 BINARY ?= docker-volume-vsphere
 SHARED_BINARY := vsphere-shared
 
+# Dockerfile templates
+DOCKERFILE ?= Dockerfile.vmdk
+SHARED_DOCKERFILE := Dockerfile.shared
+
+# Network Type
+NETWORK ?=
+SHARED_NETWORK := host
+
+# Sock Type
+SOCKTYPE ?= vsphere
+SHARED_SOCKTYPE := shared
+
 # Tmp docker image used to construct rootfs + our binaries
 TMP_IMAGE = $(PLUGIN_NAME):rootfs
 # Tmp container used for exporting rootfs from it
@@ -68,8 +80,8 @@ shared-clean:
 
 plugin: clean
 	@echo "== building Docker image, unpacking to ./rootfs and creating plugin..."
-	sed "s/\%BINARY\%/$(BINARY)/g" Dockerfile-template > Dockerfile
-	sed 's/\%BINARY\%/$(BINARY)/g' config.json-template > config.json
+	cp $(DOCKERFILE) Dockerfile
+	sed 's/\%BINARY\%/$(BINARY)/g;s/\%NETWORKTYPE\%/$(NETWORK)/g;s/\%SOCKTYPE\%/$(SOCKTYPE)/g' config.json-template > config.json
 	cp $(BIN)/$(BINARY) .
 	docker build -q -t $(TMP_IMAGE) .
 	docker create --name $(TMP_CONTAINER) $(TMP_IMAGE)
@@ -79,7 +91,7 @@ plugin: clean
 	@echo "-- Creating  plugin $(PLUGIN_NAME):$(PLUGIN_TAG) ..."
 	docker plugin create $(PLUGIN_NAME):$(PLUGIN_TAG) $(TMP_LOC)
 shared-plugin: shared-clean
-	PLUGIN_NAME=$(SHARED_PLUGIN_NAME) BINARY=$(SHARED_BINARY) $(MAKE) plugin
+	PLUGIN_NAME=$(SHARED_PLUGIN_NAME) BINARY=$(SHARED_BINARY) DOCKERFILE=$(SHARED_DOCKERFILE) NETWORK=$(SHARED_NETWORK) SOCKTYPE=$(SHARED_SOCKTYPE) $(MAKE) plugin
 
 push:
 	@echo Pushing $(PLUGIN_NAME):$(PLUGIN_TAG)  to dockerhub.io...

--- a/plugin_dockerbuild/config.json-template
+++ b/plugin_dockerbuild/config.json-template
@@ -36,11 +36,11 @@
 		}
 	],
 	"Network": {
-		"Type": ""
+		"Type": "%NETWORKTYPE%"
 	},
 	"Interface" : {
 		"Types": ["docker.volumedriver/1.0"],
-		"Socket": "vsphere.sock"
+		"Socket": "%SOCKTYPE%.sock"
 	},
 	"Linux": {
 		"AllowAllDevices": true,


### PR DESCRIPTION
Design:
Swarm leader node starts an etcd cluster when the shared volume driver is initialized.
Swarm manager nodes join the etcd cluster through the leader node.
Swarm worker nodes do nothing.

The etcd cluster resides inside plugin runc container.
Thus when plugin is stopped, the etcd member inside the container dies.
When the plugin/VM is restarted, if the plugin find there is already a started member
in the etcd cluster with the same peer url, this entry is removed by current plugin and continue to re-join.
`msterin> ` Who should do it ? Is it a part of this PR of future PRs ? 
`miao> ` This PR include the remove and re-join already. modified the statement above to clarify.

Note 1:
Due to etcd limitation, users should make sure the swarm cluster has the number of managers
(including leader) = 1 or >2, in order to avoid the situation of quorum loss.
`msterin> ` what happens if they don't ? Do we print a log message with recommendation? What happens if they loose quorum ? 
`miao> ` I updated the statement above to be more accurate. The quorum loss in our case mostly happens when 1 member adding into 1-node cluster and left. This member cannot rejoin due to quorum loss. But if 2 members joined to 1-node cluster (became 3-node cluster) and 1 member left, the quorum still exist (https://github.com/coreos/etcd/issues/6420). When the quorum loss happens, etcd cluster can still work but in unhealthy mode, which means it cannot add/remove members. We throw out error in log if users tried to start a new master plugin and failed. This is not recoverable for now but etcd has an opening progressing issue on it. I think it's ok for us to add recommendation in Readme and simply fail the new manager plugin when quorum loss happened, before ETCD make progress on this quorum loss situation.

Note 2:
For now the etcd cluster start/join only happens when the plugin is initialized.
Thus if a swarm worker node has the plugin installed first and promoted to manager later,
it won't join the etcd cluster. Before this is resolved, users should reinstall the plugin
on a promoted node.
`msterin> ` - is there an issue for this (or work item on internal tracking) ? Also, can we print a message if this happens ? We can do a periodic (each 5 min ? ) poll to check the node status and the etcd node status. Unless the issue is planned to be fixed soon. 
`miao> ` This needs more investigation and I will create a work item on this issue. We can do periodic poll to trigger etcd member operations if the plugin cannot get notification when a node is promoted. 

Note 3:
We are using the default docker swarm network (IP address from docker info) for now. And as a result, the new plugin configuration requires Network type = host.
`msterin> `  Same comment - we need either an issue or internal work item to track, and in any case please write up specific commands to configure plugin
`miao> ` yes we have a work item on it. There is no command needed to be done by users though. The config.json of the plugin build already has it by default, included with this PR.

Dockerfile change:
Create another dockerfile template so we have two dockerfile templates for the two plugins separately. This is because the new shared plugin requires etcd to be installed. The difference is too big for using the same template.

Test:
e2e test passed.