### PR TITLE
E2E test for vsphere shared volume driver

### DIFF
--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -421,14 +421,14 @@ test-e2e-shared:
 # test-e2e-runonce-windows: makes sure to run windows tests *once per ESX*
 # test-e2e-runonce-shared: makes sure to run vsphere shared tests *once per ESX*
 #
-.PHONY: test-e2e-runalways test-e2e-runonce test-e2e-runonce-windows test-e2e-runonce-shared
+.PHONY: test-e2e-runalways test-e2e-runonce test-e2e-runonce-windows
 test-e2e-runalways:
 	$(log_target)
-	$(GO) test -v -timeout 40m -tags runalways $(E2E_Tests)
+	$(GO) test -v -timeout 40m -tags "runalways" $(E2E_Tests)
 
 test-e2e-runonce:
 	$(log_target)
-	$(GO) test -v -timeout 40m -tags runonce $(E2E_Tests)
+	$(GO) test -v -timeout 40m -tags "runonce" $(E2E_Tests)
 
 test-e2e-runonce-windows:
 	$(log_target)

--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -359,6 +359,7 @@ test:
 testasroot:
 	$(log_target)
 	$(GO) test $(PLUGIN)/drivers/vmdk/vmdkops -cover -v
+	$(GO) test $(PLUGIN)/drivers/shared -cover -v
 	$(GO) test $(PLUGIN)/utils/config -cover -v
 
 # does sanity check of create/remove docker volume on the guest
@@ -407,14 +408,20 @@ test-e2e-windows:
 	$(log_target)
 	$(BUILD) test-e2e-runonce-windows
 
+# An end-to-end target for vSphere Shared Docker Volume Driver
+test-e2e-shared:
+	$(log_target)
+	$(BUILD) test-e2e-runonce-shared
+
 #
 # E2E test target to control test run on CI.
 # We have 2 ESXs on CI testbed and 2 datastore type each (VMFS/VSAN).
 # test-e2e-runalways: makes sure to run test always
 # test-e2e-runonce: makes sure to run test *once per ESX*
 # test-e2e-runonce-windows: makes sure to run windows tests *once per ESX*
+# test-e2e-runonce-shared: makes sure to run vsphere shared tests *once per ESX*
 #
-.PHONY: test-e2e-runalways test-e2e-runonce test-e2e-runonce-windows
+.PHONY: test-e2e-runalways test-e2e-runonce test-e2e-runonce-windows test-e2e-runonce-shared
 test-e2e-runalways:
 	$(log_target)
 	$(GO) test -v -timeout 40m -tags runalways $(E2E_Tests)
@@ -426,6 +433,10 @@ test-e2e-runonce:
 test-e2e-runonce-windows:
 	$(log_target)
 	$(GO) test -v -timeout 40m -tags "runoncewin winutil" $(E2E_Tests)
+
+test-e2e-runonce-shared:
+	$(log_target)
+	$(GO) test -v -timeout 40m -tags "runonceshared" $(E2E_Tests)
 
 .PHONY:clean-vm clean-esx clean-all clean-docker
 clean-vm:

--- a/tests/constants/dockercli/cmd.go
+++ b/tests/constants/dockercli/cmd.go
@@ -112,8 +112,8 @@ const (
 	// ErrorVolumeCreate Error string prefix when volume creation fails
 	ErrorVolumeCreate = "Error response from daemon: create"
 
-	// CreateVolumeShared create a volume with vshared driver
-	CreateVolumeShared = dockerVol + " create --driver=vshared "
+	// CreateSharedVolume create a volume with vshared driver
+	CreateSharedVolume = dockerVol + " create --driver=vshared "
 )
 
 // VolumeStatusFields properties returned for a volume by inspecting it

--- a/tests/constants/dockercli/cmd.go
+++ b/tests/constants/dockercli/cmd.go
@@ -111,6 +111,9 @@ const (
 
 	// ErrorVolumeCreate Error string prefix when volume creation fails
 	ErrorVolumeCreate = "Error response from daemon: create"
+
+	// CreateVolumeShared create a volume with vshared driver
+	CreateVolumeShared = dockerVol + " create --driver=vshared "
 )
 
 // VolumeStatusFields properties returned for a volume by inspecting it

