### PR TITLE
Enables volume creation e2e test for Windows

### DIFF
--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2016 VMware, Inc. All Rights Reserved.
+# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -262,7 +262,7 @@ pkg-post:
 #   Need target machines (ESX/Guest) to have proper ~/.ssh/authorized_keys
 #
 # You can
-#   set ESX and VM (and VM1 / VM2) as env. vars,
+#   set ESX and VM (and VM1 / VM2 / WIN_VM1) as env. vars,
 # or pass on command line
 # 	make deploy-esx ESX=10.20.105.54
 # 	make deploy-vm  VM=10.20.105.121
@@ -381,14 +381,16 @@ test-e2e:
 	$(log_target)
 	$(BUILD) test-e2e-runalways
 	$(BUILD) test-e2e-runonce
+	# TODO: Enable $(BUILD) test-e2e-runonce-windows once Windows VM is available locally.
 
 #
 # E2E test target to control test run on CI.
 # We have 2 ESXs on CI testbed and 2 datastore type each (VMFS/VSAN).
 # test-e2e-runalways: makes sure to run test always
 # test-e2e-runonce: makes sure to run test *once per ESX*
+# test-e2e-runonce-windows: makes sure to run windows tests *once per ESX*
 #
-.PHONY: test-e2e-runalways test-e2e-runonce
+.PHONY: test-e2e-runalways test-e2e-runonce test-e2e-runonce-windows
 test-e2e-runalways:
 	$(log_target)
 	$(GO) test -v -timeout 40m -tags runalways $(E2E_Tests)
@@ -396,6 +398,10 @@ test-e2e-runalways:
 test-e2e-runonce:
 	$(log_target)
 	$(GO) test -v -timeout 40m -tags runonce $(E2E_Tests)
+
+test-e2e-runonce-windows:
+	$(log_target)
+	$(GO) test -v -timeout 40m -tags "runoncewin winutil" $(E2E_Tests)
 
 .PHONY:clean-vm clean-esx clean-all clean-docker
 clean-vm:

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2016 VMware, Inc. All Rights Reserved.
+# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -139,6 +139,7 @@ else
     -e "ESX=$ESX" \
     -e "VM1=$VM1" \
     -e "VM2=$VM2" \
+    -e "WIN_VM1=$WIN_VM1" \
     -e "GOVC_INSECURE=1" \
     -e "GOVC_URL=$ESX" \
     -e "GOVC_USERNAME=$GOVC_USERNAME" \

--- a/tests/e2e/volumecreate_win_test.go
+++ b/tests/e2e/volumecreate_win_test.go
@@ -1,0 +1,58 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Windows specific options for volume creation tests.
+
+// +build runoncewin
+
+package e2e
+
+import "github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
+
+var (
+	// invalidVolNameList is a slice of volume names for the TestInvalidName test.
+	// 1. having more than 100 chars
+	// 2. ending -NNNNNN (6Ns)
+	// 3. contains @invalid datastore name
+	// 4. having various chars including alphanumerics
+	invalidVolNameList = []string{
+		inputparams.GetVolumeNameOfSize(101),
+		"volume-000000",
+		inputparams.GetUniqueVolumeName("volume") + "@invaliddatastore",
+		"volume-0000000-****-###",
+	}
+
+	// validFstype is a valid fstype for the TestValidOptions test.
+	validFstype = "ntfs"
+)
+
+// validVolNames returns a slice of volume names for the TestValidName test.
+// 1. having 100 chars
+// 2. ending in 5Ns
+// 3. ending in 7Ns
+// 4. contains @datastore (valid name)
+// 5. contains multiple '@'
+// 6. contains unicode character
+// 7. contains space
+func (s *VolumeCreateTestSuite) validVolNames() []string {
+	return []string{
+		inputparams.GetVolumeNameOfSize(100),
+		"volume-00000",
+		"volume-0000000",
+		inputparams.GetUniqueVolumeName("abc") + "@" + s.config.Datastores[0],
+		inputparams.GetUniqueVolumeName("abc") + "@@@@" + s.config.Datastores[0],
+		inputparams.GetUniqueVolumeName("volume-你"),
+		"\"volume space\"",
+	}
+}

