### PR TITLE
Adds windows plugin deployment and test targets

### DIFF
--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -93,6 +93,8 @@ VMDKOPS_TEST_MODULE := vmdkops
 VMDKOPS_MODULE_SRC = $(VMDKOPS_MODULE)/*.go $(VMCI_SRC)
 
 # All sources. We rebuild if anything changes here
+PLUGIN_SRC_DIR := ../
+
 COMMON_SRC = utils/log_formatter/log_formatter.go \
 	utils/refcount/refcnt.go utils/plugin_server/plugin_server.go \
 	utils/fs/fs.go utils/config/config.go utils/plugin_utils/plugin_utils.go \
@@ -288,6 +290,7 @@ TMP_LOC := /tmp/$(PLUGNAME)
 DEPLOY_VM_SH  := $(DEPLOY_TOOLS) deployvm
 DEPLOY_VM_TEST_SH  := $(DEPLOY_TOOLS) deployvmtest
 DEPLOY_VM_PLUGIN_SH := $(DEPLOY_TOOLS) deployplugin
+DEPLOY_PLUGIN_WINDOWS_VM_SH := $(DEPLOY_TOOLS) deploypluginwindows
 DEPLOY_ESX_SH := $(DEPLOY_TOOLS) deployesx
 DEPLOY_ESX_FOR_UPGRADE := $(DEPLOY_TOOLS) deployesxForUpgrade
 CLEANVM_SH    := $(DEPLOY_TOOLS) cleanvm
@@ -319,6 +322,8 @@ deploy-vm-test:
 	$(DEPLOY_VM_TEST_SH) "$(VMS)" $(BIN) $(SCRIPTS)
 deploy-vm-plugin:
 	$(DEPLOY_VM_PLUGIN_SH) "$(VM2)" $(PLUGIN_BIN) $(MANAGED_PLUGIN_LOC) $(SCRIPTS) $(DOCKER_HUB_REPO) $(VERSION_TAG) $(EXTRA_TAG)
+deploy-plugin-windows-vm:
+	$(DEPLOY_PLUGIN_WINDOWS_VM_SH) "$(WIN_VM1)" $(PLUGIN_SRC_DIR)
 
 deploy-all: deploy-esx deploy-vm deploy-vm-test
 deploy: deploy-all
@@ -381,7 +386,11 @@ test-e2e:
 	$(log_target)
 	$(BUILD) test-e2e-runalways
 	$(BUILD) test-e2e-runonce
-	# TODO: Enable $(BUILD) test-e2e-runonce-windows once Windows VM is available locally.
+
+# An end-to-end windows test target for vSphere Docker Volume Driver
+test-e2e-windows:
+	$(log_target)
+	$(BUILD) test-e2e-runonce-windows
 
 #
 # E2E test target to control test run on CI.

--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -289,8 +289,9 @@ TMP_LOC := /tmp/$(PLUGNAME)
 # scripts started locally to deploy to and clean up test machines
 DEPLOY_VM_SH  := $(DEPLOY_TOOLS) deployvm
 DEPLOY_VM_TEST_SH  := $(DEPLOY_TOOLS) deployvmtest
-DEPLOY_VM_PLUGIN_SH := $(DEPLOY_TOOLS) deployplugin
-DEPLOY_PLUGIN_WINDOWS_VM_SH := $(DEPLOY_TOOLS) deploypluginwindows
+BUILD_PLUGIN_SH := $(DEPLOY_TOOLS) buildplugin
+BUILD_WINDOWS_PLUGIN_SH := $(DEPLOY_TOOLS) buildwindowsplugin
+DEPLOY_WINDOWS_PLUGIN_SH := $(DEPLOY_TOOLS) deploywindowsplugin
 DEPLOY_ESX_SH := $(DEPLOY_TOOLS) deployesx
 DEPLOY_ESX_FOR_UPGRADE := $(DEPLOY_TOOLS) deployesxForUpgrade
 CLEANVM_SH    := $(DEPLOY_TOOLS) cleanvm
@@ -315,15 +316,18 @@ run-upgrade-test:
 	ESX='$(ESX)' VM1='$(VM1)' VIB_BIN='$(VIB_BIN)' PLUGIN_NAME='$(PLUGIN_NAME)' PLUGIN_TAG='$(PLUGIN_TAG)' UPGRADE_FROM_VER='$(UPGRADE_FROM_VER)' UPGRADE_TO_VER='$(UPGRADE_TO_VER)' $(DOCKER_HUB_REPO)='$(DOCKER_HUB_REPO)' $(UPGRADE_TEST)
 
 VMS= $(VM1) $(VM2) $(WORKER2) $(CI_NODE4)
+WIN_VMS= $(WIN_VM1)
 
 deploy-vm: clean-vm
 	$(DEPLOY_VM_SH) "$(VMS)" $(PLUGIN_NAME):$(PLUGIN_TAG)
 deploy-vm-test:
 	$(DEPLOY_VM_TEST_SH) "$(VMS)" $(BIN) $(SCRIPTS)
-deploy-vm-plugin:
-	$(DEPLOY_VM_PLUGIN_SH) "$(VM2)" $(PLUGIN_BIN) $(MANAGED_PLUGIN_LOC) $(SCRIPTS) $(DOCKER_HUB_REPO) $(VERSION_TAG) $(EXTRA_TAG)
-deploy-plugin-windows-vm:
-	$(DEPLOY_PLUGIN_WINDOWS_VM_SH) "$(WIN_VM1)" $(PLUGIN_SRC_DIR)
+build-plugin:
+	$(BUILD_PLUGIN_SH) "$(VM2)" $(PLUGIN_BIN) $(MANAGED_PLUGIN_LOC) $(SCRIPTS) $(DOCKER_HUB_REPO) $(VERSION_TAG) $(EXTRA_TAG)
+build-windows-plugin:
+	$(BUILD_WINDOWS_PLUGIN_SH) $(WIN_VM1) $(PLUGIN_SRC_DIR)
+deploy-windows-plugin:
+	$(DEPLOY_WINDOWS_PLUGIN_SH) "$(WIN_VMS)" $(PLUGIN_SRC_DIR)
 
 deploy-all: deploy-esx deploy-vm deploy-vm-test
 deploy: deploy-all

--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -93,8 +93,6 @@ VMDKOPS_TEST_MODULE := vmdkops
 VMDKOPS_MODULE_SRC = $(VMDKOPS_MODULE)/*.go $(VMCI_SRC)
 
 # All sources. We rebuild if anything changes here
-PLUGIN_SRC_DIR := ../
-
 COMMON_SRC = utils/log_formatter/log_formatter.go \
 	utils/refcount/refcnt.go utils/plugin_server/plugin_server.go \
 	utils/fs/fs.go utils/config/config.go utils/plugin_utils/plugin_utils.go \
@@ -325,9 +323,9 @@ deploy-vm-test:
 build-plugin:
 	$(BUILD_PLUGIN_SH) "$(VM2)" $(PLUGIN_BIN) $(MANAGED_PLUGIN_LOC) $(SCRIPTS) $(DOCKER_HUB_REPO) $(VERSION_TAG) $(EXTRA_TAG)
 build-windows-plugin:
-	$(BUILD_WINDOWS_PLUGIN_SH) $(WIN_VM1) $(PLUGIN_SRC_DIR)
+	$(BUILD_WINDOWS_PLUGIN_SH) $(WIN_VM1)
 deploy-windows-plugin:
-	$(DEPLOY_WINDOWS_PLUGIN_SH) "$(WIN_VMS)" $(PLUGIN_SRC_DIR)
+	$(DEPLOY_WINDOWS_PLUGIN_SH) "$(WIN_VMS)"
 
 deploy-all: deploy-esx deploy-vm deploy-vm-test
 deploy: deploy-all

--- a/install-vdvs.ps1
+++ b/install-vdvs.ps1
@@ -16,6 +16,10 @@
 # ============================================================================
 # Run the script with the plugin url as the parameter in a PowerShell session:
 # PS C:\Users\Administrator> .\install-vdvs.ps1 <vdvs-download-url>
+#
+# The -Force parameter suppresses any confirmation prompt and performs an
+# affirmative action. For example, supplying -Force during installation will
+# implicitly uninstall the plugin if it was already installed.
 # ============================================================================
 
 <#
@@ -24,9 +28,9 @@
 .DESCRIPTION
     This script helps to download, install, uninstall, and re-install VMware vSphere Docker Volume Plugin on your system.
 .EXAMPLE
-   ./install-vdvs.ps1 https://bintray.com/vmware/vDVS/download_file?file_path=docker-volume-vsphere.zip
+    ./install-vdvs.ps1 https://bintray.com/vmware/vDVS/download_file?file_path=docker-volume-vsphere.zip
 .EXAMPLE
-   ./install-vdvs.ps1 -uninstall
+    ./install-vdvs.ps1 -uninstall
 .LINK
     https://vmware.github.io/docker-volume-vsphere/
 #>

--- a/install-vdvs.ps1
+++ b/install-vdvs.ps1
@@ -19,7 +19,9 @@
 #
 # The -Force parameter suppresses any confirmation prompt and performs an
 # affirmative action. For example, supplying -Force during installation will
-# implicitly uninstall the plugin if it was already installed.
+# uninstall any previous installation of the plugin, without confirmation.
+# Supplying -Force during uninstallation suppresses the confirmation prompt
+# and uninstalls the plugin.
 # ============================================================================
 
 <#

--- a/install-vdvs.ps1
+++ b/install-vdvs.ps1
@@ -34,7 +34,8 @@
 # Command line parameters
 param (
     [string] $uri,
-    [switch] $uninstall
+    [switch] $uninstall,
+    [switch] $Force
 )
 
 # Define the constants
@@ -66,8 +67,7 @@ $svc = Get-Service | Where-Object {$_.Name -eq $svcName}
 # Handle uninstallation
 if ($uninstall) {
     if ($svc) {
-        $confirmUninstall = Read-Host "Do you really want to uninstall $svcName [Y/N]?"
-        if ($confirmUninstall -eq "Y") {
+        if ($Force -Or ($result = Read-Host "Do you really want to uninstall $svcName [Y/N]?") -eq "Y") {
             Uninstall-Service($svc)
         }
     } else {
@@ -78,15 +78,14 @@ if ($uninstall) {
 
 # Check URI parameter for installation process
 if (! $uri) {
-     echo "Usage: install-vdvs.ps1 [[-uri] <String>] [-uninstall]"
+     echo "Usage: install-vdvs.ps1 [[-uri] <String>] [-uninstall] [-Force]"
      return
 }
 
 # Handle reinstallation
 if ($svc) {
     echo "Windows service $svcName is already installed."
-    $reinstall = Read-Host "Do you want to reinstall $svcName [Y/N]?"
-    if ($reinstall -eq "Y") {
+    if ($Force -Or ($result = Read-Host "Do you want to reinstall $svcName [Y/N]?") -eq "Y") {
         Uninstall-Service($svc)
     } else {
         return

--- a/misc/drone-scripts/deploy-and-test-wrapper.sh
+++ b/misc/drone-scripts/deploy-and-test-wrapper.sh
@@ -100,7 +100,7 @@ PARAMETER="TEST_VOL_NAME=vol.build$BUILD_NUMBER"
 
 case $FUNCTION_NAME in
 pluginSanityCheck)
-        TARGET+=" deploy-vm-plugin"
+        TARGET+=" build-plugin"
         ;;
 runtests)
         if [ -e /tmp/$ESX ]

--- a/misc/scripts/deploy-tools.sh
+++ b/misc/scripts/deploy-tools.sh
@@ -106,10 +106,7 @@ function deploypluginwindows {
         TARGET=root@$ip
 
         log "Cleaning up older files from $TARGET..."
-        $SSH $TARGET <<-EOF
-            powershell Remove-Item -Recurse -Force $WIN_PLUGIN_SRC_DIR
-		EOF
-        # EOF needs to be tab indented
+        $SSH $TARGET "powershell Remove-Item -Recurse -Force $WIN_PLUGIN_SRC_DIR"
 
         log "Transferring $PLUGIN_SRC_ZIP to $TARGET..."
         scp $PLUGIN_SRC_ZIP $TARGET:$WIN_TEMP_DIR
@@ -118,11 +115,7 @@ function deploypluginwindows {
         $SSH $TARGET "powershell Expand-Archive $WIN_TEMP_DIR\\$PLUGIN_SRC_ZIP -DestinationPath $WIN_PLUGIN_SRC_DIR"
 
         log "Building windows plugin on $TARGET..."
-        $SSH $TARGET <<-EOF
-            cd $WIN_PLUGIN_SRC_DIR
-            build.bat
-		EOF
-        # EOF needs to be tab indented
+        $SSH $TARGET "cd $WIN_PLUGIN_SRC_DIR && build.bat"
 
         log "Installing plugin as a windows service on $TARGET..."
         $SSH $TARGET <<-EOF

--- a/misc/scripts/deploy-tools.sh
+++ b/misc/scripts/deploy-tools.sh
@@ -37,6 +37,7 @@ BUILD_LOC=$TMP_LOC/build
 PLUGIN_LOC=$TMP_LOC/plugin_dockerbuild
 COMMON_VARS="../Commonvars.mk"
 VMDK_OPS_CONFIG=/etc/vmware/vmdkops/log_config.json
+PLUGIN_SRC_DIR=../
 PLUGIN_SRC_ZIP=vdvs-src.zip
 PLUGIN_BIN_ZIP=vdvs-bin.zip
 WIN_TEMP_DIR=C:\\Users\\root\\AppData\\Local\\Temp
@@ -447,19 +448,9 @@ buildplugin)
         buildplugin
         ;;
 buildwindowsplugin)
-        PLUGIN_SRC_DIR="$2"
-        if [ -z "$PLUGIN_SRC_DIR" ]
-        then
-            usage "Missing params: plugin source folder"
-        fi
         buildwindowsplugin
         ;;
 deploywindowsplugin)
-        PLUGIN_SRC_DIR="$2"
-        if [ -z "$PLUGIN_SRC_DIR" ]
-        then
-            usage "Missing params: plugin source folder"
-        fi
         deploywindowsplugin
         ;;
 *)

--- a/misc/scripts/deploy-tools.sh
+++ b/misc/scripts/deploy-tools.sh
@@ -102,8 +102,7 @@ function buildwindowsplugin {
     log "Compressing source into $PLUGIN_SRC_ZIP..."
     cd $PLUGIN_SRC_DIR
     rm -f $PLUGIN_SRC_ZIP
-    stashName=`git stash create`;
-    git archive --format zip --output $PLUGIN_SRC_ZIP $stashName
+    git archive --format zip --output $PLUGIN_SRC_ZIP HEAD
 
     log "Cleaning up older files from $TARGET..."
     $SSH $TARGET "powershell Remove-Item -Recurse -Force $WIN_PLUGIN_SRC_DIR"

--- a/misc/scripts/deploy-tools.sh
+++ b/misc/scripts/deploy-tools.sh
@@ -42,6 +42,7 @@ PLUGIN_BIN_ZIP=vdvs-bin.zip
 WIN_TEMP_DIR=C:\\Users\\root\\AppData\\Local\\Temp
 WIN_PLUGIN_SRC_DIR=C:\\Users\\root\\go\\src\\github.com\\vmware\\docker-volume-vsphere
 WIN_PLUGIN_BIN_ZIP_LOC=$WIN_PLUGIN_SRC_DIR\\build\\windows\\docker-volume-vsphere.zip
+WIN_BUILD_DIR=build/windows/
 
 # VM Functions
 
@@ -65,7 +66,7 @@ function deployvm {
     done
 }
 
-function deployplugin {
+function buildplugin {
     for ip in $IP_LIST
     do
         TARGET=root@$ip
@@ -94,40 +95,49 @@ function deployplugin {
     done
 }
 
-function deploypluginwindows {
+function buildwindowsplugin {
+    TARGET=root@${IP_LIST[0]}
+
     log "Compressing source into $PLUGIN_SRC_ZIP..."
     cd $PLUGIN_SRC_DIR
     rm -f $PLUGIN_SRC_ZIP
     stashName=`git stash create`;
     git archive --format zip --output $PLUGIN_SRC_ZIP $stashName
 
+    log "Cleaning up older files from $TARGET..."
+    $SSH $TARGET "powershell Remove-Item -Recurse -Force $WIN_PLUGIN_SRC_DIR"
+
+    log "Transferring $PLUGIN_SRC_ZIP to $TARGET..."
+    scp $PLUGIN_SRC_ZIP $TARGET:$WIN_TEMP_DIR
+
+    log "Extracting $PLUGIN_SRC_ZIP on $TARGET..."
+    $SSH $TARGET "powershell Expand-Archive $WIN_TEMP_DIR\\$PLUGIN_SRC_ZIP -DestinationPath $WIN_PLUGIN_SRC_DIR"
+
+    log "Building windows plugin on $TARGET..."
+    $SSH $TARGET "cd $WIN_PLUGIN_SRC_DIR && build.bat"
+
+    log "Copying $WIN_PLUGIN_BIN_ZIP_LOC from $TARGET to local..."
+    mkdir -p $WIN_BUILD_DIR
+    scp $TARGET:$WIN_PLUGIN_BIN_ZIP_LOC $WIN_BUILD_DIR/$PLUGIN_BIN_ZIP
+
+    log "Cleaning up..."
+    rm -f $PLUGIN_SRC_ZIP
+}
+
+function deploywindowsplugin {
+    cd $PLUGIN_SRC_DIR
+
     for ip in $IP_LIST
     do
         TARGET=root@$ip
 
-        log "Cleaning up older files from $TARGET..."
-        $SSH $TARGET "powershell Remove-Item -Recurse -Force $WIN_PLUGIN_SRC_DIR"
-
-        log "Transferring $PLUGIN_SRC_ZIP to $TARGET..."
-        scp $PLUGIN_SRC_ZIP $TARGET:$WIN_TEMP_DIR
-
-        log "Extracting $PLUGIN_SRC_ZIP on $TARGET..."
-        $SSH $TARGET "powershell Expand-Archive $WIN_TEMP_DIR\\$PLUGIN_SRC_ZIP -DestinationPath $WIN_PLUGIN_SRC_DIR"
-
-        log "Building windows plugin on $TARGET..."
-        $SSH $TARGET "cd $WIN_PLUGIN_SRC_DIR && build.bat"
+        log "Transferring dependencies to $TARGET..."
+        scp install-vdvs.ps1 $TARGET:$WIN_TEMP_DIR
+        scp $WIN_BUILD_DIR/$PLUGIN_BIN_ZIP $TARGET:$WIN_TEMP_DIR
 
         log "Installing plugin as a windows service on $TARGET..."
-        $SSH $TARGET <<-EOF
-            cd $WIN_PLUGIN_SRC_DIR
-            cp $WIN_PLUGIN_BIN_ZIP_LOC $PLUGIN_BIN_ZIP
-            powershell -ExecutionPolicy ByPass -File install-vdvs.ps1 "file:///$WIN_PLUGIN_SRC_DIR\\$PLUGIN_BIN_ZIP" -Force
-		EOF
-        # EOF needs to be tab indented
+        $SSH $TARGET "powershell -ExecutionPolicy ByPass -File $WIN_TEMP_DIR\\install-vdvs.ps1 file:///$WIN_TEMP_DIR\\$PLUGIN_BIN_ZIP -Force"
     done
-
-    log "Cleaning up..."
-    rm -f $PLUGIN_SRC_ZIP
 }
 
 function managedPluginSanityCheck {
@@ -423,7 +433,7 @@ cleanvm)
         fi
         cleanvm
         ;;
-deployplugin)
+buildplugin)
         PLUGIN_BIN="$2"
         MANAGED_PLUGIN_SRC="$3"
         SCRIPTS="$4"
@@ -434,11 +444,23 @@ deployplugin)
         then
             usage "Missing params: plugin/binary/script folder"
         fi
-        deployplugin
+        buildplugin
         ;;
-deploypluginwindows)
+buildwindowsplugin)
         PLUGIN_SRC_DIR="$2"
-        deploypluginwindows
+        if [ -z "$PLUGIN_SRC_DIR" ]
+        then
+            usage "Missing params: plugin source folder"
+        fi
+        buildwindowsplugin
+        ;;
+deploywindowsplugin)
+        PLUGIN_SRC_DIR="$2"
+        if [ -z "$PLUGIN_SRC_DIR" ]
+        then
+            usage "Missing params: plugin source folder"
+        fi
+        deploywindowsplugin
         ;;
 *)
         usage "Unknown function:  \"$FUNCTION_NAME\""


### PR DESCRIPTION
## Description
This PR adds 2 new targets, `build-windows-plugin` for building, and `deploy-windows-plugin` for deploying the plugin on a Windows VM. It also adds a `test-e2e-windows` target for executing e2e tests on that VM. Fixes #1595.

This PR also renames the existing `deploy-vm-plugin` target to `build-plugin`.

## Output
The following output comes from `make build-windows-plugin`.
```
vnoronha-m01:docker-volume-vsphere vnoronha$ make build-windows-plugin
/Library/Developer/CommandLineTools/usr/bin/make --directory=client_plugin build-windows-plugin
../misc/scripts/deploy-tools.sh buildwindowsplugin 10.192.151.205 ../


=> Compressing source into vdvs-src.zip... Tue Aug 1 12:04:02 PDT 2017




=> Cleaning up older files from root@10.192.151.205... Tue Aug 1 12:04:02 PDT 2017




=> Transferring vdvs-src.zip to root@10.192.151.205... Tue Aug 1 12:04:05 PDT 2017


vdvs-src.zip                                                                                                                                                                                              100% 4516KB   7.8MB/s   00:00    


=> Extracting vdvs-src.zip on root@10.192.151.205... Tue Aug 1 12:04:06 PDT 2017




=> Building windows plugin on root@10.192.151.205... Tue Aug 1 12:04:33 PDT 2017


Found Go.
Found Microsoft Visual C++ Build Tools.
Cleaning up.
The system cannot find the path specified.
The system cannot find the path specified.
Clean up complete.
Building vDVS...
Entering the MSVC Build Tools environment.
Entering the vmci source directory.
Compiling vmci_client.dll.
Microsoft (R) C/C++ Optimizing Compiler Version 19.00.24210 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

vmci_client.c
vmci_client.c(143): warning C4133: 'function': incompatible types - from 'FILE *' to 'const char *const '
vmci_client.c(227): warning C4133: 'function': incompatible types - from 'uint32_t *' to 'const char *'
vmci_client.c(233): warning C4133: 'function': incompatible types - from 'uint32_t *' to 'const char *'
vmci_client.c(248): warning C4133: 'function': incompatible types - from 'uint32_t *' to 'char *'
vmci_client.c(262): warning C4133: 'function': incompatible types - from 'uint32_t *' to 'char *'
vmci_client.c(251): warning C4477: 'snprintf' : format string '%d' requires an argument of type 'int', but variadic argument 2 has type 'std::size_t'
vmci_client.c(251): note: consider using '%zd' in the format string
Microsoft (R) Incremental Linker Version 14.00.24210.0
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:vmci_client.exe 
/defaultlib:ws2_32.lib 
/DLL 
/OUT:vmci_client.dll 
/DEF:vmci_client.def 
vmci_client.obj 
   Creating library vmci_client.lib and object vmci_client.exp
Compiled vmci_client.dll successfully.
Moving vmci_client.dll to the vmdkops directory.
        1 file(s) moved.
Successfully moved vmci_client.dll to the vmdkops directory.
Entering the plugin directory.
Building vdvs.exe.
github.com/vmware/docker-volume-vsphere/vendor/github.com/Sirupsen/logrus
github.com/vmware/docker-volume-vsphere/vendor/golang.org/x/sys/windows
github.com/vmware/docker-volume-vsphere/vendor/github.com/Microsoft/go-winio
github.com/vmware/docker-volume-vsphere/vendor/golang.org/x/net/proxy
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/go-connections/sockets
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/go-plugins-helpers/sdk
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/go-plugins-helpers/volume
github.com/vmware/docker-volume-vsphere/vendor/golang.org/x/sys/windows/registry
github.com/vmware/docker-volume-vsphere/vendor/golang.org/x/sys/windows/svc
github.com/vmware/docker-volume-vsphere/vendor/golang.org/x/sys/windows/svc/eventlog
github.com/vmware/docker-volume-vsphere/vendor/golang.org/x/sys/windows/svc/mgr
github.com/vmware/docker-volume-vsphere/vendor/github.com/kardianos/service
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/distribution/digest
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/distribution/reference
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/engine-api/client/transport
github.com/vmware/docker-volume-vsphere/vendor/golang.org/x/net/context
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/engine-api/client/transport/cancellable
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/engine-api/types/blkiodev
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/engine-api/types/strslice
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/go-connections/nat
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/go-units
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/engine-api/types/container
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/engine-api/types/versions
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/engine-api/types/filters
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/engine-api/types/network
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/engine-api/types/registry
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/engine-api/types/swarm
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/engine-api/types
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/engine-api/types/reference
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/engine-api/types/time
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/go-connections/tlsconfig
github.com/vmware/docker-volume-vsphere/vendor/github.com/docker/engine-api/client
github.com/vmware/docker-volume-vsphere/client_plugin/drivers
github.com/vmware/docker-volume-vsphere/client_plugin/utils/fs
github.com/vmware/docker-volume-vsphere/client_plugin/utils/plugin_utils
github.com/vmware/docker-volume-vsphere/client_plugin/utils/refcount
github.com/vmware/docker-volume-vsphere/client_plugin/drivers/utils
github.com/vmware/docker-volume-vsphere/vendor/github.com/natefinch/lumberjack
github.com/vmware/docker-volume-vsphere/client_plugin/utils/log_formatter
github.com/vmware/docker-volume-vsphere/client_plugin/utils/config
github.com/vmware/docker-volume-vsphere/vendor/github.com/vmware/photon-controller-go-sdk/photon/lightwave
github.com/vmware/docker-volume-vsphere/vendor/github.com/vmware/photon-controller-go-sdk/photon
github.com/vmware/docker-volume-vsphere/client_plugin/drivers/photon
github.com/vmware/docker-volume-vsphere/client_plugin/drivers/vmdk/vmdkops
github.com/vmware/docker-volume-vsphere/client_plugin/drivers/vmdk
github.com/vmware/docker-volume-vsphere/client_plugin/utils/plugin_server
command-line-arguments
Successfully built vdvs.exe.
Writing vsphere.json to the docker plugin config directory.
Successfully wrote vsphere.json to the docker plugin config directory.
Moving binaries to the build directory.
        1 file(s) moved.
        1 file(s) moved.
Successfully moved binaries to the build directory.
vDVS build complete.
Binaries are available under C:\Users\root\go\src\github.com\vmware\docker-volume-vsphere\build\windows.


=> Copying C:\Users\root\go\src\github.com\vmware\docker-volume-vsphere\build\windows\docker-volume-vsphere.zip from root@10.192.151.205 to local... Tue Aug 1 12:04:52 PDT 2017


docker-volume-vsphere.zip                                                                                                                                                                                 100% 2100KB  12.8MB/s   00:00    


=> Cleaning up... Tue Aug 1 12:04:53 PDT 2017
```

The following one is from `make deploy-windows-plugin`.
```
vnoronha-m01:docker-volume-vsphere vnoronha$ make deploy-windows-plugin
/Library/Developer/CommandLineTools/usr/bin/make --directory=client_plugin deploy-windows-plugin
../misc/scripts/deploy-tools.sh deploywindowsplugin "10.192.151.205" ../


=> Transferring dependencies to root@10.192.151.205... Tue Aug 1 12:05:23 PDT 2017


install-vdvs.ps1                                                                                                                                                                                          100% 4496   100.4KB/s   00:00    
vdvs-bin.zip                                                                                                                                                                                              100% 2100KB   9.6MB/s   00:00    


=> Installing plugin as a windows service on root@10.192.151.205... Tue Aug 1 12:05:23 PDT 2017


Windows service vdvs is already installed.
Stopping Windows service vdvs...
Deleting Windows service vdvs...
[SC] DeleteService SUCCESS
Deleting C:\Program Files\VMware\vmdkops...
Windows service vdvs uninstalled successfully!
Downloading from file:///C:\Users\root\AppData\Local\Temp\vdvs-bin.zip...
Extracting docker-volume-vsphere.zip into C:\Program Files\VMware\vmdkops...
Deleting docker-volume-vsphere.zip...
Installing Windows service vdvs from C:\Program Files\VMware\vmdkops\vdvs.exe...

Status   Name               DisplayName                           
------   ----               -----------                           
Stopped  vdvs               vSphere Docker Volume Service         
Starting Windows service vdvs...
Running  vdvs               vSphere Docker Volume Service         
Windows service vdvs installed successfully!
```