### PR TITLE
vShared plugin: Add Mount() support for worker

### DIFF
--- a/client_plugin/drivers/shared/kvstore/kvstore.go
+++ b/client_plugin/drivers/shared/kvstore/kvstore.go
@@ -86,4 +86,14 @@ type KvStore interface {
 
 	// List - List all the different portion of keys with a given prefix
 	List(prefix string) ([]string, error)
+
+	// AtomicIncr - Increase a key value by one
+	AtomicIncr(key string) error
+
+	// AtomicDecr - Decrease a key value by one
+	AtomicDecr(key string) error
+
+	// BlockingWaitAndGet - Blocking wait until a key value becomes equal to a specific value
+	// then read the value of another key
+	BlockingWaitAndGet(key string, value string, newKey string) (string, error)
 }

--- a/client_plugin/drivers/shared/shared_driver.go
+++ b/client_plugin/drivers/shared/shared_driver.go
@@ -148,6 +148,7 @@ func (d *VolumeDriver) Get(r volume.Request) volume.Response {
 	log.Infof("VolumeDriver Get: %s", r.Name)
 	status, err := d.GetVolume(r.Name)
 	if err != nil {
+		log.WithFields(log.Fields{"name": r.Name, "error": err}).Error("Failed to get volume meta-data ")
 		return volume.Response{Err: err.Error()}
 	}
 
@@ -160,6 +161,7 @@ func (d *VolumeDriver) Get(r volume.Request) volume.Response {
 func (d *VolumeDriver) List(r volume.Request) volume.Response {
 	volumes, err := d.kvStore.List(kvstore.VolPrefixState)
 	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("Failed to get volume list ")
 		return volume.Response{Err: err.Error()}
 	}
 

--- a/client_plugin/drivers/shared/shared_driver.go
+++ b/client_plugin/drivers/shared/shared_driver.go
@@ -435,7 +435,8 @@ func (d *VolumeDriver) processMount(r volume.MountRequest) volume.Response {
 	mountpoint, err := d.MountVolume(r.Name, "", "", false, true)
 	if err != nil {
 		log.WithFields(
-			log.Fields{"name": r.Name, "error": err},
+			log.Fields{"name": r.Name,
+				"error": err},
 		).Error("Failed to mount ")
 
 		refcnt, _ := d.DecrRefCount(r.Name)
@@ -449,14 +450,15 @@ func (d *VolumeDriver) processMount(r volume.MountRequest) volume.Response {
 	return volume.Response{Mountpoint: mountpoint}
 }
 
-// MountVolume - Request attach and them mounts the volume.
+// MountVolume - Request attach and then mounts the volume.
 func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isReadOnly bool, skipAttach bool) (string, error) {
 	mountpoint := d.GetMountPoint(name)
 	// First, make sure  that mountpoint exists.
 	err := fs.Mkdir(mountpoint)
 	if err != nil {
 		log.WithFields(
-			log.Fields{"name": name, "dir": mountpoint},
+			log.Fields{"name": name,
+				"dir": mountpoint},
 		).Error("Failed to make directory for volume mount ")
 		return mountpoint, err
 	}
@@ -466,7 +468,8 @@ func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isRead
 	err = d.kvStore.AtomicIncr(kvstore.VolPrefixGRef + name)
 	if err != nil {
 		log.WithFields(
-			log.Fields{"name": name, "error": err},
+			log.Fields{"name": name,
+				"error": err},
 		).Error("Failed to increase global refcount when processMount ")
 		return "", err
 	}
@@ -480,7 +483,9 @@ func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isRead
 		if err != nil {
 			msg += fmt.Sprintf(" Also failed to decrease global refcount. Error: %v.", err)
 		}
-		log.WithFields(log.Fields{"name": name, "error": msg}).Error("")
+		log.WithFields(
+			log.Fields{"name": name,
+				"error": msg}).Error("")
 		return "", errors.New(msg)
 	}
 
@@ -490,7 +495,10 @@ func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isRead
 	// Unmarshal Info key
 	err = json.Unmarshal([]byte(info), &volRecord)
 	if err != nil {
-		log.WithFields(log.Fields{"name": name, "error": err}).Error("Failed to unmarshal info data ")
+		log.WithFields(
+			log.Fields{"name": name,
+				"error": err},
+		).Error("Failed to unmarshal info data ")
 		return "", err
 	}
 
@@ -506,7 +514,9 @@ func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isRead
 		if err != nil {
 			msg += fmt.Sprintf(" Also failed to decrease global refcount. Error: %v.", err)
 		}
-		log.WithFields(log.Fields{"name": name, "error": msg}).Error("")
+		log.WithFields(
+			log.Fields{"name": name,
+				"error": msg}).Error("")
 		return "", errors.New(msg)
 	}
 

--- a/client_plugin/drivers/vmdk/vmdk_driver.go
+++ b/client_plugin/drivers/vmdk/vmdk_driver.go
@@ -126,7 +126,7 @@ func (d *VolumeDriver) GetVolume(name string) (map[string]interface{}, error) {
 	return d.ops.Get(name)
 }
 
-// MountVolume - Request attach and them mounts the volume.
+// MountVolume - Request attach and then mounts the volume.
 // Actual mount - send attach to ESX and do the in-guest magic
 // Returns mount point and  error (or nil)
 func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isReadOnly bool, skipAttach bool) (string, error) {
@@ -136,21 +136,27 @@ func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isRead
 	err := fs.Mkdir(mountpoint)
 	if err != nil {
 		log.WithFields(
-			log.Fields{"name": name, "dir": mountpoint},
+			log.Fields{"name": name,
+				"dir": mountpoint},
 		).Error("Failed to make directory for volume mount ")
 		return mountpoint, err
 	}
 
 	waitCtx, errWait := fs.DevAttachWaitPrep()
 	if errWait != nil {
-		log.WithFields(log.Fields{"name": name,
-			"error": errWait}).Warning("Failed to initialize wait context, continuing however.. ")
+		log.WithFields(
+			log.Fields{"name": name,
+				"error": errWait},
+		).Warning("Failed to initialize wait context, continuing however.. ")
 	}
 
 	if d.useMockEsx {
 		dev, err := d.ops.RawAttach(name, nil)
 		if err != nil {
-			log.WithFields(log.Fields{"name": name, "error": err}).Error("Failed to attach volume ")
+			log.WithFields(
+				log.Fields{"name": name,
+					"error": err},
+			).Error("Failed to attach volume ")
 			return mountpoint, err
 		}
 		return mountpoint, fs.MountByDevicePath(mountpoint, fstype, string(dev[:]), false)
@@ -158,7 +164,10 @@ func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isRead
 
 	volDev, err := d.ops.Attach(name, nil)
 	if err != nil {
-		log.WithFields(log.Fields{"name": name, "error": err}).Error("Attach volume failed ")
+		log.WithFields(
+			log.Fields{"name": name,
+				"error": err},
+		).Error("Attach volume failed ")
 		return mountpoint, err
 	}
 
@@ -424,7 +433,8 @@ func (d *VolumeDriver) Remove(r volume.Request) volume.Response {
 	err := d.ops.Remove(r.Name, r.Options)
 	if err != nil {
 		log.WithFields(
-			log.Fields{"name": r.Name, "error": err},
+			log.Fields{"name": r.Name,
+				"error": err},
 		).Error("Failed to remove volume ")
 		return volume.Response{Err: err.Error()}
 	}


### PR DESCRIPTION
* Add new methods for KvStore interface:
  AtomicIncr, AtomicDecr, and BlockingWaitAndGet
* Implement Mount() function

With this PR, user can execute "docker run -v vol:/path container" with a volume created with vShared plugin.
This is the implementation on worker side.
Corresponding server side implementation is required for a complete docker run functionality.