--- a/tests/e2e/volumecreatedefault_test.go
+++ b/tests/e2e/volumecreatedefault_test.go
@@ -1,0 +1,78 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Options and additional volume creation tests for non-windows platforms.
+
+// +build runonce
+
+package e2e
+
+import (
+	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
+
+	. "gopkg.in/check.v1"
+)
+
+var (
+	// invalidVolNameList is a slice of volume names for the TestInvalidName test.
+	// 1. having more than 100 chars
+	// 2. ending -NNNNNN (6Ns)
+	// 3. contains @invalid datastore name
+	invalidVolNameList = []string{
+		inputparams.GetVolumeNameOfSize(101),
+		"Volume-000000",
+		inputparams.GetUniqueVolumeName("Volume") + "@invalidDatastore",
+	}
+
+	// validFstype is a valid fstype for the TestValidOptions test.
+	validFstype = "ext4"
+)
+
+// validVolNames returns a slice of volume names for the TestValidName test.
+// 1. having 100 chars
+// 2. having various chars including alphanumerics
+// 3. ending in 5Ns
+// 4. ending in 7Ns
+// 5. contains @datastore (valid name)
+// 6. contains multiple '@'
+// 7. contains unicode character
+// 8. contains space
+func (s *VolumeCreateTestSuite) validVolNames() []string {
+	return []string{
+		inputparams.GetVolumeNameOfSize(100),
+		"Volume-0000000-****-###",
+		"Volume-00000",
+		"Volume-0000000",
+		inputparams.GetUniqueVolumeName("abc") + "@" + s.config.Datastores[0],
+		inputparams.GetUniqueVolumeName("abc") + "@@@@" + s.config.Datastores[0],
+		inputparams.GetUniqueVolumeName("Volume-你"),
+		"\"Volume Space\"",
+	}
+}
+
+// TestValidXFSOption tests valid volume creation with fstype xfs.
+func (s *VolumeCreateTestSuite) TestValidXFSOption(c *C) {
+	misc.LogTestStart(c.TestName())
+
+	// xfs file system needs volume name upto than 12 characters
+	xfsVolName := inputparams.GetVolumeNameOfSize(12)
+	s.volumeList = append(s.volumeList, xfsVolName)
+	out, err := dockercli.CreateVolumeWithOptions(s.config.DockerHosts[0], xfsVolName, " -o fstype=xfs")
+	c.Assert(err, IsNil, Commentf(out))
+	s.accessCheck(s.config.DockerHosts[0], s.volumeList, c)
+
+	misc.LogTestEnd(c.TestName())
+}

--- a/tests/utils/inputparams/testparams_win.go
+++ b/tests/utils/inputparams/testparams_win.go
@@ -1,0 +1,38 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Support for basic utility/helper methods used in tests on the windows platform.
+
+// +build winutil
+
+package inputparams
+
+import (
+	"log"
+	"os"
+)
+
+// volNameCharset is the valid set of characters for volume name generation.
+const volNameCharset = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+// getDockerHosts returns a slice of Docker host VM IP addresses.
+func getDockerHosts() []string {
+	dockerHosts := []string{
+		os.Getenv("WIN_VM1"),
+	}
+	if dockerHosts[0] == "" {
+		log.Fatal("A windows docker host is needed to run tests.")
+	}
+	return dockerHosts
+}

--- a/tests/utils/inputparams/testparamsdefault.go
+++ b/tests/utils/inputparams/testparamsdefault.go
@@ -1,0 +1,39 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Support for basic utility/helper methods used in tests on non-windows platforms.
+
+// +build !winutil
+
+package inputparams
+
+import (
+	"log"
+	"os"
+)
+
+// volNameCharset is the valid set of characters for volume name generation.
+const volNameCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// getDockerHosts returns a slice of Docker host VM IP addresses.
+func getDockerHosts() []string {
+	dockerHosts := []string{
+		os.Getenv("VM1"),
+		os.Getenv("VM2"),
+	}
+	if dockerHosts[0] == "" || dockerHosts[1] == "" {
+		log.Fatal("Two linux docker hosts are needed to run tests.")
+	}
+	return dockerHosts
+}


