### PR TITLE
Create test setup script [SKIP CI]

### DIFF
--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -63,6 +63,11 @@ SYSTEMD_LIB  := $(PACKAGE)/lib/systemd/system/
 INSTALL_BIN  := $(PACKAGE)/usr/local/bin
 UPSTART_INIT := $(PACKAGE)/etc/init/
 
+#
+# Scripts to set up VMs to create a Docker swarm test bed
+#
+SETUP_VMS := $(SCRIPTS)/testbed.sh
+
 # esx service for docker volume ops
 ESX_SRC     := ../esx_service
 VMCI_SRC    := $(ESX_SRC)/vmci/*.h $(ESX_SRC)/vmci/vmci_client.c
@@ -424,3 +429,17 @@ all: clean-all build-all deploy-all test-all
 # if we do not recognize the target, warn and keep going.
 .DEFAULT:
 	@echo "***" Warning: Skipping unsupported target \"$@\"
+
+# Create a test set up of VMs and a docker swarm
+.PHONY: testbed setup-vms delete-testbed delete-vms
+testbed:
+	$(BUILD) setup-vms
+
+delete-testbed:
+	$(BUILD) delete-vms
+
+setup-vms:
+	$(SETUP_VMS) 1
+
+delete-vms:
+	$(SETUP_VMS) 0

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -154,8 +154,10 @@ else
     -e "TEST_OVAPATH=$TEST_OVAPATH" \
     -e "TEST_OVAURL=$TEST_OVAURL" \
     -e "TEST_USER=`whoami`" \
-    -e "TEST_TMPDIR=$TMPDIR" \
+    -e "TEST_PASSWORD=$TEST_PASSWORD" \
     -v $docker_socket:$docker_socket  \
     -v $ssh_key_path:$ssh_key_opt_container:ro \
+    -v $ssh_key_path.pub:$ssh_key_opt_container.pub:ro \
+    -v $TEST_OVAPATH:$TEST_OVAPATH:ro \
     -v $PWD/..:$dir -w $dir $plug_container $MAKE $1
 fi

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -150,6 +150,11 @@ else
     -e "UPGRADE_FROM_VER=$UPGRADE_FROM_VER" \
     -e "UPGRADE_TO_VER=$UPGRADE_TO_VER" \
     -e "DOCKER_HUB_REPO=$DOCKER_HUB_REPO" \
+    -e "TEST_VMDATASTORE=$TEST_VMDATASTORE" \
+    -e "TEST_OVAPATH=$TEST_OVAPATH" \
+    -e "TEST_OVAURL=$TEST_OVAURL" \
+    -e "TEST_USER=`whoami`" \
+    -e "TEST_TMPDIR=$TMPDIR" \
     -v $docker_socket:$docker_socket  \
     -v $ssh_key_path:$ssh_key_opt_container:ro \
     -v $PWD/..:$dir -w $dir $plug_container $MAKE $1

--- a/misc/scripts/testbed.sh
+++ b/misc/scripts/testbed.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GOVC=govc
+CURL=curl
+SSH="ssh -q -kTax -o StrictHostKeyChecking=no"
+
+ROOT=root
+
+DEFAULT_TMPDIR="/tmp"
+TEST_VM_OVA="test-vm.ova"
+TEST_VM1="vdvstest-master"
+TEST_VM2="vdvstest-worker1"
+TEST_VM3="vdvstest-worker2"
+
+VMS=($TEST_VM1 $TEST_VM2 $TEST_VM3)
+TEST_VMS=()
+TEST_VM_IPS=()
+
+DOCKER_INFO="docker info"
+DOCKERD_PORT=2377
+
+fetch_ova()
+{
+	tmp=$DEFAULT_TMPDIR
+	if [ -n $TEST_TMPDIR]; then
+		tmp=$TEST_TMPDIR
+	fi
+
+	ova_fpath=$tmp/$TEST_VM_OVA
+	$CURL --anyauth -#L $TEST_OVAURL -o $ova_fpath
+}
+
+# Delete all test VMs
+delete_vms()
+{
+	for n in ${TEST_VMS[@]}; do
+		$GOVC vm.destroy $n
+	done
+}
+
+# Deploy the test worker VMs to the ESX host and power on 
+# the VMs.
+deploy_vms()
+{
+	for n in ${VMS[@]}; do
+		vmname=$TEST_USER-$n
+		$GOVC vm.ip $vmname > /dev/null 2>&1
+		if [ $? -eq 0 ]; then
+			TEST_VMS+=($vmname)
+			testbed_exists=1
+			continue
+		fi
+		$GOVC import.ova -ds=$TEST_VMDATASTORE -name=$vmname
+		if [ $? -ne 0 ]; then
+			delete_vms
+			echo "Failed to deploy VM $vmname"
+			exit 1
+		fi
+		# add the VM to the list of test VMs
+		TEST_VMS+=($vmname)
+		$GOVC vm.power on=true $vmname
+		if [ $? -ne 0 ]; then
+			delete_vms
+			echo "Failed to power on vm $vmname"
+			exit 1
+		fi
+	done
+}
+
+# Get the IPs for each VM deployed earlier
+get_vm_ips()
+{
+	for n in ${TEST_VMS[@]}; do
+		vm_ip=`$GOVC vm.ip -a $vmname|cut -f1 -d,`
+		# add to the VM IPs list	
+		TEST_VM_IPS+=(vm_ip)
+	done
+}
+
+# Verify if docker is available on the VMs
+verify_docker_isrunning()
+{
+	for vm_ip in ${TEST_VM_IPS[@]}; do
+		retry=10
+		info=1
+		while [ $info -ne 0 ] && [ $retry -gt 0 ]; do
+			$SSH $ROOT@vm_ip $DOCKER_INFO
+			info=$?
+			if [ $info -ne 0 ]; then
+				sleep 2
+			fi
+			retry=`expr $retry - 1`
+		done
+		if [ $info -ne 0]; then
+			echo "Failed to detect docker instance on $vm_ip, deleting setup."
+			delete_vms
+			exit 1
+		fi
+	done
+}
+
+# Create a docker swarm with one master and two worker nodes
+create_docker_swarm()
+{
+	master_ip=${TEST_VM_IPS[0]}
+	$SSH $ROOT@$master_ip docker node ls > /dev/null 2>&1
+	if [ $? -ne 0 ]; then
+		$SSH $ROOT@master_ip docker swarm init --advertise-addr $master_ip > /dev/null 2>&1
+	fi
+
+	worker_token=`docker swarm join-token -q worker`
+
+	# join the worker nodes to the swarm
+	$SSH $ROOT@${TEST_VM_IPS[1]} docker swarm join --token $worker_token $master_ip:$DOCKERD_PORT
+	$SSH $ROOT@${TEST_VM_IPS[2]} docker swarm join --token $worker_token $master_ip:$DOCKERD_PORT
+}
+
+# Create a manifest of the VMS created
+create_manifest()
+{
+
+}
+
+if [ $1 -eq 0 ]; then
+	for n in ${VMS[@]}; do
+		vmname=$TEST_USER-$n
+		TEST_VMS+=($vmname)
+	done
+	delete_vms
+	echo "Removed testbed ${TEST_VMS[@]}"
+	exit 0
+fi
+
+testbed_exists=0
+# If an OVA_PATH has been provided then use that to deploy the VMs
+# else if an OVA_URL is provided then download the OVA and use that instead
+if [ -n $TEST_OVAURL ]; then
+	fetch_ova $TEST_OVAURL
+	deploy_vms ova_fpath
+elif [ -f $TEST_OVAPATH ]; then
+	deploy_vms $TEST_OVAPATH
+else
+	echo "OVA_PATH/OVA_URL not set, no OVA to deploy.
+	exit 1
+fi
+
+if  [ $testbed_exists -ne 0 ]; then
+	echo "Unable to create a new testbed, a testbed is already available - [${TEST_VMS[@]}]"
+fi
+
+get_vm_ips
+
+verify_docker_isrunning
+
+create_docker_swarm
+
+create_manifest
+
+#End

--- a/misc/scripts/testbed.sh
+++ b/misc/scripts/testbed.sh
@@ -14,33 +14,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -x
+
 GOVC=govc
 CURL=curl
-SSH="ssh -q -kTax -o StrictHostKeyChecking=no"
+
+SSH_PASS=/usr/bin/sshpass
+SSH="$SSH_PASS -p $TEST_PASSWORD ssh -q -kTax -o StrictHostKeyChecking=no"
+SSH_PUB_KEY=$HOME/.ssh/id_rsa.pub
+SSH_AUTH_KEYS=/root/.ssh/authorized_keys
 
 ROOT=root
 
 DEFAULT_TMPDIR="/tmp"
 TEST_VM_OVA="test-vm.ova"
-TEST_VM1="vdvstest-master"
-TEST_VM2="vdvstest-worker1"
-TEST_VM3="vdvstest-worker2"
+TEST_VM1="$TEST_USER-vdvstest-master"
+TEST_VM2="$TEST_USER-vdvstest-worker1"
+TEST_VM3="$TEST_USER-vdvstest-worker2"
+TEST_VM_TEMPLATE="$TEST_USER-vdvstest-template"
 
+LINKED_CLONE="vm.create -ds=$TEST_VMDATASTORE -disk $TEST_VM_TEMPLATE/$TEST_VM_TEMPLATE.vmdk -disk-datastore=$TEST_VMDATASTORE -link"
 VMS=($TEST_VM1 $TEST_VM2 $TEST_VM3)
 TEST_VMS=()
 TEST_VM_IPS=()
 
-DOCKER_INFO="docker info"
+MANIFEST=$PWD/.testvms
+
+DOCKER=/usr/local/bin/docker
+DOCKER_INFO="$DOCKER info"
 DOCKERD_PORT=2377
+DOCKER_INSTALL_COMMON="curl -fsSL https://get.docker.com/ | sh"
+DOCKER_INSTALL_TDNF="tdnf -y install docker"
 
 fetch_ova()
 {
 	tmp=$DEFAULT_TMPDIR
-	if [ -n $TEST_TMPDIR]; then
-		tmp=$TEST_TMPDIR
-	fi
 
 	ova_fpath=$tmp/$TEST_VM_OVA
+	echo "Fetching $TEST_OVAURL ......" 
 	$CURL --anyauth -#L $TEST_OVAURL -o $ova_fpath
 }
 
@@ -48,69 +59,120 @@ fetch_ova()
 delete_vms()
 {
 	for n in ${TEST_VMS[@]}; do
+		echo "Deleteing VM $n"
 		$GOVC vm.destroy $n
 	done
+	$GOVC vm.destroy $TEST_VM_TEMPLATE
 }
 
 # Deploy the test worker VMs to the ESX host and power on 
 # the VMs.
 deploy_vms()
 {
-	for n in ${VMS[@]}; do
-		vmname=$TEST_USER-$n
-		$GOVC vm.ip $vmname > /dev/null 2>&1
-		if [ $? -eq 0 ]; then
-			TEST_VMS+=($vmname)
-			testbed_exists=1
-			continue
+	echo "Checking if VM $TEST_VM_TEMPLATE already exists...."
+	info=`$GOVC vm.info $TEST_VM_TEMPLATE|wc -l`
+	if [ $info -eq 0 ]; then
+		echo "Importing OVA $1 as VM $vmname on datastore $TEST_VMDATASTORE"
+		if [ `echo $1|grep ova` ] || [ $? -eq 0 ]; then
+			$GOVC import.ova -ds=$TEST_VMDATASTORE -name=$TEST_VM_TEMPLATE $1
+		else
+			$GOVC import.ovf -ds=$TEST_VMDATASTORE -name=$TEST_VM_TEMPLATE $1
 		fi
-		$GOVC import.ova -ds=$TEST_VMDATASTORE -name=$vmname $1
 		if [ $? -ne 0 ]; then
 			delete_vms
-			echo "Failed to deploy VM $vmname"
+			echo "Failed to deploy VM $vmname for $1"
 			exit 1
 		fi
-		# add the VM to the list of test VMs
+	fi
+	# Create the linked clones from the template and
+	# add the VMs to the list of test VMs
+	for vmname in ${VMS[@]}; do
+		$GOVC $LINKED_CLONE $vmname
+		if [ $? -ne 0 ]; then
+			echo "Failed to create vm $vmname"
+			delete_vms
+			exit 1
+		fi
 		TEST_VMS+=($vmname)
-		$GOVC vm.power on=true $vmname
-		if [ $? -ne 0 ]; then
-			delete_vms
-			echo "Failed to power on vm $vmname"
-			exit 1
-		fi
 	done
 }
 
 # Get the IPs for each VM deployed earlier
 get_vm_ips()
 {
-	for n in ${TEST_VMS[@]}; do
+	for vmname in ${TEST_VMS[@]}; do
+		echo "Fetching IP for VM $vmname"
 		vm_ip=`$GOVC vm.ip -a $vmname|cut -f1 -d,`
-		# add to the VM IPs list	
-		TEST_VM_IPS+=(vm_ip)
+		echo "Got IP $vm_ip for VM $vmname"
+		# add to the VM IPs list
+		TEST_VM_IPS+=($vm_ip)
+	done
+}
+
+# Copy the ssh public key to the new VMs
+copy_ssh_keys()
+{
+	for vm_ip in ${TEST_VM_IPS[@]}; do
+		echo "Copying keys to $vm_ip"
+		cat $SSH_PUB_KEY | $SSH $ROOT@$vm_ip "cat >> $SSH_AUTH_KEYS"
+	done
+}
+
+# Install docker if not present or upgrade docker to
+# version specified in TES_DOCKER_VERSION
+install_docker()
+{
+	vm_ip=$1
+	$SSH $ROOT@$vm_ip $DOCKER_INFO #> /dev/null 2>&1
+	if [ $? -ne 0 ]; then
+		echo "Docker not found on $vm_ip, installing..."
+		# try installing docker
+		$SSH $ROOT@$vm_ip $DOCKER_INSTALL_COMMON
+		if [ $? -ne 0 ]; then
+			# try a tdnf install
+			$SSH $ROOT@$vm_ip $DOCKER_INSTALL_TDNF
+			if [ $? -ne 0 ]; then
+				echo "Failed to install docker on $vm_ip, deleting vms, exiting."
+				delete_vms
+				exit 1
+			fi
+		fi
+	else
+		# check docker version matches requested version
+		docker_version=`$DOCKER version --format '{{.Server.Version}}'`
+		echo "Found docker version $docker_version installed, skipping install.."
+	fi
+
+}
+
+# Verify docker is installed and running
+verify_docker_available()
+{
+	for vm_ip in ${TEST_VM_IPS[@]}; do
+		install_docker $vm_ip
+		verify_docker_isrunning $vm_ip
 	done
 }
 
 # Verify if docker is available on the VMs
 verify_docker_isrunning()
 {
-	for vm_ip in ${TEST_VM_IPS[@]}; do
-		retry=10
-		info=1
-		while [ $info -ne 0 ] && [ $retry -gt 0 ]; do
-			$SSH $ROOT@vm_ip $DOCKER_INFO
-			info=$?
-			if [ $info -ne 0 ]; then
-				sleep 2
-			fi
-			retry=`expr $retry - 1`
-		done
-		if [ $info -ne 0]; then
-			echo "Failed to detect docker instance on $vm_ip, deleting setup."
-			delete_vms
-			exit 1
+	vm_ip=$1
+	retry=10
+	info=1
+	while [ $info -ne 0 ] && [ $retry -gt 0 ]; do
+		$SSH $ROOT@$vm_ip $DOCKER_INFO > /dev/null 2>&1
+		info=$?
+		if [ $info -ne 0 ]; then
+			sleep 2
 		fi
+		retry=`expr $retry - 1`
 	done
+	if [ $info -ne 0 ]; then
+		echo "Failed to detect docker instance on $vm_ip, deleting vms, exiting."
+		delete_vms
+		exit 1
+	fi
 }
 
 # Create a docker swarm with one master and two worker nodes
@@ -118,25 +180,47 @@ create_docker_swarm()
 {
 	echo "Creating docker swarm on ${TEST_VMS[@]}"
 	master_ip=${TEST_VM_IPS[0]}
-	$SSH $ROOT@$master_ip docker node ls > /dev/null 2>&1
+	$SSH $ROOT@$master_ip $DOCKER node ls > /dev/null 2>&1
 	if [ $? -ne 0 ]; then
-		$SSH $ROOT@master_ip docker swarm init --advertise-addr $master_ip > /dev/null 2>&1
+		$SSH $ROOT@master_ip $DOCKER swarm init --advertise-addr $master_ip > /dev/null 2>&1
 	fi
 
-	worker_token=`docker swarm join-token -q worker`
+	worker_token=`$DOCKER swarm join-token -q worker`
 
 	# join the worker nodes to the swarm
 	echo "Joining ${TEST_VM_IPS[1]} to the swarm."
-	$SSH $ROOT@${TEST_VM_IPS[1]} docker swarm join --token $worker_token $master_ip:$DOCKERD_PORT
+	$SSH $ROOT@${TEST_VM_IPS[1]} $DOCKER swarm join --token $worker_token $master_ip:$DOCKERD_PORT
+
 	echo "Joining ${TEST_VM_IPS[2]} to the swarm."
-	$SSH $ROOT@${TEST_VM_IPS[2]} docker swarm join --token $worker_token $master_ip:$DOCKERD_PORT
+	$SSH $ROOT@${TEST_VM_IPS[2]} $DOCKER swarm join --token $worker_token $master_ip:$DOCKERD_PORT
 }
 
 # Create a manifest of the VMS created
 create_manifest()
 {
-
+	cat > $MANIFEST <<TEST
+	export VM1=${TEST_VM_IPS[0]}
+	export VM2=${TEST_VM_IPS[1]}
+	export VM3=${TEST_VM_IPS[2]}
+	export VM1_NAME=${TEST_VMS[0]}
+	export VM2_NAME=${TEST_VMS[1]}
+	export VM3_NAME=${TEST_VMS[2]}
+TEST
 }
+
+# Print a usage message
+usage()
+{
+	echo "Missing argument."
+	echo "testbed.sh <0|1>"
+	echo "0 - Delete testbed"
+	echo "1 - Create testbed"
+}
+
+if [ $# -eq 0 ]; then
+	usage
+	exit 1
+fi
 
 if [ $1 -eq 0 ]; then
 	for n in ${VMS[@]}; do
@@ -144,14 +228,14 @@ if [ $1 -eq 0 ]; then
 		TEST_VMS+=($vmname)
 	done
 	delete_vms
+	rm $MANIFEST
 	echo "Removed testbed ${TEST_VMS[@]}"
 	exit 0
 fi
 
-testbed_exists=0
 # If an OVA_PATH has been provided then use that to deploy the VMs
 # else if an OVA_URL is provided then download the OVA and use that instead
-if [ -n $TEST_OVAURL ]; then
+if [ "X"$TEST_OVAURL"X" != "XX" ]; then
 	fetch_ova $TEST_OVAURL
 	deploy_vms ova_fpath
 elif [ -f $TEST_OVAPATH ]; then
@@ -161,13 +245,11 @@ else
 	exit 1
 fi
 
-if  [ $testbed_exists -ne 0 ]; then
-	echo "Unable to create a new testbed, a testbed is already available - [${TEST_VMS[@]}]"
-fi
-
 get_vm_ips
 
-verify_docker_isrunning
+copy_ssh_keys
+
+verify_docker_available
 
 create_docker_swarm
 

--- a/misc/scripts/testbed.sh
+++ b/misc/scripts/testbed.sh
@@ -64,7 +64,7 @@ deploy_vms()
 			testbed_exists=1
 			continue
 		fi
-		$GOVC import.ova -ds=$TEST_VMDATASTORE -name=$vmname
+		$GOVC import.ova -ds=$TEST_VMDATASTORE -name=$vmname $1
 		if [ $? -ne 0 ]; then
 			delete_vms
 			echo "Failed to deploy VM $vmname"
@@ -116,6 +116,7 @@ verify_docker_isrunning()
 # Create a docker swarm with one master and two worker nodes
 create_docker_swarm()
 {
+	echo "Creating docker swarm on ${TEST_VMS[@]}"
 	master_ip=${TEST_VM_IPS[0]}
 	$SSH $ROOT@$master_ip docker node ls > /dev/null 2>&1
 	if [ $? -ne 0 ]; then
@@ -125,7 +126,9 @@ create_docker_swarm()
 	worker_token=`docker swarm join-token -q worker`
 
 	# join the worker nodes to the swarm
+	echo "Joining ${TEST_VM_IPS[1]} to the swarm."
 	$SSH $ROOT@${TEST_VM_IPS[1]} docker swarm join --token $worker_token $master_ip:$DOCKERD_PORT
+	echo "Joining ${TEST_VM_IPS[2]} to the swarm."
 	$SSH $ROOT@${TEST_VM_IPS[2]} docker swarm join --token $worker_token $master_ip:$DOCKERD_PORT
 }
 
@@ -154,7 +157,7 @@ if [ -n $TEST_OVAURL ]; then
 elif [ -f $TEST_OVAPATH ]; then
 	deploy_vms $TEST_OVAPATH
 else
-	echo "OVA_PATH/OVA_URL not set, no OVA to deploy.
+	echo "OVA_PATH/OVA_URL not set, no OVA to deploy."
 	exit 1
 fi
 


### PR DESCRIPTION
This change is for review only. The script is presently being tested as a stand alone script and needs the change in #1612 to be able to run as a make target. The script needs _sshpass_ utiil and if run as a stand alone script then user needs to have installed sshpass on their VM.

1. Needs three variables to be exported thats used by the script.
2. Uses govc to deploy and manage creating the testbed (1master + 2 workers).
3. Supports create/delete of a test bed.
4. Deploys the given OVA (user gives file path or a URL) as a "template" VM and creates the testbed as linked clones off that vs. using up space for three separate VMs.
5. Checks and installs docker on the VMs and creates a swarm on those.

User can provide an OVA that has docker already installed on it in which case the script won't bother installing docker.

Photon OVA has an issue that the first login needs the root password to be changed, This is difficult to handle in a script and hence unable to use Photon presently. I can use expect to work around this but thats not done yet. Will need expect to be installed in vibauthor-go container so it can be used or user should have Tcl/Tk installed on the VM to have expect available for the script. If the OVA has the password for root user already set (which is ideal as the user can set up their VM the way they want and then use that as the VM type for their test deployments) then the script should work ok.