### PR TITLE
Enables Mkdir and adds Mount, Unmount impl for Windows

### DIFF
--- a/client_plugin/utils/fs/fs_linux.go
+++ b/client_plugin/utils/fs/fs_linux.go
@@ -119,23 +119,6 @@ func DevAttachWaitFallback() {
 	time.Sleep(sleepBeforeMount)
 }
 
-// Mkdir creates a directory at the specified path
-func Mkdir(path string) error {
-	stat, err := os.Lstat(path)
-	if os.IsNotExist(err) {
-		if err := os.MkdirAll(path, 0755); err != nil {
-			return err
-		}
-	} else if err != nil {
-		return err
-	}
-
-	if stat != nil && !stat.IsDir() {
-		return fmt.Errorf("%v already exist and it's not a directory", path)
-	}
-	return nil
-}
-
 // Mkfs creates a filesystem at the specified volDev.
 func Mkfs(fstype string, label string, volDev *VolumeDevSpec) error {
 	device, err := getDevicePath(volDev)


### PR DESCRIPTION
## Description
This PR enables directory creation, volume mounting and unmounting on the Windows platform.

* Moves common `Mkdir(..)` from `fs_linux.go` to `fs.go`.
* Adds `PowerShell` based `Mount(..)` and `Unmount(..)` impl to `fs_windows.go`.

**Note:** Go doesn't implement `syscall.Mount(..)` and `syscall.Unmount(..)` for Windows.

## Output
**Create Volume**
![screen shot 2017-07-20 at 12 34 49 pm](https://user-images.githubusercontent.com/1722758/28436374-99f64178-6d4b-11e7-9d09-52afc36273bd.png)

**List Volumes**
![screen shot 2017-07-20 at 12 32 59 pm](https://user-images.githubusercontent.com/1722758/28436244-0f7afa5c-6d4b-11e7-9aa1-2092d7a5dea8.png)

**Inspect Volume**
<img width="550" alt="screen shot 2017-07-20 at 12 33 43 pm" src="https://user-images.githubusercontent.com/1722758/28436344-852cf6e2-6d4b-11e7-813a-df1eca1a903c.png">

**Attach Volume**
![screen shot 2017-07-20 at 1 06 54 pm](https://user-images.githubusercontent.com/1722758/28436599-59de0f2a-6d4c-11e7-9329-94cadb9dd498.png)

**Create File (within Container)**
![screen shot 2017-07-20 at 1 06 26 pm](https://user-images.githubusercontent.com/1722758/28436607-60cd8ee6-6d4c-11e7-8df2-cb268dbe092f.png)

**Verify File (from Host)**
![screen shot 2017-07-20 at 12 34 02 pm](https://user-images.githubusercontent.com/1722758/28436270-2e0a9b62-6d4b-11e7-9684-c43d29da61e8.png)

**Remove Volume**
![screen shot 2017-07-20 at 12 35 51 pm](https://user-images.githubusercontent.com/1722758/28436417-c370b092-6d4b-11e7-9d85-87a229a6d9ad.png)

## Test Results
The `test-all` target passes locally, and following is the tail'd output.
```
--- PASS: TestCommands (0.68s)
	cmd_linux_test.go:30: 
		Creating Test Volume with name = [TestVol]...
PASS
coverage: 40.7% of statements
ssh  -kTax -o StrictHostKeyChecking=no root@10.192.122.236 /tmp/docker-volume-vsphere/docker-volume-vsphere.test -test.v \
		-v DefaultTestVol \
		-H1 tcp://10.192.122.236:2375 -H2 tcp://10.192.108.211:2375
=== RUN   TestSanity
2017-07-20T13:17:37-07:00 START: Running TestSanity on  tcp://10.192.122.236:2375 (may take a while)...
2017-07-20T13:17:43-07:00 END: Running TestSanity on  tcp://10.192.122.236:2375 (may take a while)...
--- PASS: TestSanity (5.79s)
	sanity_test.go:207: Successfully connected to tcp://10.192.122.236:2375
	sanity_test.go:207: Successfully connected to tcp://10.192.108.211:2375
	sanity_test.go:225: Creating vol=DefaultTestVol on client tcp://10.192.122.236:2375.
	sanity_test.go:111: Running cmd=&[touch /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.192.122.236:2375
	sanity_test.go:111: Running cmd=&[stat /mnt/testvol/DefaultTestVol/file_to_touch] with vol=DefaultTestVol on client tcp://10.192.122.236:2375
=== RUN   TestConcurrency
2017-07-20T13:17:43-07:00 Running concurrent tests on tcp://10.192.122.236:2375 and tcp://10.192.108.211:2375 (may take a while)...
2017-07-20T13:17:43-07:00 START: Running create/delete multi-host concurrent test ...
2017-07-20T13:17:52-07:00 END: Running create/delete multi-host concurrent test ...
Running same docker host concurrent create/delete test on tcp://10.192.122.236:2375...
2017-07-20T13:17:57-07:00 START: Running clone concurrent test...
2017-07-20T13:18:06-07:00 END: Running clone concurrent test...
--- PASS: TestConcurrency (22.83s)
	sanity_test.go:207: Successfully connected to tcp://10.192.122.236:2375
	sanity_test.go:207: Successfully connected to tcp://10.192.108.211:2375
PASS
coverage: 0.0% of statements
```