### PR DESCRIPTION
## Description
This PR enables volume creation e2e tests for the Windows plugin.

* Adds `test-e2e-runonce-windows` target to `Makefile`.
* Refactors `volumecreation_test.go` to handle linux / windows specific options.
* Refactors the `inputparams` module to support linux / windows specific tests.

## Test Results
The `test-e2e-runonce-windows` target passes locally. It's currently not enabled for CI; however, it will be enabled along with a new PR that would handle vDVS plugin deployment on Windows.

Here's the output from the `test-e2e-runonce-windows` target.
```
=> Running target test-e2e-runonce-windows Fri Jul 28 01:22:19 UTC 2017

GO15VENDOREXPERIMENT=1 go test -v -timeout 40m -tags "runoncewin winutil" github.com/vmware/docker-volume-vsphere/tests/e2e
=== RUN   Test
2017/07/28 01:22:23 START: VolumeCreateTestSuite.TestInvalidName
2017/07/28 01:22:23 Creating volume [volume-0000000-****-###] on VM [10.192.151.205]
2017/07/28 01:22:23 Creating volume [volume_volume_912225@invaliddatastore] on VM [10.192.151.205]
2017/07/28 01:22:23 Creating volume [fpllngzieyoh43e0133ols6k1hh2gdnyxxvi7hvszwk1b182tvjzjpezi4hx9gvmkir0xcta0opsb5qipjzb3h3x9kcegta5m1zcv] on VM [10.192.151.205]
2017/07/28 01:22:23 Creating volume [volume-000000] on VM [10.192.151.205]
2017/07/28 01:22:26 END: VolumeCreateTestSuite.TestInvalidName
2017/07/28 01:22:26 START: VolumeCreateTestSuite.TestInvalidOptions
2017/07/28 01:22:26 Creating volume [option_volume_698345] with options [ -o diskformat=zeroedthick,thin] on VM [10.192.151.205]
2017/07/28 01:22:26 Creating volume [option_volume_1060130] with options [ -o fstype=xfs_ext] on VM [10.192.151.205]
2017/07/28 01:22:26 Creating volume [option_volume_720751] with options [ -o access=read-write-both] on VM [10.192.151.205]
2017/07/28 01:22:26 Creating volume [option_volume_630744] with options [ -o access=write-only] on VM [10.192.151.205]
2017/07/28 01:22:26 Creating volume [option_volume_273860] with options [ -o access=read-write-both] on VM [10.192.151.205]
2017/07/28 01:22:26 Creating volume [option_volume_350110] with options [ -o diskformat=zeroedthickk] on VM [10.192.151.205]
2017/07/28 01:22:26 Creating volume [option_volume_698345] with options [ -o clone-from=IDontExist] on VM [10.192.151.205]
2017/07/28 01:22:26 Creating volume [option_volume_411341] with options [ -o size=100mbb] on VM [10.192.151.205]
2017/07/28 01:22:26 Creating volume [option_volume_313748] with options [ -o size=100gbEE] on VM [10.192.151.205]
2017/07/28 01:22:26 Creating volume [option_volume_1078773] with options [ -o sizes=100mb] on VM [10.192.151.205]
2017/07/28 01:22:30 END: VolumeCreateTestSuite.TestInvalidOptions
2017/07/28 01:22:30 START: VolumeCreateTestSuite.TestValidName
2017/07/28 01:22:30 Creating volume [volume-0000000] on VM [10.192.151.205]
2017/07/28 01:22:30 Creating volume [abc_volume_870316@sharedvmfs-0] on VM [10.192.151.205]
2017/07/28 01:22:30 Creating volume [nnwfq625ej8ryfzcatzuss6barjze12q547f0es0aazigta8vts009ceanmn26u849um8p9at6qxllf4x42v0tv1fqc9fajvnz44] on VM [10.192.151.205]
2017/07/28 01:22:30 Creating volume [volume-00000] on VM [10.192.151.205]
2017/07/28 01:22:30 Creating volume [abc_volume_899229@@@@sharedvmfs-0] on VM [10.192.151.205]
2017/07/28 01:22:30 Creating volume ["volume space"] on VM [10.192.151.205]
2017/07/28 01:22:30 Creating volume [volume-你_volume_1015556] on VM [10.192.151.205]
2017/07/28 01:23:32 Checking volume [volume-00000 abc_volume_899229@@@@sharedvmfs-0 nnwfq625ej8ryfzcatzuss6barjze12q547f0es0aazigta8vts009ceanmn26u849um8p9at6qxllf4x42v0tv1fqc9fajvnz44 "volume space" volume-0000000 volume-你_volume_1015556 abc_volume_870316@sharedvmfs-0] availability from VM [10.192.151.205]
2017/07/28 01:23:34 END: VolumeCreateTestSuite.TestValidName
2017/07/28 01:23:34 Destroying volume [volume-00000 abc_volume_899229@@@@sharedvmfs-0 nnwfq625ej8ryfzcatzuss6barjze12q547f0es0aazigta8vts009ceanmn26u849um8p9at6qxllf4x42v0tv1fqc9fajvnz44 "volume space" volume-0000000 volume-你_volume_1015556 abc_volume_870316@sharedvmfs-0]
2017/07/28 01:23:37 START: VolumeCreateTestSuite.TestValidOptions
2017/07/28 01:23:37 Creating volume [clone_src_volume_999833] on VM [10.192.151.205]
2017/07/28 01:23:50 Creating volume [option_volume_1005046] with options [ -o diskformat=zeroedthick] on VM [10.192.151.205]
2017/07/28 01:23:50 Creating volume [option_volume_426196] with options [ -o clone-from=clone_src_volume_999833] on VM [10.192.151.205]
2017/07/28 01:23:50 Creating volume [option_volume_838409] with options [ -o size=10gb] on VM [10.192.151.205]
2017/07/28 01:23:50 Creating volume [option_volume_296032] with options [ -o attach-as=persistent] on VM [10.192.151.205]
2017/07/28 01:23:50 Creating volume [option_volume_315958] with options [ -o access=read-only] on VM [10.192.151.205]
2017/07/28 01:23:50 Creating volume [option_volume_734076] with options [ -o fstype=ntfs] on VM [10.192.151.205]
2017/07/28 01:23:50 Creating volume [option_volume_674999] with options [ -o access=read-write] on VM [10.192.151.205]
2017/07/28 01:23:50 Creating volume [option_volume_335095] with options [ -o diskformat=eagerzeroedthick] on VM [10.192.151.205]
2017/07/28 01:23:50 Creating volume [option_volume_329240] with options [ -o diskformat=thin] on VM [10.192.151.205]
2017/07/28 01:23:50 Creating volume [option_volume_685544] with options [ -o attach-as=independent_persistent] on VM [10.192.151.205]
2017/07/28 01:25:18 Checking volume [clone_src_volume_999833 option_volume_426196 option_volume_315958 option_volume_685544 option_volume_838409 option_volume_296032 option_volume_674999 option_volume_1005046 option_volume_329240 option_volume_734076 option_volume_335095] availability from VM [10.192.151.205]
2017/07/28 01:25:20 END: VolumeCreateTestSuite.TestValidOptions
2017/07/28 01:25:20 Destroying volume [clone_src_volume_999833 option_volume_426196 option_volume_315958 option_volume_685544 option_volume_838409 option_volume_296032 option_volume_674999 option_volume_1005046 option_volume_329240 option_volume_734076 option_volume_335095]
OK: 4 passed
--- PASS: Test (185.37s)
PASS
ok  	github.com/vmware/docker-volume-vsphere/tests/e2e	185.379s
```