### PR TITLE
Fixed request options init for create op.

### DIFF
--- a/client_plugin/drivers/photon/photon_driver.go
+++ b/client_plugin/drivers/photon/photon_driver.go
@@ -131,7 +131,11 @@ func NewVolumeDriver(cfg config.Config, mountDir string) *VolumeDriver {
 }
 
 // validateCreateOptions validates the volume create request.
-func validateCreateOptions(r volume.Request) error {
+func validateCreateOptions(r *volume.Request) error {
+	if r.Options == nil {
+		r.Options = make(map[string]string)
+	}
+
 	// Clone isn't supported
 	if _, result := r.Options["clone-from"]; result == true {
 		return fmt.Errorf("Unrecognized option - clone-from")
@@ -439,7 +443,7 @@ func (d *VolumeDriver) UnmountVolume(name string) error {
 func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 	log.WithFields(log.Fields{"name": r.Name, "option": r.Options}).Info("Creating volume ")
 
-	err := validateCreateOptions(r)
+	err := validateCreateOptions(&r)
 	if err != nil {
 		return volume.Response{Err: err.Error()}
 	}

--- a/client_plugin/drivers/vmdk/vmdk_driver.go
+++ b/client_plugin/drivers/vmdk/vmdk_driver.go
@@ -266,8 +266,9 @@ func (d *VolumeDriver) processMount(r volume.MountRequest) volume.Response {
 	return volume.Response{Mountpoint: mountpoint}
 }
 
-// prepareCreateOptions sets default options for create request r.
-func (d *VolumeDriver) prepareCreateOptions(r volume.Request) error {
+// prepareCreateOptions sets default options for the given request, allocates
+// request options if needed
+func (d *VolumeDriver) prepareCreateOptions(r *volume.Request) error {
 	if r.Options == nil {
 		r.Options = make(map[string]string)
 	}
@@ -332,7 +333,7 @@ func (d *VolumeDriver) detachAndRemove(name string) {
 
 // Create creates a volume.
 func (d *VolumeDriver) Create(r volume.Request) volume.Response {
-	err := d.prepareCreateOptions(r)
+	err := d.prepareCreateOptions(&r)
 	if err != nil {
 		log.WithFields(log.Fields{"name": r.Name, "error": err}).Error("Failed to prepare options ")
 		return volume.Response{Err: err.Error()}


### PR DESCRIPTION
Verified via the command line posted in the issue,

root@photon-machine [ /vol/vpl-dv/docker-volume-vsphere ]# docker run -it --volume-driver=vsphere -v debugvol14@sharedVmfs-0:/v1 --name=abc busybox
/ # 