### PR TITLE
Shared plugin: fix to make sure error out when swarm is not active.

### DIFF
--- a/client_plugin/drivers/shared/shared_driver.go
+++ b/client_plugin/drivers/shared/shared_driver.go
@@ -124,11 +124,12 @@ func NewVolumeDriver(cfg config.Config, mountDir string) *VolumeDriver {
 	}
 
 	// initialize built-in etcd cluster
-	d.kvStore = etcdops.NewKvStore(d.dockerOps)
-	if d.kvStore == nil {
+	etcdKVS := etcdops.NewKvStore(d.dockerOps)
+	if etcdKVS == nil {
 		log.Errorf("Failed to create new KV store")
 		return nil
 	}
+	d.kvStore = etcdKVS
 
 	log.WithFields(log.Fields{
 		"version": version,


### PR DESCRIPTION
When the swarm status of a node is not active, NewKvStore returns an empty result.
This should be checked before assigned to d.kvStore, which won't be empty.
This minor fix makes sure when the returned result is empty, NewVolumeDriver will error out and retry.

Local test passed.