### PR TITLE
Silencing mount logs on plugin side to Debug instead of Info

### DIFF
--- a/client_plugin/utils/fs/fs_linux.go
+++ b/client_plugin/utils/fs/fs_linux.go
@@ -349,7 +349,7 @@ func GetMountInfo(mountRoot string) (map[string]string, error) {
 		log.Errorf("Can't get info from %s (%v)", linuxMountsFile, err)
 		return volumeMountMap, err
 	}
-	log.WithFields(log.Fields{"data": string(data)}).Info("Mounts read successfully")
+	log.WithFields(log.Fields{"data": string(data)}).Debug("Mounts read successfully: ")
 
 	for _, line := range strings.Split(string(data), lf) {
 		field := strings.Fields(line)
@@ -363,6 +363,6 @@ func GetMountInfo(mountRoot string) (map[string]string, error) {
 		volumeMountMap[filepath.Base(field[1])] = field[0]
 	}
 
-	log.WithFields(log.Fields{"map": volumeMountMap}).Info("Successfully retrieved mounts")
+	log.WithFields(log.Fields{"map": volumeMountMap}).Debug("Successfully retrieved mounts: ")
 	return volumeMountMap, nil
 }


### PR DESCRIPTION
Fixes #1703

Log for command: docker run -v test1:/vol busybox echo "Hello World"
```
2017-08-07 10:15:29.855702144 -0700 PDT [INFO] Mounting volume name=test1
2017-08-07 10:15:29.935677786 -0700 PDT [INFO] Directory doesn't exist, creating it path="/mnt/vmdk/test1@sharedVmfs-0"
2017-08-07 10:15:30.323388376 -0700 PDT [INFO] Scan complete device="/dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:0:0" event="/dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:0:0": 0x100 == IN_CREATE
2017-08-07 10:15:30.682192924 -0700 PDT [INFO] Unmounting Volume name=test1
```