--- a/tests/e2e/basic_shared_test.go
+++ b/tests/e2e/basic_shared_test.go
@@ -1,0 +1,120 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This test suite includes test cases to verify basic functionality
+// in most common configurations
+
+// +build runonceshared
+package e2e
+
+import (
+	"log"
+
+	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/verification"
+	. "gopkg.in/check.v1"
+)
+
+type BasicSharedTestSuite struct {
+	config        *inputparams.TestConfig
+	esx           string
+	vm1           string
+	vm2           string
+	vm1Name       string
+	vm2Name       string
+	volName1      string
+	volName2      string
+	containerName string
+}
+
+func (s *BasicSharedTestSuite) SetUpSuite(c *C) {
+	s.config = inputparams.GetTestConfig()
+	if s.config == nil {
+		c.Skip("Unable to retrieve test config, skipping basic sharedtests")
+	}
+
+	s.esx = s.config.EsxHost
+	s.vm1 = s.config.DockerHosts[0]
+	s.vm1Name = s.config.DockerHostNames[0]
+	if len(s.config.DockerHosts) == 2 {
+		s.vm2 = s.config.DockerHosts[1]
+		s.vm2Name = s.config.DockerHostNames[1]
+	}
+}
+
+func (s *BasicSharedTestSuite) SetUpTest(c *C) {
+	s.volName1 = inputparams.GetUniqueVolumeName(c.TestName())
+	s.volName2 = inputparams.GetUniqueVolumeName(c.TestName())
+	s.containerName = inputparams.GetUniqueContainerName(c.TestName())
+}
+
+var _ = Suite(&BasicSharedTestSuite{})
+
+// Test volume lifecycle management on different datastores:
+// VM1 - created on local VMFS datastore
+// VM2 - created on shared VMFS datastore
+// VM3 - created on shared VSAN datastore (TODO: currently not available)
+//
+// Test steps:
+// 1. Create a volume
+// 2. Verify the volume is available
+// 3. Attach the volume
+// 4. Verify volume status is attached
+// 5. Remove the volume (expect fail)
+// 6. Remove the container
+// 7. Verify volume status is detached
+// 8. Remove the volume
+// 9. Verify the volume is unavailable
+// TODO: step 3-7 currently not available since volume mount/unmount is not available yet
+func (s *BasicSharedTestSuite) TestVolumeLifecycle(c *C) {
+	misc.LogTestStart(c.TestName())
+
+	for _, host := range s.config.DockerHosts {
+		out, err := dockercli.CreateSharedVolume(host, s.volName1)
+		c.Assert(err, IsNil, Commentf(out))
+
+		accessible := verification.CheckVolumeAvailability(host, s.volName1)
+		c.Assert(accessible, Equals, true, Commentf("Volume %s is not available", s.volName1))
+
+		// out, err = dockercli.AttachVolume(host, s.volName1, s.containerName)
+		// c.Assert(err, IsNil, Commentf(out))
+
+		// status := verification.VerifyAttachedStatus(s.volName1, host, s.esx)
+		// c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volName1))
+
+		// out, err = dockercli.DeleteVolume(host, s.volName1)
+		// c.Assert(err, Not(IsNil), Commentf(out))
+
+		// out, err = dockercli.RemoveContainer(host, s.containerName)
+		// c.Assert(err, IsNil, Commentf(out))
+
+		// status = verification.VerifyDetachedStatus(s.volName1, host, s.esx)
+		// c.Assert(status, Equals, true, Commentf("Volume %s is still attached", s.volName1))
+		out = verification.GetSharedVolumeStatusHost(s.volName1, host)
+		log.Println("GetSharedVolumeStatusHost return out[%s] for volume %s", out, s.volName1)
+		c.Assert(out, Equals, "Ready", Commentf("Volume %s status is expected to be [Ready], actual status is [%s]",
+			s.volName1, out))
+
+		accessible = verification.CheckVolumeAvailability(host, s.volName1)
+		c.Assert(accessible, Equals, true, Commentf("Volume %s is not available", s.volName1))
+
+		// delete the volume from master until issue 1715 is fixed
+		out, err = dockercli.DeleteVolume(s.config.DockerHosts[0], s.volName1)
+		c.Assert(err, IsNil, Commentf(out))
+	}
+
+	misc.LogTestEnd(c.TestName())
+}

