### PR TITLE
Enables ssh via Go for Windows OpenSSH server

### DIFF
--- a/tests/utils/ssh/ssh_default.go
+++ b/tests/utils/ssh/ssh_default.go
@@ -12,23 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This util exposes util to invoke remove commands using ssh
+// Exposes util to invoke remote commands on non-windows hosts via ssh.
+
+// +build !runoncewin
 
 package ssh
 
 import (
-	"log"
+	"os"
 	"os/exec"
 	"strings"
 )
 
-// InvokeCommandLocally - can be consumed by test directly to invoke
-// any command locally.
+// sshKeyOptPath is the option to specify the rsa key while connecting via ssh.
+const sshKeyOptPath = "-i /root/.ssh/id_rsa"
+
+// InvokeCommand - can be consumed by test directly to invoke
+// any command on the remote host.
+// ip: remote machine address to execute on the machine
 // cmd: A command string to be executed on the remote host as per
-func InvokeCommandLocally(cmd string) (string, error) {
-	out, err := exec.Command("sh", "-c", cmd).CombinedOutput()
-	if err != nil {
-		log.Printf("Failed to invoke command [%s]: %v", cmd, err)
+func InvokeCommand(ip, cmd string) (string, error) {
+	sshKeyOpt := strings.Split(os.Getenv("SSH_KEY_OPT"), " ")
+	if sshKeyOpt == nil {
+		sshKeyOpt = strings.Split(sshKeyOptPath, " ")
 	}
+	sshIdentity := []string{sshKeyOpt[0], sshKeyOpt[1], "-q", "-kTax", "-o StrictHostKeyChecking=no"}
+
+	out, err := exec.Command("/usr/bin/ssh", append(sshIdentity, "root@"+ip, cmd)...).CombinedOutput()
 	return strings.TrimSpace(string(out[:])), err
 }

--- a/tests/utils/ssh/ssh_win.go
+++ b/tests/utils/ssh/ssh_win.go
@@ -1,0 +1,39 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Exposes util to invoke remote commands on windows hosts via ssh.
+
+// +build runoncewin
+
+package ssh
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// sshTemplate is the ssh command template for Windows hosts.
+const sshTemplate = "/usr/bin/ssh -q -o StrictHostKeyChecking=no root@%s '%s'; exit"
+
+// InvokeCommand invokes the given command on the given host via ssh.
+func InvokeCommand(ip, cmdStr string) (string, error) {
+	// OpenSSH sessions terminate sporadically when a pty isn't allocated.
+	// The -t flag doesn't work with OpenSSH on Windows, so we wrap the ssh call
+	// within a bash session as a workaround, so that a pty is created.
+	cmd := exec.Command("/bin/bash")
+	cmd.Stdin = strings.NewReader(fmt.Sprintf(sshTemplate, ip, cmdStr))
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out[:])), err
+}

--- a/tests/utils/ssh/ssh_win.go
+++ b/tests/utils/ssh/ssh_win.go
@@ -14,7 +14,7 @@
 
 // Exposes util to invoke remote commands on windows hosts via ssh.
 
-// +build runoncewin
+// +build winutil
 
 package ssh
 

--- a/tests/utils/ssh/sshdefault.go
+++ b/tests/utils/ssh/sshdefault.go
@@ -14,7 +14,7 @@
 
 // Exposes util to invoke remote commands on non-windows hosts via ssh.
 
-// +build !runoncewin
+// +build !winutil
 
 package ssh
 


### PR DESCRIPTION
This PR enables `ssh` via `Go` for the Windows `OpenSSH` server. This will aid the development of e2e tests for the Windows plugin.

This PR has been reviewed in #1640.