### PR TITLE
Enables Windows e2e tests on CI

### DIFF
--- a/misc/drone-scripts/deploy-and-test-wrapper.sh
+++ b/misc/drone-scripts/deploy-and-test-wrapper.sh
@@ -115,7 +115,7 @@ coverage)
         TARGET=" coverage"
         ;;
 winplugin)
-        TARGET=" build-windows-plugin deploy-windows-plugin"
+        TARGET=" build-windows-plugin deploy-windows-plugin test-e2e-runonce-windows"
         ;;
 esac
 


### PR DESCRIPTION
This PR enables volume lifecycle tests on the Windows VM on CI. Fixes #1719.