### PR TITLE
Ports basic_test.go to Windows

### DIFF
--- a/tests/constants/dockercli/cmd.go
+++ b/tests/constants/dockercli/cmd.go
@@ -79,17 +79,8 @@ const (
 	// RunCmdInContainer run a command in a running container
 	RunCmdInContainer = docker + "exec -t "
 
-	// ContainerImage busybox container image
-	ContainerImage = " busybox "
-
-	// TestContainer test busybox container that keeps running
-	TestContainer = ContainerImage + " tail -f /dev/null "
-
 	// QueryContainer checks whether container exists or not
 	QueryContainer = docker + "ps -aq --filter name="
-
-	// ContainerMountPoint mount point where a volume is mounted inside a container
-	ContainerMountPoint = "/vol"
 
 	// ListContainers list all running docker containers
 	ListContainers = docker + "ps "

--- a/tests/constants/dockercli/cmd_win.go
+++ b/tests/constants/dockercli/cmd_win.go
@@ -1,0 +1,30 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Windows specific constants related to docker cli.
+
+// +build winutil
+
+package dockercli
+
+const (
+	// ContainerImage refers to the microsoft/nanoserver container image.
+	ContainerImage = " microsoft/nanoserver "
+
+	// TestContainer represents a test microsoft/nanoserver container that keeps running.
+	TestContainer = ContainerImage + " ping -t localhost "
+
+	// ContainerMountPoint is the mount point where a volume is mounted inside a container.
+	ContainerMountPoint = `C:\vol`
+)

--- a/tests/constants/dockercli/cmddefault.go
+++ b/tests/constants/dockercli/cmddefault.go
@@ -1,0 +1,30 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Default constants related to docker cli.
+
+// +build !winutil
+
+package dockercli
+
+const (
+	// ContainerImage busybox container image
+	ContainerImage = " busybox "
+
+	// TestContainer test busybox container that keeps running
+	TestContainer = ContainerImage + " tail -f /dev/null "
+
+	// ContainerMountPoint mount point where a volume is mounted inside a container
+	ContainerMountPoint = "/vol"
+)

--- a/tests/e2e/basic_test.go
+++ b/tests/e2e/basic_test.go
@@ -15,13 +15,11 @@
 // This test suite includes test cases to verify basic functionality
 // in most common configurations
 
-// +build runalways
+// +build runalways runoncewin
 
 package e2e
 
 import (
-	admincliconst "github.com/vmware/docker-volume-vsphere/tests/constants/admincli"
-	"github.com/vmware/docker-volume-vsphere/tests/utils/admincli"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
@@ -49,9 +47,11 @@ func (s *BasicTestSuite) SetUpSuite(c *C) {
 
 	s.esx = s.config.EsxHost
 	s.vm1 = s.config.DockerHosts[0]
-	s.vm2 = s.config.DockerHosts[1]
 	s.vm1Name = s.config.DockerHostNames[0]
-	s.vm2Name = s.config.DockerHostNames[1]
+	if len(s.config.DockerHosts) == 2 {
+		s.vm2 = s.config.DockerHosts[1]
+		s.vm2Name = s.config.DockerHostNames[1]
+	}
 }
 
 func (s *BasicTestSuite) SetUpTest(c *C) {
@@ -108,106 +108,6 @@ func (s *BasicTestSuite) TestVolumeLifecycle(c *C) {
 		accessible = verification.CheckVolumeAvailability(host, s.volName1)
 		c.Assert(accessible, Equals, false, Commentf("Volume %s is still available", s.volName1))
 	}
-
-	misc.LogTestEnd(c.TestName())
-}
-
-// Test volume isolation between VMs backed by different datastores:
-// Volume is created on the local datastore attached to the ESX where
-// VM1 resides on. It's expected that this volume is visible to VM1,
-// but invisible to VM2 which resides on a different ESX that has no
-// access to this datastore.
-//
-// Test steps:
-// 1. Create a volume from VM1
-// 2. Verify the volume is available from VM1
-// 3. Verify the volume is unavailable from VM2
-// 4. Remove the volume
-func (s *BasicTestSuite) TestBasicVolumeIsolation(c *C) {
-	misc.LogTestStart(c.TestName())
-
-	out, err := dockercli.CreateVolume(s.vm1, s.volName1)
-	c.Assert(err, IsNil, Commentf(out))
-
-	accessible := verification.CheckVolumeAvailability(s.vm1, s.volName1)
-	c.Assert(accessible, Equals, true, Commentf("Volume %s is not available", s.volName1))
-
-	accessible = verification.CheckVolumeAvailability(s.vm2, s.volName1)
-	//TODO: VM2 inaccessible to this volume is currently not available
-	//c.Assert(accessible, Equals, false, Commentf("Volume %s is still available", s.volName1))
-
-	out, err = dockercli.DeleteVolume(s.vm1, s.volName1)
-	c.Assert(err, IsNil, Commentf(out))
-
-	misc.LogTestEnd(c.TestName())
-}
-
-// Test volume isolation between _DEFAULT and user defined vmgroups:
-// Volume created in a VM belonging to _DEFAULT should be invisible
-// to VMs inside a user defined vmgroup; and vice versa.
-//
-// Test steps:
-// 1. Initialize Config DB
-// 2. Create a volume from VM1
-// 3. Verify the volume is visible to VM1 and VM2
-// 4. Create a VmGroup T1, add VM1 to T1
-// 5. Verify the volume is still visible to VM2, but invisible to VM1
-// 6. Create the 2nd volume from VM1
-// 7. Verify the 2nd volume is visible to VM1, but invisible to VM2
-// 8. Remove the volumes
-// 9. Remove Config DB
-func (s *BasicTestSuite) TestVmGroupVolumeIsolation(c *C) {
-	misc.LogTestStart(c.TestName())
-
-	// Initialize Config DB
-	out, err := admincli.ConfigInit(s.esx)
-	c.Assert(err, IsNil, Commentf(out))
-
-	out, err = dockercli.CreateVolume(s.vm1, s.volName1)
-	c.Assert(err, IsNil, Commentf(out))
-
-	accessible := verification.CheckVolumeAvailability(s.vm1, s.volName1)
-	c.Assert(accessible, Equals, true, Commentf("Volume %s is not available on [%s]", s.volName1, s.vm1))
-
-	accessible = verification.CheckVolumeAvailability(s.vm2, s.volName1)
-	c.Assert(accessible, Equals, true, Commentf("Volume %s is not available on [%s]", s.volName1, s.vm2))
-
-	const vmgroup = "T1"
-	out, err = admincli.CreateVMgroup(s.esx, vmgroup, s.vm1Name, admincliconst.VMHomeDatastore)
-	c.Assert(err, IsNil, Commentf(out))
-
-	accessible = verification.CheckVolumeAvailability(s.vm1, s.volName1)
-	c.Assert(accessible, Equals, false, Commentf("Volume %s is still available on [%s]", s.volName1, s.vm1))
-
-	accessible = verification.CheckVolumeAvailability(s.vm2, s.volName1)
-	c.Assert(accessible, Equals, true, Commentf("Volume %s is not available on [%s]", s.volName1, s.vm2))
-
-	out, err = dockercli.CreateVolume(s.vm1, s.volName2)
-	c.Assert(err, IsNil, Commentf(out))
-
-	accessible = verification.CheckVolumeAvailability(s.vm1, s.volName2)
-	c.Assert(accessible, Equals, true, Commentf("Volume %s is not available on [%s]", s.volName2, s.vm1))
-
-	accessible = verification.CheckVolumeAvailability(s.vm2, s.volName2)
-	c.Assert(accessible, Equals, false, Commentf("Volume %s is available on [%s]", s.volName2, s.vm2))
-
-	// Clean up the volumes
-	out, err = dockercli.DeleteVolume(s.vm2, s.volName1)
-	c.Assert(err, IsNil, Commentf(out))
-
-	out, err = dockercli.DeleteVolume(s.vm1, s.volName2)
-	c.Assert(err, IsNil, Commentf(out))
-
-	// Clean up the vm group
-	out, err = admincli.RemoveVMFromVMgroup(s.esx, vmgroup, s.vm1Name)
-	c.Assert(err, IsNil, Commentf(out))
-
-	out, err = admincli.DeleteVMgroup(s.esx, vmgroup, false)
-	c.Assert(err, IsNil, Commentf(out))
-
-	// Remove Config DB
-	out, err = admincli.ConfigRemove(s.esx)
-	c.Assert(err, IsNil, Commentf(out))
 
 	misc.LogTestEnd(c.TestName())
 }

--- a/tests/e2e/basicdefault_test.go
+++ b/tests/e2e/basicdefault_test.go
@@ -1,0 +1,129 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This test suite includes additional test cases to verify basic functionality
+// in most common configurations.
+
+// +build runalways
+
+package e2e
+
+import (
+	admincliconst "github.com/vmware/docker-volume-vsphere/tests/constants/admincli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/admincli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/verification"
+	. "gopkg.in/check.v1"
+)
+
+// Test volume isolation between VMs backed by different datastores:
+// Volume is created on the local datastore attached to the ESX where
+// VM1 resides on. It's expected that this volume is visible to VM1,
+// but invisible to VM2 which resides on a different ESX that has no
+// access to this datastore.
+//
+// Test steps:
+// 1. Create a volume from VM1
+// 2. Verify the volume is available from VM1
+// 3. Verify the volume is unavailable from VM2
+// 4. Remove the volume
+func (s *BasicTestSuite) TestBasicVolumeIsolation(c *C) {
+	misc.LogTestStart(c.TestName())
+
+	out, err := dockercli.CreateVolume(s.vm1, s.volName1)
+	c.Assert(err, IsNil, Commentf(out))
+
+	accessible := verification.CheckVolumeAvailability(s.vm1, s.volName1)
+	c.Assert(accessible, Equals, true, Commentf("Volume %s is not available", s.volName1))
+
+	accessible = verification.CheckVolumeAvailability(s.vm2, s.volName1)
+	//TODO: VM2 inaccessible to this volume is currently not available
+	//c.Assert(accessible, Equals, false, Commentf("Volume %s is still available", s.volName1))
+
+	out, err = dockercli.DeleteVolume(s.vm1, s.volName1)
+	c.Assert(err, IsNil, Commentf(out))
+
+	misc.LogTestEnd(c.TestName())
+}
+
+// Test volume isolation between _DEFAULT and user defined vmgroups:
+// Volume created in a VM belonging to _DEFAULT should be invisible
+// to VMs inside a user defined vmgroup; and vice versa.
+//
+// Test steps:
+// 1. Initialize Config DB
+// 2. Create a volume from VM1
+// 3. Verify the volume is visible to VM1 and VM2
+// 4. Create a VmGroup T1, add VM1 to T1
+// 5. Verify the volume is still visible to VM2, but invisible to VM1
+// 6. Create the 2nd volume from VM1
+// 7. Verify the 2nd volume is visible to VM1, but invisible to VM2
+// 8. Remove the volumes
+// 9. Remove Config DB
+func (s *BasicTestSuite) TestVmGroupVolumeIsolation(c *C) {
+	misc.LogTestStart(c.TestName())
+
+	// Initialize Config DB
+	out, err := admincli.ConfigInit(s.esx)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.CreateVolume(s.vm1, s.volName1)
+	c.Assert(err, IsNil, Commentf(out))
+
+	accessible := verification.CheckVolumeAvailability(s.vm1, s.volName1)
+	c.Assert(accessible, Equals, true, Commentf("Volume %s is not available on [%s]", s.volName1, s.vm1))
+
+	accessible = verification.CheckVolumeAvailability(s.vm2, s.volName1)
+	c.Assert(accessible, Equals, true, Commentf("Volume %s is not available on [%s]", s.volName1, s.vm2))
+
+	const vmgroup = "T1"
+	out, err = admincli.CreateVMgroup(s.esx, vmgroup, s.vm1Name, admincliconst.VMHomeDatastore)
+	c.Assert(err, IsNil, Commentf(out))
+
+	accessible = verification.CheckVolumeAvailability(s.vm1, s.volName1)
+	c.Assert(accessible, Equals, false, Commentf("Volume %s is still available on [%s]", s.volName1, s.vm1))
+
+	accessible = verification.CheckVolumeAvailability(s.vm2, s.volName1)
+	c.Assert(accessible, Equals, true, Commentf("Volume %s is not available on [%s]", s.volName1, s.vm2))
+
+	out, err = dockercli.CreateVolume(s.vm1, s.volName2)
+	c.Assert(err, IsNil, Commentf(out))
+
+	accessible = verification.CheckVolumeAvailability(s.vm1, s.volName2)
+	c.Assert(accessible, Equals, true, Commentf("Volume %s is not available on [%s]", s.volName2, s.vm1))
+
+	accessible = verification.CheckVolumeAvailability(s.vm2, s.volName2)
+	c.Assert(accessible, Equals, false, Commentf("Volume %s is available on [%s]", s.volName2, s.vm2))
+
+	// Clean up the volumes
+	out, err = dockercli.DeleteVolume(s.vm2, s.volName1)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = dockercli.DeleteVolume(s.vm1, s.volName2)
+	c.Assert(err, IsNil, Commentf(out))
+
+	// Clean up the vm group
+	out, err = admincli.RemoveVMFromVMgroup(s.esx, vmgroup, s.vm1Name)
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = admincli.DeleteVMgroup(s.esx, vmgroup, false)
+	c.Assert(err, IsNil, Commentf(out))
+
+	// Remove Config DB
+	out, err = admincli.ConfigRemove(s.esx)
+	c.Assert(err, IsNil, Commentf(out))
+
+	misc.LogTestEnd(c.TestName())
+}

--- a/tests/utils/inputparams/testparams.go
+++ b/tests/utils/inputparams/testparams.go
@@ -75,7 +75,7 @@ func GetUniqueVmgroupName(vmgroupName string) string {
 
 // GetUniqueVolumeName prepares unique volume name with a random generated number
 func GetUniqueVolumeName(volName string) string {
-	return volName + "_volume_" + GetRandomNumber()
+	return normalizeVolumeName(volName + "_volume_" + GetRandomNumber())
 }
 
 // GetVolumeNameOfSize returns a random volume name of required length

--- a/tests/utils/inputparams/testparams_win.go
+++ b/tests/utils/inputparams/testparams_win.go
@@ -21,6 +21,7 @@ package inputparams
 import (
 	"log"
 	"os"
+	"strings"
 )
 
 // volNameCharset is the valid set of characters for volume name generation.
@@ -35,4 +36,9 @@ func getDockerHosts() []string {
 		log.Fatal("A windows docker host is needed to run tests.")
 	}
 	return dockerHosts
+}
+
+// normalizeVolumeName returns a lower-case form of the given name.
+func normalizeVolumeName(name string) string {
+	return strings.ToLower(name)
 }

--- a/tests/utils/inputparams/testparamsdefault.go
+++ b/tests/utils/inputparams/testparamsdefault.go
@@ -37,3 +37,8 @@ func getDockerHosts() []string {
 	}
 	return dockerHosts
 }
+
+// normalizeVolumeName returns the name as-is.
+func normalizeVolumeName(name string) string {
+	return name
+}

--- a/tests/utils/verification/volumeproperties.go
+++ b/tests/utils/verification/volumeproperties.go
@@ -35,7 +35,7 @@ import (
 // GetVMAttachedToVolUsingDockerCli returns attached to vm field of volume using docker cli
 // TODO: make this private member after finishing refactoring of volmprop_test.go and remove this TODO
 func GetVMAttachedToVolUsingDockerCli(volName string, hostname string) string {
-	cmd := dockercli.InspectVolume + " --format '{{index .Status \"attached to VM\"}}' " + volName
+	cmd := dockercli.InspectVolume + " --format \"{{index .Status \\\"attached to VM\\\"}}\" " + volName
 	op, _ := ssh.InvokeCommand(hostname, cmd)
 	if op == "" {
 		log.Fatal("Null value is returned by docker cli when looking for attached to vm field for volume. Output: ", op)
@@ -133,7 +133,7 @@ func VerifyAttachedStatus(name, hostName, esxName string) bool {
 
 // getVolumeStatusHost - get the volume status on a given host
 func getVolumeStatusHost(name, hostName string) string {
-	cmd := dockercli.InspectVolume + " --format '{{index .Status.status}}' " + name
+	cmd := dockercli.InspectVolume + " --format \"{{index .Status.status}}\" " + name
 	// ignoring the error here, helper is part of polling util
 	// error most likely to be "unable to reach host [ssh:255 error]"
 	// VerifyDetachedStatus takes care of retry mechanism


### PR DESCRIPTION
## Description
This PR ports the existing `TestVolumeLifecycle` test in `basic_test.go` to Windows.

* Enables spawning of a `microsoft/nanoserver` Container on a Windows host.
* Normalizes volume name in `GetUniqueVolumeName` based on the test platform.

## Test Result
The `test-e2e-windows` target prints the following output locally.
```
vnoronha-m01:docker-volume-vsphere vnoronha$ make test-e2e-windows
/Library/Developer/CommandLineTools/usr/bin/make --directory=client_plugin test-e2e-windows

=> Running target test-e2e-windows Fri Aug 4 16:45:38 PDT 2017

../misc/scripts/build.sh test-e2e-runonce-windows
make: Entering directory `/go/src/github.com/vmware/docker-volume-vsphere/client_plugin'

=> Running target test-e2e-runonce-windows Fri Aug 4 23:45:38 UTC 2017

go test -v -timeout 40m -tags "runoncewin winutil" github.com/vmware/docker-volume-vsphere/tests/e2e
=== RUN   Test
2017/08/04 23:45:41 START: BasicTestSuite.TestVolumeLifecycle
2017/08/04 23:45:41 Creating volume [basictestsuite.testvolumelifecycle_volume_913301] on VM [10.160.221.127]
2017/08/04 23:45:57 Checking volume [basictestsuite.testvolumelifecycle_volume_913301] availability from VM [10.160.221.127]
2017/08/04 23:45:58 Attaching volume [basictestsuite.testvolumelifecycle_volume_913301] on VM [10.160.221.127]
2017/08/04 23:46:15 Confirming attached status for volume [basictestsuite.testvolumelifecycle_volume_913301]
2017/08/04 23:46:15 Fetching full name for volume [basictestsuite.testvolumelifecycle_volume_913301] from VM [10.160.221.127]
2017/08/04 23:46:16 Full volume name: [basictestsuite.testvolumelifecycle_volume_913301@sharedvmfs-1]
2017/08/04 23:46:19 Destroying volume [basictestsuite.testvolumelifecycle_volume_913301]
2017/08/04 23:46:20 Removing container [BasicTestSuite.TestVolumeLifecycle_container_764923] on VM [10.160.221.127]
2017/08/04 23:46:24 Confirming detached status for volume [basictestsuite.testvolumelifecycle_volume_913301]
2017/08/04 23:46:24 Fetching full name for volume [basictestsuite.testvolumelifecycle_volume_913301] from VM [10.160.221.127]
2017/08/04 23:46:25 Full volume name: [basictestsuite.testvolumelifecycle_volume_913301@sharedvmfs-1]
2017/08/04 23:46:26 Destroying volume [basictestsuite.testvolumelifecycle_volume_913301]
2017/08/04 23:46:27 Checking volume [basictestsuite.testvolumelifecycle_volume_913301] availability from VM [10.160.221.127]
2017/08/04 23:46:28 END: BasicTestSuite.TestVolumeLifecycle
2017/08/04 23:46:28 START: VolumeCreateTestSuite.TestInvalidName
2017/08/04 23:46:28 Creating volume [volume-000000] on VM [10.160.221.127]
2017/08/04 23:46:28 Creating volume [volume_volume_1046883@invaliddatastore] on VM [10.160.221.127]
2017/08/04 23:46:28 Creating volume [volume-0000000-****-###] on VM [10.160.221.127]
2017/08/04 23:46:28 Creating volume [volume\abc] on VM [10.160.221.127]
2017/08/04 23:46:28 Creating volume [fpllngzieyoh43e0133ols6k1hh2gdnyxxvi7hvszwk1b182tvjzjpezi4hx9gvmkir0xcta0opsb5qipjzb3h3x9kcegta5m1zcv] on VM [10.160.221.127]
2017/08/04 23:46:30 END: VolumeCreateTestSuite.TestInvalidName
2017/08/04 23:46:30 START: VolumeCreateTestSuite.TestInvalidOptions
2017/08/04 23:46:30 Creating volume [option_volume_1018280] with options [ -o size=100mbb] on VM [10.160.221.127]
2017/08/04 23:46:30 Creating volume [option_volume_413153] with options [ -o diskformat=zeroedthickk] on VM [10.160.221.127]
2017/08/04 23:46:30 Creating volume [option_volume_837626] with options [ -o sizes=100mb] on VM [10.160.221.127]
2017/08/04 23:46:30 Creating volume [option_volume_1041036] with options [ -o clone-from=IDontExist] on VM [10.160.221.127]
2017/08/04 23:46:30 Creating volume [option_volume_822116] with options [ -o size=100gbEE] on VM [10.160.221.127]
2017/08/04 23:46:30 Creating volume [option_volume_183667] with options [ -o access=read-write-both] on VM [10.160.221.127]
2017/08/04 23:46:30 Creating volume [option_volume_446821] with options [ -o access=read-write-both] on VM [10.160.221.127]
2017/08/04 23:46:30 Creating volume [option_volume_109194] with options [ -o diskformat=zeroedthick,thin] on VM [10.160.221.127]
2017/08/04 23:46:30 Creating volume [option_volume_468450] with options [ -o access=write-only] on VM [10.160.221.127]
2017/08/04 23:46:30 Creating volume [option_volume_766108] with options [ -o fstype=xfs_ext] on VM [10.160.221.127]
2017/08/04 23:46:33 END: VolumeCreateTestSuite.TestInvalidOptions
2017/08/04 23:46:33 START: VolumeCreateTestSuite.TestValidName
2017/08/04 23:46:33 Creating volume ["volume space"] on VM [10.160.221.127]
2017/08/04 23:46:33 Creating volume [volume-0000000] on VM [10.160.221.127]
2017/08/04 23:46:33 Creating volume [abc_volume_866282@@@@sharedvmfs-0] on VM [10.160.221.127]
2017/08/04 23:46:33 Creating volume [abc_volume_609733@sharedvmfs-0] on VM [10.160.221.127]
2017/08/04 23:46:33 Creating volume [volume-你_volume_901495] on VM [10.160.221.127]
2017/08/04 23:46:33 Creating volume [q2mgf6939ig4qc8ipc5crsf5ulkjtc6yh9alpv8t4xw4tmfz5u7cib9dgu0npne8o43yxhohq9whwzvad1q1l1hscpfb4clzbrvw] on VM [10.160.221.127]
2017/08/04 23:46:33 Creating volume [volume-00000] on VM [10.160.221.127]
2017/08/04 23:47:36 Checking volume ["volume space" volume-00000 volume-0000000 q2mgf6939ig4qc8ipc5crsf5ulkjtc6yh9alpv8t4xw4tmfz5u7cib9dgu0npne8o43yxhohq9whwzvad1q1l1hscpfb4clzbrvw abc_volume_609733@sharedvmfs-0 abc_volume_866282@@@@sharedvmfs-0 volume-你_volume_901495] availability from VM [10.160.221.127]
2017/08/04 23:47:37 END: VolumeCreateTestSuite.TestValidName
2017/08/04 23:47:37 Destroying volume ["volume space" volume-00000 volume-0000000 q2mgf6939ig4qc8ipc5crsf5ulkjtc6yh9alpv8t4xw4tmfz5u7cib9dgu0npne8o43yxhohq9whwzvad1q1l1hscpfb4clzbrvw abc_volume_609733@sharedvmfs-0 abc_volume_866282@@@@sharedvmfs-0 volume-你_volume_901495]
2017/08/04 23:47:40 START: VolumeCreateTestSuite.TestValidOptions
2017/08/04 23:47:40 Creating volume [clone_src_volume_855696] on VM [10.160.221.127]
2017/08/04 23:47:55 Creating volume [option_volume_448675] with options [ -o diskformat=zeroedthick] on VM [10.160.221.127]
2017/08/04 23:47:55 Creating volume [option_volume_597324] with options [ -o diskformat=thin] on VM [10.160.221.127]
2017/08/04 23:47:55 Creating volume [option_volume_325626] with options [ -o fstype=ntfs] on VM [10.160.221.127]
2017/08/04 23:47:55 Creating volume [option_volume_311193] with options [ -o attach-as=independent_persistent] on VM [10.160.221.127]
2017/08/04 23:47:55 Creating volume [option_volume_106020] with options [ -o attach-as=persistent] on VM [10.160.221.127]
2017/08/04 23:47:55 Creating volume [option_volume_1020486] with options [ -o size=10gb] on VM [10.160.221.127]
2017/08/04 23:47:55 Creating volume [option_volume_397750] with options [ -o diskformat=eagerzeroedthick] on VM [10.160.221.127]
2017/08/04 23:47:55 Creating volume [option_volume_524991] with options [ -o access=read-only] on VM [10.160.221.127]
2017/08/04 23:47:55 Creating volume [option_volume_711272] with options [ -o access=read-write] on VM [10.160.221.127]
2017/08/04 23:47:55 Creating volume [option_volume_826658] with options [ -o clone-from=clone_src_volume_855696] on VM [10.160.221.127]
2017/08/04 23:49:41 Checking volume [clone_src_volume_855696 option_volume_826658 option_volume_1020486 option_volume_597324 option_volume_325626 option_volume_311193 option_volume_448675 option_volume_397750 option_volume_524991 option_volume_711272 option_volume_106020] availability from VM [10.160.221.127]
2017/08/04 23:49:43 END: VolumeCreateTestSuite.TestValidOptions
2017/08/04 23:49:43 Destroying volume [clone_src_volume_855696 option_volume_826658 option_volume_1020486 option_volume_597324 option_volume_325626 option_volume_311193 option_volume_448675 option_volume_397750 option_volume_524991 option_volume_711272 option_volume_106020]
OK: 5 passed
--- PASS: Test (251.28s)
PASS
ok  	github.com/vmware/docker-volume-vsphere/tests/e2e	251.284s
make: Leaving directory `/go/src/github.com/vmware/docker-volume-vsphere/client_plugin'
```