--- a/tests/e2e/basic_shared_test.go
+++ b/tests/e2e/basic_shared_test.go
@@ -63,11 +63,7 @@ func (s *BasicSharedTestSuite) SetUpTest(c *C) {
 
 var _ = Suite(&BasicSharedTestSuite{})
 
-// Test volume lifecycle management on different datastores:
-// VM1 - created on local VMFS datastore
-// VM2 - created on shared VMFS datastore
-// VM3 - created on shared VSAN datastore (TODO: currently not available)
-//
+// All VMs are created in a shared datastore
 // Test steps:
 // 1. Create a volume
 // 2. Verify the volume is available
@@ -78,7 +74,7 @@ var _ = Suite(&BasicSharedTestSuite{})
 // 7. Verify volume status is detached
 // 8. Remove the volume
 // 9. Verify the volume is unavailable
-// TODO: step 3-7 currently not available since volume mount/unmount is not available yet
+// TODO: step 3-7 currently is not available since volume mount/unmount is not available yet
 func (s *BasicSharedTestSuite) TestVolumeLifecycle(c *C) {
 	misc.LogTestStart(c.TestName())
 

--- a/tests/e2e/basic_shared_test.go
+++ b/tests/e2e/basic_shared_test.go
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 // This test suite includes test cases to verify basic functionality
-// in most common configurations
+// before upgrade for upgrade test
 
 // +build runonceshared
+
 package e2e
 
 import (

--- a/tests/e2e/volumecreate_shared_test.go
+++ b/tests/e2e/volumecreate_shared_test.go
@@ -62,7 +62,7 @@ var (
 // 8. contains space
 func (s *VolumeCreateSharedTestSuite) validVolNames() []string {
 	return []string{
-		// for each volume volname, a internal volume with name "InternalVolvolname"
+		// for each volume volname, an internal volume with name with prefix "InternalVolvolname"
 		// will be created by vsphere driver
 		inputparams.GetVolumeNameOfSize(89),
 		"Volume-0000000-****-###",
@@ -177,7 +177,7 @@ func (s *VolumeCreateSharedTestSuite) TestInvalidName(c *C) {
 // 1. size 10gb
 // 2. disk format (thin, zeroedthick, eagerzeroedthick)
 // 3. attach-as (persistent, independent_persistent)
-// 4. fstype ext4 for linux / ntfs for windows
+// 4. fstype ext4 for linux
 // 5. access (read-write, read-only)
 func (s *VolumeCreateSharedTestSuite) TestValidOptions(c *C) {
 	misc.LogTestStart(c.TestName())

--- a/tests/e2e/volumecreate_shared_test.go
+++ b/tests/e2e/volumecreate_shared_test.go
@@ -47,6 +47,8 @@ var (
 		inputparams.GetUniqueVolumeName("Volume") + "@invalidDatastore",
 		"volume/abc",
 	}
+	// validFstype is a valid fstype for the TestValidOptions test.
+	validFstype = "ext4"
 )
 
 // validVolNames returns a slice of volume names for the TestValidName test.
@@ -100,9 +102,9 @@ func (s *VolumeCreateSharedTestSuite) createVolCheck(name, option string, valid 
 	var err error
 
 	if option == "" {
-		out, err = dockercli.CreateVolumeShared(s.config.DockerHosts[0], name)
+		out, err = dockercli.CreateSharedVolume(s.config.DockerHosts[0], name)
 	} else {
-		out, err = dockercli.CreateVolumeSharedWithOptions(s.config.DockerHosts[0], name, option)
+		out, err = dockercli.CreateSharedVolumeWithOptions(s.config.DockerHosts[0], name, option)
 	}
 
 	// if creation is successful, add it to the list so that it gets cleaned later
@@ -175,7 +177,8 @@ func (s *VolumeCreateSharedTestSuite) TestInvalidName(c *C) {
 // 1. size 10gb
 // 2. disk format (thin, zeroedthick, eagerzeroedthick)
 // 3. attach-as (persistent, independent_persistent)
-// 4. access (read-write, read-only)
+// 4. fstype ext4 for linux / ntfs for windows
+// 5. access (read-write, read-only)
 func (s *VolumeCreateSharedTestSuite) TestValidOptions(c *C) {
 	misc.LogTestStart(c.TestName())
 
@@ -186,6 +189,7 @@ func (s *VolumeCreateSharedTestSuite) TestValidOptions(c *C) {
 		" -o diskformat=eagerzeroedthick",
 		" -o attach-as=independent_persistent",
 		" -o attach-as=persistent",
+		" -o fstype=" + validFstype,
 		" -o access=read-only",
 		" -o access=read-write",
 	}
@@ -199,7 +203,8 @@ func (s *VolumeCreateSharedTestSuite) TestValidOptions(c *C) {
 // Invalid volume create operations
 // 1. Wrong disk formats
 // 2. Wrong volume size
-// 3. Wrong access types
+// 3. Wrong fs types
+// 4. Wrong access types
 func (s *VolumeCreateSharedTestSuite) TestInvalidOptions(c *C) {
 	misc.LogTestStart(c.TestName())
 
@@ -209,6 +214,7 @@ func (s *VolumeCreateSharedTestSuite) TestInvalidOptions(c *C) {
 		" -o size=100mbb",
 		" -o size=100gbEE",
 		" -o sizes=100mb",
+		" -o fstype=xfs_ext",
 		" -o access=read-write-both",
 		" -o access=write-only",
 		" -o access=read-write-both",

--- a/tests/e2e/volumecreate_shared_test.go
+++ b/tests/e2e/volumecreate_shared_test.go
@@ -1,0 +1,220 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This test is going to cover various volume creation test cases
+
+// +build runonceshared
+
+package e2e
+
+import (
+	"strings"
+	"sync"
+
+	dockerclicon "github.com/vmware/docker-volume-vsphere/tests/constants/dockercli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
+	"github.com/vmware/docker-volume-vsphere/tests/utils/verification"
+
+	. "gopkg.in/check.v1"
+)
+
+type VolumeCreateSharedTestSuite struct {
+	config     *inputparams.TestConfig
+	volumeList []string
+}
+
+var (
+	// invalidVolNameList is a slice of volume names for the TestInvalidName test.
+	// 1. having more than 100 chars
+	// 2. ending -NNNNNN (6Ns)
+	// 3. contains @invalid datastore name
+	invalidVolNameList = []string{
+		inputparams.GetVolumeNameOfSize(101),
+		"Volume-000000",
+		inputparams.GetUniqueVolumeName("Volume") + "@invalidDatastore",
+		"volume/abc",
+	}
+)
+
+// validVolNames returns a slice of volume names for the TestValidName test.
+// 1. having 100 chars
+// 2. having various chars including alphanumerics
+// 3. ending in 5Ns
+// 4. ending in 7Ns
+// 5. contains @datastore (valid name)
+// 6. contains multiple '@'
+// 7. contains unicode character
+// 8. contains space
+func (s *VolumeCreateSharedTestSuite) validVolNames() []string {
+	return []string{
+		// for each volume volname, a internal volume with name "InternalVolvolname"
+		// will be created by vsphere driver
+		inputparams.GetVolumeNameOfSize(89),
+		"Volume-0000000-****-###",
+		"Volume-00000",
+		"Volume-0000000",
+		inputparams.GetUniqueVolumeName("abc") + "@" + s.config.Datastores[0],
+		inputparams.GetUniqueVolumeName("abc") + "@@@@" + s.config.Datastores[0],
+		inputparams.GetUniqueVolumeName("Volume-你"),
+		"\"Volume Space\"",
+	}
+}
+
+func (s *VolumeCreateSharedTestSuite) SetUpSuite(c *C) {
+	s.config = inputparams.GetTestConfig()
+	if s.config == nil {
+		c.Skip("Unable to retrieve test config, skipping volume create tests for shared plugin")
+	}
+}
+
+func (s *VolumeCreateSharedTestSuite) TearDownTest(c *C) {
+	volList := strings.Join(s.volumeList, " ")
+
+	if volList != "" {
+		out, err := dockercli.DeleteVolume(s.config.DockerHosts[0], volList)
+		c.Assert(err, IsNil, Commentf(out))
+	}
+
+	// clean the list of volumes created
+	s.volumeList = s.volumeList[:0]
+}
+
+var _ = Suite(&VolumeCreateSharedTestSuite{})
+
+// create volume and do valid/invalid assertion
+func (s *VolumeCreateSharedTestSuite) createVolCheck(name, option string, valid bool, c *C) {
+	var out string
+	var err error
+
+	if option == "" {
+		out, err = dockercli.CreateVolumeShared(s.config.DockerHosts[0], name)
+	} else {
+		out, err = dockercli.CreateVolumeSharedWithOptions(s.config.DockerHosts[0], name, option)
+	}
+
+	// if creation is successful, add it to the list so that it gets cleaned later
+	if err == nil {
+		s.volumeList = append(s.volumeList, name)
+	}
+
+	if valid {
+		// positive test case
+		c.Assert(err, IsNil, Commentf(out))
+	} else {
+		// negative test case
+		c.Assert(err, Not(IsNil), Commentf(out))
+		c.Assert(strings.HasPrefix(out, dockerclicon.ErrorVolumeCreate), Equals, true, Commentf(out))
+	}
+}
+
+// loop over volume names to parallely create volumes
+func (s *VolumeCreateSharedTestSuite) parallelCreateByName(names []string, valid bool, c *C) {
+	var wg sync.WaitGroup
+	for _, volName := range names {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			s.createVolCheck(name, "", valid, c)
+		}(volName)
+	}
+	wg.Wait()
+}
+
+// loop over volume options to parallely create volumes
+func (s *VolumeCreateSharedTestSuite) parallelCreateByOption(options []string, valid bool, c *C) {
+	var wg sync.WaitGroup
+	for _, volOption := range options {
+		wg.Add(1)
+		go func(option string) {
+			defer wg.Done()
+			volName := inputparams.GetUniqueVolumeName("option")
+			s.createVolCheck(volName, option, valid, c)
+		}(volOption)
+	}
+	wg.Wait()
+}
+
+func (s *VolumeCreateSharedTestSuite) accessCheck(hostIP string, volList []string, c *C) {
+	isAvailable := verification.CheckVolumeListAvailability(hostIP, volList)
+	c.Assert(isAvailable, Equals, true, Commentf("Volume %s is not available after creation", volList))
+}
+
+// Valid volume names test
+func (s *VolumeCreateSharedTestSuite) TestValidName(c *C) {
+	misc.LogTestStart(c.TestName())
+
+	s.parallelCreateByName(s.validVolNames(), true, c)
+	s.accessCheck(s.config.DockerHosts[0], s.volumeList, c)
+
+	misc.LogTestEnd(c.TestName())
+}
+
+// Invalid volume names test
+func (s *VolumeCreateSharedTestSuite) TestInvalidName(c *C) {
+	misc.LogTestStart(c.TestName())
+
+	s.parallelCreateByName(invalidVolNameList, false, c)
+
+	misc.LogTestEnd(c.TestName())
+}
+
+// Valid volume creation options
+// 1. size 10gb
+// 2. disk format (thin, zeroedthick, eagerzeroedthick)
+// 3. attach-as (persistent, independent_persistent)
+// 4. access (read-write, read-only)
+func (s *VolumeCreateSharedTestSuite) TestValidOptions(c *C) {
+	misc.LogTestStart(c.TestName())
+
+	validVolOpts := []string{
+		" -o size=10gb",
+		" -o diskformat=zeroedthick",
+		" -o diskformat=thin",
+		" -o diskformat=eagerzeroedthick",
+		" -o attach-as=independent_persistent",
+		" -o attach-as=persistent",
+		" -o access=read-only",
+		" -o access=read-write",
+	}
+
+	s.parallelCreateByOption(validVolOpts, true, c)
+	s.accessCheck(s.config.DockerHosts[0], s.volumeList, c)
+
+	misc.LogTestEnd(c.TestName())
+}
+
+// Invalid volume create operations
+// 1. Wrong disk formats
+// 2. Wrong volume size
+// 3. Wrong access types
+func (s *VolumeCreateSharedTestSuite) TestInvalidOptions(c *C) {
+	misc.LogTestStart(c.TestName())
+
+	invalidVolOpts := []string{
+		" -o diskformat=zeroedthickk",
+		" -o diskformat=zeroedthick,thin",
+		" -o size=100mbb",
+		" -o size=100gbEE",
+		" -o sizes=100mb",
+		" -o access=read-write-both",
+		" -o access=write-only",
+		" -o access=read-write-both",
+	}
+
+	s.parallelCreateByOption(invalidVolOpts, false, c)
+
+	misc.LogTestEnd(c.TestName())
+}

--- a/tests/e2e/volumecreate_shared_test.go
+++ b/tests/e2e/volumecreate_shared_test.go
@@ -179,19 +179,21 @@ func (s *VolumeCreateSharedTestSuite) TestInvalidName(c *C) {
 // 3. attach-as (persistent, independent_persistent)
 // 4. fstype ext4 for linux
 // 5. access (read-write, read-only)
+// TODO: Right now, only -o size option is supported by vsphere shared volume
+// all other options are not supported yet
 func (s *VolumeCreateSharedTestSuite) TestValidOptions(c *C) {
 	misc.LogTestStart(c.TestName())
 
 	validVolOpts := []string{
 		" -o size=10gb",
-		" -o diskformat=zeroedthick",
-		" -o diskformat=thin",
-		" -o diskformat=eagerzeroedthick",
-		" -o attach-as=independent_persistent",
-		" -o attach-as=persistent",
-		" -o fstype=" + validFstype,
-		" -o access=read-only",
-		" -o access=read-write",
+		// " -o diskformat=zeroedthick",
+		// " -o diskformat=thin",
+		// " -o diskformat=eagerzeroedthick",
+		// " -o attach-as=independent_persistent",
+		// " -o attach-as=persistent",
+		// " -o fstype=" + validFstype,
+		// " -o access=read-only",
+		// " -o access=read-write",
 	}
 
 	s.parallelCreateByOption(validVolOpts, true, c)
@@ -205,19 +207,21 @@ func (s *VolumeCreateSharedTestSuite) TestValidOptions(c *C) {
 // 2. Wrong volume size
 // 3. Wrong fs types
 // 4. Wrong access types
+// TODO: Right now, only -o size option is supported by vsphere shared volume
+// all other options are not supported yet
 func (s *VolumeCreateSharedTestSuite) TestInvalidOptions(c *C) {
 	misc.LogTestStart(c.TestName())
 
 	invalidVolOpts := []string{
-		" -o diskformat=zeroedthickk",
-		" -o diskformat=zeroedthick,thin",
+		// " -o diskformat=zeroedthickk",
+		// " -o diskformat=zeroedthick,thin",
 		" -o size=100mbb",
 		" -o size=100gbEE",
 		" -o sizes=100mb",
-		" -o fstype=xfs_ext",
-		" -o access=read-write-both",
-		" -o access=write-only",
-		" -o access=read-write-both",
+		// " -o fstype=xfs_ext",
+		// " -o access=read-write-both",
+		// " -o access=write-only",
+		// " -o access=read-write-both",
 	}
 
 	s.parallelCreateByOption(invalidVolOpts, false, c)

--- a/tests/utils/dockercli/volumelifecycle.go
+++ b/tests/utils/dockercli/volumelifecycle.go
@@ -47,16 +47,16 @@ func CreateVolumeWithOptions(ip, name, options string) (string, error) {
 	return ssh.InvokeCommand(ip, dockercli.CreateVolume+"--name="+name+" "+options)
 }
 
-// CreateVolumeShared is going to create docker volume with given name using vsphere shared driver.
-func CreateVolumeShared(ip, name string) (string, error) {
+// CreateSharedVolume is going to create docker volume with given name using vsphere shared driver.
+func CreateSharedVolume(ip, name string) (string, error) {
 	log.Printf("Creating shared volume [%s] on VM [%s]\n", name, ip)
-	return ssh.InvokeCommand(ip, dockercli.CreateVolumeShared+" --name= "+name)
+	return ssh.InvokeCommand(ip, dockercli.CreateSharedVolume+" --name= "+name)
 }
 
-// CreateVolumeWithOptions is going to create docker volume with given name using vshpere shared driver.
-func CreateVolumeSharedWithOptions(ip, name, options string) (string, error) {
+// CreateSharedVolumeWithOptions is going to create docker volume with given name using vshpere shared driver.
+func CreateSharedVolumeWithOptions(ip, name, options string) (string, error) {
 	log.Printf("Creating shared volume [%s] with options [%s] on VM [%s]\n", name, options, ip)
-	return ssh.InvokeCommand(ip, dockercli.CreateVolumeShared+"--name="+name+" "+options)
+	return ssh.InvokeCommand(ip, dockercli.CreateSharedVolume+"--name="+name+" "+options)
 }
 
 // AttachVolume - attach volume to container on given host

--- a/tests/utils/dockercli/volumelifecycle.go
+++ b/tests/utils/dockercli/volumelifecycle.go
@@ -47,6 +47,18 @@ func CreateVolumeWithOptions(ip, name, options string) (string, error) {
 	return ssh.InvokeCommand(ip, dockercli.CreateVolume+"--name="+name+" "+options)
 }
 
+// CreateVolumeShared is going to create docker volume with given name using vsphere shared driver.
+func CreateVolumeShared(ip, name string) (string, error) {
+	log.Printf("Creating shared volume [%s] on VM [%s]\n", name, ip)
+	return ssh.InvokeCommand(ip, dockercli.CreateVolumeShared+" --name= "+name)
+}
+
+// CreateVolumeWithOptions is going to create docker volume with given name using vshpere shared driver.
+func CreateVolumeSharedWithOptions(ip, name, options string) (string, error) {
+	log.Printf("Creating shared volume [%s] with options [%s] on VM [%s]\n", name, options, ip)
+	return ssh.InvokeCommand(ip, dockercli.CreateVolumeShared+"--name="+name+" "+options)
+}
+
 // AttachVolume - attach volume to container on given host
 func AttachVolume(ip, volName, containerName string) (string, error) {
 	log.Printf("Attaching volume [%s] on VM [%s]\n", volName, ip)

--- a/tests/utils/verification/volumeproperties.go
+++ b/tests/utils/verification/volumeproperties.go
@@ -141,6 +141,15 @@ func getVolumeStatusHost(name, hostName string) string {
 	return out
 }
 
+// GetSharedVolumeStatusHost - get the volume status on a given host, the volume is created by
+// vsphere shared driver
+func GetSharedVolumeStatusHost(name, hostName string) string {
+	cmd := dockercli.InspectVolume + " --format \"{{index .Status \\\"Volume Status\\\"}}\" " + name
+	log.Printf("GetSharedVolumeStatusHost: cmd[]", cmd)
+	out, _ := ssh.InvokeCommand(hostName, cmd)
+	return out
+}
+
 // VerifyDetachedStatus - check if the status gets detached within the timeout.
 // The name of the volume MUST be a shorter name without @datastore suffix.
 // Use this util in test scenarios where the test expects instant change of status to detached.


### PR DESCRIPTION
**This PR includes:**
1. E2E test to test volume create with various valid/invalid option
2. E2E test for basic life cycle, which include create/get/inspect/rm now.  Mount/unmount test will be added later after mount/unmount is available.
3. necessary changes in Makefile

**Test:**
prerequisites: need to install vsphere shared volume driver and set alias to "vshared" on all docker hosts.

```
lipingx-m01:docker-volume-vsphere lipingx$ make test-e2e-shared 
/Library/Developer/CommandLineTools/usr/bin/make --directory=client_plugin test-e2e-shared

=> Running target test-e2e-shared Tue Aug 8 10:50:18 PDT 2017

../misc/scripts/build.sh test-e2e-runonce-shared
make: Entering directory `/go/src/github.com/vmware/docker-volume-vsphere/client_plugin'

=> Running target test-e2e-runonce-shared Tue Aug 8 17:50:20 UTC 2017

go test -v -timeout 40m -tags "runonceshared" github.com/vmware/docker-volume-vsphere/tests/e2e
=== RUN   Test
2017/08/08 17:50:23 START: BasicSharedTestSuite.TestVolumeLifecycle
2017/08/08 17:50:23 Creating shared volume [BasicSharedTestSuite.TestVolumeLifecycle_volume_902000] on VM [10.160.100.14]
2017/08/08 17:50:29 Checking volume [BasicSharedTestSuite.TestVolumeLifecycle_volume_902000] availability from VM [10.160.100.14]
2017/08/08 17:50:30 GetSharedVolumeStatusHost: cmd[]%!(EXTRA string=docker volume inspect  --format "{{index .Status \"Volume Status\"}}" BasicSharedTestSuite.TestVolumeLifecycle_volume_902000)
2017/08/08 17:50:30 GetSharedVolumeStatusHost return out[%s] for volume %s Ready BasicSharedTestSuite.TestVolumeLifecycle_volume_902000
2017/08/08 17:50:30 Checking volume [BasicSharedTestSuite.TestVolumeLifecycle_volume_902000] availability from VM [10.160.100.14]
2017/08/08 17:50:31 Destroying volume [BasicSharedTestSuite.TestVolumeLifecycle_volume_902000]
2017/08/08 17:50:33 Creating shared volume [BasicSharedTestSuite.TestVolumeLifecycle_volume_902000] on VM [10.160.99.2]
2017/08/08 17:50:39 Checking volume [BasicSharedTestSuite.TestVolumeLifecycle_volume_902000] availability from VM [10.160.99.2]
2017/08/08 17:50:40 GetSharedVolumeStatusHost: cmd[]%!(EXTRA string=docker volume inspect  --format "{{index .Status \"Volume Status\"}}" BasicSharedTestSuite.TestVolumeLifecycle_volume_902000)
2017/08/08 17:50:40 GetSharedVolumeStatusHost return out[%s] for volume %s Ready BasicSharedTestSuite.TestVolumeLifecycle_volume_902000
2017/08/08 17:50:40 Checking volume [BasicSharedTestSuite.TestVolumeLifecycle_volume_902000] availability from VM [10.160.99.2]
2017/08/08 17:50:41 Destroying volume [BasicSharedTestSuite.TestVolumeLifecycle_volume_902000]
2017/08/08 17:50:43 END: BasicSharedTestSuite.TestVolumeLifecycle
2017/08/08 17:50:43 START: VolumeCreateSharedTestSuite.TestInvalidName
2017/08/08 17:50:43 Creating shared volume [volume/abc] on VM [10.160.100.14]
2017/08/08 17:50:43 Creating shared volume [Volume-000000] on VM [10.160.100.14]
2017/08/08 17:50:43 Creating shared volume [BpLnfgDsc2WD8F2qNfHK5a84jjJkwzDkh9h2fhfUVuS9jZ8uVbhV3vC5AWX39IVUWSP2NcHciWvqZTa2N95RxRTZHWUsaD6HEdz0T] on VM [10.160.100.14]
2017/08/08 17:50:43 Creating shared volume [Volume_volume_305432@invalidDatastore] on VM [10.160.100.14]
2017/08/08 17:50:45 END: VolumeCreateSharedTestSuite.TestInvalidName
2017/08/08 17:50:45 START: VolumeCreateSharedTestSuite.TestInvalidOptions
2017/08/08 17:50:45 Creating shared volume [option_volume_974534] with options [ -o access=read-write-both] on VM [10.160.100.14]
2017/08/08 17:50:45 Creating shared volume [option_volume_752538] with options [ -o diskformat=zeroedthick,thin] on VM [10.160.100.14]
2017/08/08 17:50:45 Creating shared volume [option_volume_931047] with options [ -o size=100mbb] on VM [10.160.100.14]
2017/08/08 17:50:45 Creating shared volume [option_volume_200376] with options [ -o size=100gbEE] on VM [10.160.100.14]
2017/08/08 17:50:45 Creating shared volume [option_volume_892013] with options [ -o sizes=100mb] on VM [10.160.100.14]
2017/08/08 17:50:45 Creating shared volume [option_volume_647695] with options [ -o diskformat=zeroedthickk] on VM [10.160.100.14]
2017/08/08 17:50:45 Creating shared volume [option_volume_728097] with options [ -o fstype=xfs_ext] on VM [10.160.100.14]
2017/08/08 17:50:45 Creating shared volume [option_volume_466696] with options [ -o access=read-write-both] on VM [10.160.100.14]
2017/08/08 17:50:45 Creating shared volume [option_volume_1005756] with options [ -o access=write-only] on VM [10.160.100.14]
2017/08/08 17:50:49 END: VolumeCreateSharedTestSuite.TestInvalidOptions
2017/08/08 17:50:49 START: VolumeCreateSharedTestSuite.TestValidName
2017/08/08 17:50:49 Creating shared volume ["Volume Space"] on VM [10.160.100.14]
2017/08/08 17:50:49 Creating shared volume [mSzO1fCUWooVQlNpimWSFrLHSXg6xXya0iNuDQLZgAJ5UdCvLSJXbf1NE2wVqDumwKRWMjF7qCNqL5LNJ2ZPUpYZt] on VM [10.160.100.14]
2017/08/08 17:50:49 Creating shared volume [abc_volume_871177@sharedVmfs-0] on VM [10.160.100.14]
2017/08/08 17:50:49 Creating shared volume [Volume-0000000] on VM [10.160.100.14]
2017/08/08 17:50:49 Creating shared volume [abc_volume_1084464@@@@sharedVmfs-0] on VM [10.160.100.14]
2017/08/08 17:50:49 Creating shared volume [Volume-你_volume_831293] on VM [10.160.100.14]
2017/08/08 17:50:49 Creating shared volume [Volume-0000000-****-###] on VM [10.160.100.14]
2017/08/08 17:50:49 Creating shared volume [Volume-00000] on VM [10.160.100.14]
2017/08/08 17:51:07 Checking volume [Volume-0000000 abc_volume_1084464@@@@sharedVmfs-0 mSzO1fCUWooVQlNpimWSFrLHSXg6xXya0iNuDQLZgAJ5UdCvLSJXbf1NE2wVqDumwKRWMjF7qCNqL5LNJ2ZPUpYZt Volume-0000000-****-### Volume-00000 abc_volume_871177@sharedVmfs-0 "Volume Space" Volume-你_volume_831293] availability from VM [10.160.100.14]
2017/08/08 17:51:07 END: VolumeCreateSharedTestSuite.TestValidName
2017/08/08 17:51:07 Destroying volume [Volume-0000000 abc_volume_1084464@@@@sharedVmfs-0 mSzO1fCUWooVQlNpimWSFrLHSXg6xXya0iNuDQLZgAJ5UdCvLSJXbf1NE2wVqDumwKRWMjF7qCNqL5LNJ2ZPUpYZt Volume-0000000-****-### Volume-00000 abc_volume_871177@sharedVmfs-0 "Volume Space" Volume-你_volume_831293]
2017/08/08 17:51:21 START: VolumeCreateSharedTestSuite.TestValidOptions
2017/08/08 17:51:21 Creating shared volume [option_volume_110623] with options [ -o access=read-write] on VM [10.160.100.14]
2017/08/08 17:51:21 Creating shared volume [option_volume_425789] with options [ -o diskformat=eagerzeroedthick] on VM [10.160.100.14]
2017/08/08 17:51:21 Creating shared volume [option_volume_890580] with options [ -o access=read-only] on VM [10.160.100.14]
2017/08/08 17:51:21 Creating shared volume [option_volume_313277] with options [ -o diskformat=zeroedthick] on VM [10.160.100.14]
2017/08/08 17:51:21 Creating shared volume [option_volume_1086080] with options [ -o diskformat=thin] on VM [10.160.100.14]
2017/08/08 17:51:21 Creating shared volume [option_volume_1005060] with options [ -o attach-as=independent_persistent] on VM [10.160.100.14]
2017/08/08 17:51:21 Creating shared volume [option_volume_748273] with options [ -o fstype=ext4] on VM [10.160.100.14]
2017/08/08 17:51:21 Creating shared volume [option_volume_296877] with options [ -o size=10gb] on VM [10.160.100.14]
2017/08/08 17:51:21 Creating shared volume [option_volume_354728] with options [ -o attach-as=persistent] on VM [10.160.100.14]
2017/08/08 17:51:42 Checking volume [option_volume_296877 option_volume_1086080 option_volume_110623 option_volume_890580 option_volume_748273 option_volume_354728 option_volume_313277 option_volume_425789 option_volume_1005060] availability from VM [10.160.100.14]
2017/08/08 17:51:42 END: VolumeCreateSharedTestSuite.TestValidOptions
2017/08/08 17:51:42 Destroying volume [option_volume_296877 option_volume_1086080 option_volume_110623 option_volume_890580 option_volume_748273 option_volume_354728 option_volume_313277 option_volume_425789 option_volume_1005060]
--- PASS: Test (97.26s)
PASS
OK: 5 passed
ok  	github.com/vmware/docker-volume-vsphere/tests/e2e	97.267s
make: Leaving directory `/go/src/github.com/vmware/docker-volume-vsphere/client_plugin'

``` 