### PR TITLE
Integrating vmdkops_admin cli commands with esxcli - Part 1

### DIFF
--- a/esx_service/Makefile
+++ b/esx_service/Makefile
@@ -40,6 +40,9 @@ PY_VMODL := $(filter-out %_test.py, $(wildcard vmodl/*.py))
 PY_CLI   := $(filter-out %_test.py, $(wildcard cli/[a-z]*.py))
 PY_UTILS := $(filter-out %_test.py, $(wildcard utils/*.py))
 
+# xml based esxcli extension file
+ESXCLI_XML = cli/vmdkops_admin.xml
+
 C_SRC  := vmci/vmci_server.c
 
 # Build both a 32-bit and a 64-bit library for vmci.
@@ -79,6 +82,7 @@ VMDKOPS_PY2     := $(VMDKOPS_PAYLOAD)$(ESX_LOC)/Python/2
 VMDKOPS_LIB     := $(VMDKOPS_PAYLOAD)$(ESX_LOC)/lib
 VMDKOPS_LIB64   := $(VMDKOPS_PAYLOAD)$(ESX_LOC)/lib64
 VMDKOPS_INITD   := $(VMDKOPS_PAYLOAD)/etc/init.d
+VMDKOPS_CLI_XML := $(VMDKOPS_PAYLOAD)/usr/lib/vmware/esxcli/ext
 
 # build the docker-volume-plugin
 
@@ -97,6 +101,7 @@ TO_ESX_BIN := $(PY_SRC) $(PY_CLI)
 TO_ESX_PY  := $(PY_UTILS)
 TO_ESX_LIB := $(VMCI_SRV_LIBS)
 TO_ESX_INITD := $(INIT_SCRIPT)
+TO_ESXCLI_EXT := $(ESXCLI_XML)
 
 
 # SQLITE python libs. We need that on ESX before 6.0 U2
@@ -109,9 +114,9 @@ VMODL_PY := $(shell find ../esx_service/vmodl -name '*.py')
 $(VIB_BIN): $(TO_WDIR) $(TO_ESX_BIN) $(TO_ESX_PY) $(TO_ESX_LIB) $(TO_ESX_INITD)  $(VMODL_PY) $(PY_SQLITE) $(SO_SQLITE)
 	@echo Staging in $(PAYLOAD)
 ifeq ($(INCLUDE_UI), true)
-	@mkdir -p $(VMDKOPS_BIN) $(VMDKOPS_PY) $(VMDKOPS_PY2) $(VMDKOPS_LIB) $(VMDKOPS_LIB64) $(VMDKOPS_INITD) $(UI_TO)
+	@mkdir -p $(VMDKOPS_BIN) $(VMDKOPS_PY) $(VMDKOPS_PY2) $(VMDKOPS_LIB) $(VMDKOPS_LIB64) $(VMDKOPS_INITD) $(VMDKOPS_CLI_XML) $(UI_TO)
 else
-	@mkdir -p $(VMDKOPS_BIN) $(VMDKOPS_PY) $(VMDKOPS_PY2) $(VMDKOPS_LIB) $(VMDKOPS_LIB64) $(VMDKOPS_INITD)
+	@mkdir -p $(VMDKOPS_BIN) $(VMDKOPS_PY) $(VMDKOPS_PY2) $(VMDKOPS_LIB) $(VMDKOPS_LIB64) $(VMDKOPS_INITD) $(VMDKOPS_CLI_XML)
 endif
 	@chmod -R u+w $(PAYLOAD)
 	cp $(TO_ESX_BIN) $(VMDKOPS_BIN)
@@ -124,6 +129,7 @@ endif
 	cp $(VMCI_SRV_LIB) $(VMDKOPS_LIB)/$(VMCI_SRV_LIB_NAME)
 	cp $(VMCI_SRV_LIB64) $(VMDKOPS_LIB64)/$(VMCI_SRV_LIB_NAME)
 	cp $(TO_ESX_INITD) $(VMDKOPS_INITD)
+	cp $(TO_ESXCLI_EXT) $(VMDKOPS_CLI_XML)
 	VMDKOPS_PAYLOAD=$(VMDKOPS_PAYLOAD) $(MAKE)  --directory=vmodl copy_to_payload
 	@chmod -R u+x $(VMDKOPS_BIN)
 	@sed "s/   <version>1.0.0-0.0.1<\/version>/   <version>$(PKG_VERSION)-$(RELEASE_VERSION)<\/version>/g" $(TO_WDIR) > $(WDIR)/$(DESCRIPTOR)

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -30,6 +30,7 @@ sys.path.insert(0, vmdk_ops.PY_LOC)
 
 import volume_kv as kv
 import cli_table
+import cli_xml
 import vsan_policy
 import vmdk_utils
 import vsan_info
@@ -527,10 +528,29 @@ def commands():
         }
     }
 
+def printList(output_format, header, rows):
+    """
+    Prints the output generated from header and rows
+    in specified format
+    """
+    if output_format == "xml":
+        print(cli_xml.create(header, rows))
+    else:
+        print(cli_table.create(header, rows))
+
+def printMessage(output_format, message):
+    """
+    Prints the message in specified output format
+    """
+    if output_format == "xml":
+        print(cli_xml.createMessage(message))
+    else:
+        print(message)
 
 def create_parser():
     """ Create a CLI parser via argparse based on the dictionary returned from commands() """
     parser = argparse.ArgumentParser(description='vSphere Docker Volume Service admin CLI')
+    parser.add_argument('--output-format', help='Specify output format. Supported format : xml. Default one is plaintext')
     add_subparser(parser, commands(), title='Manage VMDK-based Volumes for Docker')
     return parser
 
@@ -609,7 +629,7 @@ def ls(args):
     else:
         header = all_ls_headers()
         rows = generate_ls_rows(tenant_reg)
-    print(cli_table.create(header, rows))
+    printList(args.output_format, header, rows)
 
 
 def ls_dash_c(columns, tenant_reg):
@@ -778,7 +798,7 @@ def policy_create(args):
     if output:
         return err_out(output)
     else:
-        print('Successfully created policy: {0}'.format(args.name))
+        printMessage(args.output_format, 'Successfully created policy: {0}'.format(args.name))
 
 
 def policy_rm(args):
@@ -786,7 +806,7 @@ def policy_rm(args):
     if output:
         return err_out(output)
     else:
-        print('Successfully removed policy: {0}'.format(args.name))
+        printMessage(args.output_format, 'Successfully removed policy: {0}'.format(args.name))
 
 
 def policy_ls(args):
@@ -809,7 +829,7 @@ def policy_ls(args):
             active = 'Unused'
         rows.append([name, content.strip(), active])
 
-    print(cli_table.create(header, rows))
+    printList(args.output_format, header, rows)
 
 
 def policy_update(args):
@@ -817,7 +837,7 @@ def policy_update(args):
     if output:
         return err_out(output)
     else:
-        print('Successfully updated policy: {0}'.format(args.name))
+        printMessage(args.output_format, 'Successfully updated policy {0}'.format(args.name))
 
 
 def status(args):
@@ -838,9 +858,12 @@ def status(args):
     result.append({"LogLevel": log_config.get_log_level()})
     result.append({"=== Authorization Config DB": ""})
     result += config_db_get_status()
-    for r in result:
-        print("{}: {}".format(list(r.keys())[0], list(r.values())[0]))
 
+    output_list = []
+    for r in result:
+        output_list.append("{}: {}".format(list(r.keys())[0], list(r.values())[0]))
+
+    printMessage(args.output_format,"\n".join(output_list))
     return None
 
 
@@ -848,7 +871,7 @@ def set_vol_opts(args):
     try:
         set_ok = vmdk_ops.set_vol_opts(args.volume, args.vmgroup, args.options)
         if set_ok:
-            print('Successfully updated settings for : {0}'.format(args.volume))
+            printMessage(args.output_format, 'Successfully updated settings for {0}'.format(args.volume))
         else:
             return err_out('Failed to update {0} for {1}.'.format(args.options, args.volume))
     except Exception as ex:
@@ -959,9 +982,9 @@ def tenant_create(args):
     if error_info:
         return err_out(error_info.msg)
     elif args.name != auth_data_const.DEFAULT_TENANT:
-        print("vmgroup '{}' is created. Do not forget to run 'vmgroup vm add' to add vm to vmgroup.".format(args.name))
+        printMessage(args.output_format, "vmgroup '{}' is created. Do not forget to run 'vmgroup vm add' to add vm to vmgroup.".format(args.name))
     else:
-        print("vmgroup '{}' is created.".format(args.name))
+        printMessage(args.output_format, "vmgroup '{}' is created.".format(args.name))
 
 def tenant_update(args):
     """ Handle tenant update command """
@@ -976,7 +999,7 @@ def tenant_update(args):
     if error_info:
         return err_out(error_info.msg)
     else:
-        print("vmgroup modify succeeded")
+        printMessage(args.output_format, "vmgroup modify succeeded")
 
 def tenant_rm(args):
     """ Handle tenant rm command """
@@ -984,7 +1007,6 @@ def tenant_rm(args):
     # If args "remove_volumes" is not specified in CLI
     # args.remove_volumes will be None
     if args.remove_volumes:
-        print("All Volumes will be removed")
         remove_volumes = True
 
     error_info = auth_api._tenant_rm(args.name, remove_volumes)
@@ -992,7 +1014,8 @@ def tenant_rm(args):
     if error_info:
         return err_out(error_info.msg)
     else:
-        print("vmgroup rm succeeded")
+        msg = "vmgroup rm succeeded"
+        printMessage(args.output_format, "All Volumes will be removed. " + msg if remove_volumes else msg)
 
 def tenant_ls(args):
     """ Handle tenant ls command """
@@ -1005,7 +1028,7 @@ def tenant_ls(args):
     if error_info:
         return err_out(error_info.msg)
     else:
-        print(cli_table.create(header, rows))
+        printList(args.output_format, header, rows)
 
 def tenant_vm_add(args):
     """ Handle tenant vm add command """
@@ -1014,7 +1037,7 @@ def tenant_vm_add(args):
     if error_info:
         return err_out(error_info.msg)
     else:
-        print("vmgroup vm add succeeded")
+        printMessage(args.output_format, "vmgroup vm add succeeded")
 
 def tenant_vm_rm(args):
     """ Handle tenant vm rm command """
@@ -1023,7 +1046,7 @@ def tenant_vm_rm(args):
     if error_info:
         return err_out(error_info.msg)
     else:
-        print("vmgroup vm rm succeeded")
+        printMessage(args.output_format, "vmgroup vm rm succeeded")
 
 def tenant_vm_replace(args):
     """ Handle tenant vm replace command """
@@ -1032,7 +1055,7 @@ def tenant_vm_replace(args):
     if error_info:
         return err_out(error_info.msg)
     else:
-        print("vmgroup vm replace succeeded")
+        printMessage(args.output_format, "vmgroup vm replace succeeded")
 
 def tenant_vm_ls_headers():
     """ Return column names for tenant vm ls command """
@@ -1066,7 +1089,7 @@ def tenant_vm_ls(args):
 
     header = tenant_vm_ls_headers()
     rows = generate_tenant_vm_ls_rows(vms)
-    print(cli_table.create(header, rows))
+    printList(args.output_format, header, rows)
 
 
 def tenant_access_add(args):
@@ -1088,7 +1111,7 @@ def tenant_access_add(args):
     if error_info:
         return err_out(error_info.msg)
     else:
-        print("vmgroup access add succeeded")
+        printMessage(args.output_format, "vmgroup access add succeeded")
 
 def tenant_access_set(args):
     """ Handle tenant access set command """
@@ -1108,7 +1131,7 @@ def tenant_access_set(args):
     if error_info:
         return err_out(error_info.msg)
     else:
-        print("vmgroup access set succeeded")
+        printMessage(args.output_format, "vmgroup access set succeeded")
 
 def tenant_access_rm(args):
     """ Handle tenant access rm command """
@@ -1116,7 +1139,7 @@ def tenant_access_rm(args):
     if error_info:
         return err_out(error_info.msg)
     else:
-        print("vmgroup access rm succeeded")
+        printMessage(args.output_format, "vmgroup access rm succeeded")
 
 def tenant_access_ls_headers():
     """ Return column names for tenant access ls command """
@@ -1157,7 +1180,7 @@ def tenant_access_ls(args):
     if error_info:
         return err_out(error_info.msg)
     else:
-        print(cli_table.create(header, rows))
+        printList(args.output_format, header, rows)
 
 # ==== CONFIG DB manipulation functions ====
 
@@ -1205,15 +1228,16 @@ def err_out(_msg, _info=None):
     A helper to print an error message with (optional) info if the vmdkops admin command fails.
     Returns the message.
     """
-    print(_msg)
+    _msg = ("ERROR:" + _msg)
     if _info:
-        print("Additional information: {}".format(_info))
+        _msg = _msg + (". Additional information: {}".format(_info))
+    print(_msg)
     return _msg
 
 
 def err_override(_msg, _info):
     """A helper to print messates with extra help about --force flag"""
-    new_msg = "Error: {}".format(_msg) + " . Add '--force' flag to force the request execution"
+    new_msg = "{}".format(_msg) + " . Add '--force' flag to force the request execution"
     return err_out(new_msg, _info)
 
 
@@ -1255,7 +1279,10 @@ def config_init(args):
     if err:
         return err
 
-    print("Warning: this feature is EXPERIMENTAL")
+    output_list = []
+
+    output_list.append("Warning: this feature is EXPERIMENTAL")
+
     if args.datastore:
         ds_name = args.datastore
         db_path = auth_data.AuthorizationDataManager.ds_to_db_path(ds_name)
@@ -1278,7 +1305,7 @@ def config_init(args):
     elif mode == auth_data.DBMode.MultiNode or mode == auth_data.DBMode.SingleNode:
         return err_out(DB_REF + " is already initialized. Use 'rm --local' or 'rm --unlink' to reset", info)
     else:
-        raise Exception("Fatal: Internal error - unknown mode: {}".format(mode))
+        return err_out("Fatal: Internal error - unknown mode: {}".format(mode))
 
     if args.datastore:
         # Check that the target datastore is NOT local VMFS, bail out if it is (--force to overide).
@@ -1292,7 +1319,7 @@ def config_init(args):
                                 other_ds_config)
 
     if not os.path.exists(db_path):
-        print("Creating new DB at {}".format(db_path))
+        output_list.append("Creating new DB at {}".format(db_path))
         auth = auth_data.AuthorizationDataManager(db_path)
         err = auth.new_db()
         if err:
@@ -1300,13 +1327,15 @@ def config_init(args):
 
     # Almost done -  just create link and refresh the service
     if args.local:
-        print("Warning: Local configuration will not survive ESXi reboot." +
+        output_list.append("Warning: Local configuration will not survive ESXi reboot." +
               " See KB2043564 for details")
     else:
-        print("Creating a symlink to {} at {}".format(db_path, link_path))
+        output_list.append("Creating a symlink to {} at {}".format(db_path, link_path))
         create_db_symlink(db_path, link_path)
-        print("Updating {}".format(local_sh.LOCAL_SH_PATH))
+        output_list.append("Updating {}".format(local_sh.LOCAL_SH_PATH))
         local_sh.update_symlink_info(args.datastore)
+
+    printMessage(args.output_format, "\n".join(output_list))
 
     return None
 
@@ -1347,7 +1376,7 @@ def config_rm(args):
             mode = auth.mode # for usage outside of the 'with'
         except auth_data.DbAccessError as ex:
             # the DB is broken and is being asked to be removed, so let's oblige
-            print("Received error - removing comfiguration anyways. Err: \"{}\"".format(str(ex)))
+            printMessage(args.output_format, "Received error - removing comfiguration anyways. Err: \"{}\"".format(str(ex)))
             try:
                 os.remove(auth_data.AUTH_DB_PATH)
             except:
@@ -1360,7 +1389,7 @@ def config_rm(args):
 
     # mode is NotConfigured, path does not exist
     if mode == auth_data.DBMode.NotConfigured:
-        print("Nothing to do - Mode={}.".format(str(mode)))
+        printMessage(args.output_format, "Nothing to do - Mode={}.".format(str(mode)))
 
     link_path = auth_data.AUTH_DB_PATH # local DB or link
     if not os.path.lexists(link_path):
@@ -1371,12 +1400,15 @@ def config_rm(args):
             return err_out("'rm --local' is not supported when " + DB_REF + "is in MultiNode mode."
                            " Use 'rm --unlink' to remove the local link to shared DB.")
         else:
+            output_list = []
             try:
                 os.remove(link_path)
-                print("Removed link {}".format(link_path))
+                output_list.append("Removed link {}".format(link_path))
             except Exception as ex:
-                print(" Failed to remove {}: {}".format(link_path, ex))
-            print("Updating {}".format(local_sh.LOCAL_SH_PATH))
+                output_list.append("Failed to remove {}: {}".format(link_path, ex))
+
+            output_list.append("Updating {}".format(local_sh.LOCAL_SH_PATH))
+            printMessage(args.output_format, "\n".join(output_list))
             local_sh.update_symlink_info(add=False)
             return None
 
@@ -1387,12 +1419,12 @@ def config_rm(args):
                            " Use 'rm --local' to remove local DB configuration.")
         else:
             if not args.no_backup:
-                print("Moved {} to backup file {}".format(link_path,
+                printMessage(args.output_format, "Moved {} to backup file {}".format(link_path,
                                                           db_move_to_backup(link_path)))
             return None
 
     # All other cases
-    print("Nothing to do - Mode={}.".format(str(mode)))
+    printMessage(args.output_format, "Nothing to do - Mode={}.".format(str(mode)))
 
 def config_mv(args):
     """[Not Supported Yet]
@@ -1412,7 +1444,7 @@ def config_mv(args):
     # need --dryrun or --confirm
     # issue: works really with discovery only , as others need to find it out
 
-    print("Sorry, configuration move ('config mv' command) is not supported yet")
+    printMessage(args.output_format, "Sorry, configuration move ('config mv' command) is not supported yet")
     return None
 
 
@@ -1431,8 +1463,11 @@ def config_db_get_status():
 
 def config_status(args):
     """A subset of 'config' command - prints the DB config only"""
+    output_list = []
     for r in config_db_get_status():
-        print("{}: {}".format(list(r.keys())[0], list(r.values())[0]))
+        output_list.append("{}: {}".format(list(r.keys())[0], list(r.values())[0]))
+
+    printMessage(args.output_format, "\n".join(output_list))
     return None
 
 

--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -1236,7 +1236,7 @@ def err_out(_msg, _info=None):
 
 
 def err_override(_msg, _info):
-    """A helper to print messates with extra help about --force flag"""
+    """A helper to print messages with extra help about --force flag"""
     new_msg = "{}".format(_msg) + " . Add '--force' flag to force the request execution"
     return err_out(new_msg, _info)
 

--- a/esx_service/cli/vmdkops_admin.xml
+++ b/esx_service/cli/vmdkops_admin.xml
@@ -4,32 +4,32 @@
     <!-- esxcli extension syntax version -->
     <version>1.0.0</version>
     <namespaces>
-        <namespace path="vdvs">
-            <description>vSphere Docker Volume Service admin CLI</description>
+        <namespace path="storage.vdvs">
+            <description>Admin commands to manage volumes consumed by vdvs</description>
         </namespace>
-        <namespace path="vdvs.volume">
+        <namespace path="storage.vdvs.volume">
             <description>Manage vDVS volumes</description>
         </namespace>
-        <namespace path="vdvs.policy">
+        <namespace path="storage.vdvs.policy">
             <description>Configure and display storage policy information</description>
         </namespace>
-        <namespace path="vdvs.vmgroup">
+        <namespace path="storage.vdvs.vmgroup">
             <description>Administer and monitor volume access control</description>
         </namespace>
-        <namespace path="vdvs.vmgroup.vm">
+        <namespace path="storage.vdvs.vmgroup.vm">
             <description>Add, removes, replaces and lists VMs in a vmgroup</description>
         </namespace>
-        <namespace path="vdvs.vmgroup.access">
+        <namespace path="storage.vdvs.vmgroup.access">
             <description>Add or remove Datastore access and quotas for a vmgroup</description>
         </namespace>
-        <namespace path="vdvs.config">
+        <namespace path="storage.vdvs.config">
             <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>
         </namespace>
     </namespaces>
     <commands>
         <!-- Volume commands -->
-        <command path="vdvs.volume.ls">
-            <description>'List volumes'</description>
+        <command path="storage.vdvs.volume.ls">
+            <description>List volumes</description>
             <input-spec>
                 <parameter name="vmgroup" type="string" required="false">
                     <description>Displays volumes for a given vmgroup</description>
@@ -87,7 +87,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume ls $if{vmgroup, --vmgroup $val{vmgroup}}</execute>
         </command>
-        <command path="vdvs.volume.set">
+        <command path="storage.vdvs.volume.set">
             <description>Edit settings for a given volume</description>
             <input-spec>
                 <parameter name="volume" type="string" required="true">
@@ -109,7 +109,7 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume set --vmgroup=$val{vmgroup} --volume=$val{volume} --options=$val{options}</execute>
         </command>
         <!-- Policy commands -->
-        <command path="vdvs.policy.create">
+        <command path="storage.vdvs.policy.create">
             <description>Create a storage policy</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -127,8 +127,8 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy create --name=$val{name} --content='$val{content}'</execute>
         </command>
-        <command path="vdvs.policy.rm">
-            <description>'Remove a storage policy'</description>
+        <command path="storage.vdvs.policy.rm">
+            <description>Remove a storage policy</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
                     <description>The name of the policy</description>
@@ -142,7 +142,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy rm --name=$val{name}</execute>
         </command>
-        <command path="vdvs.policy.ls">
+        <command path="storage.vdvs.policy.ls">
             <description>List storage policies and volumes using those policies</description>
             <input-spec></input-spec>
             <output-spec>
@@ -167,8 +167,8 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy ls</execute>
         </command>
-        <command path="vdvs.policy.update">
-            <description>'Update the definition of a storage policy and all VSAN objects using that policy'</description>
+        <command path="storage.vdvs.policy.update">
+            <description>Update the definition of a storage policy and all VSAN objects using that policy</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
                     <description>The name of the policy</description>
@@ -186,7 +186,7 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy update --name=$val{name} --content='$val{content}'</execute>
         </command>
         <!-- vmgroup commands -->
-        <command path="vdvs.vmgroup.create">
+        <command path="storage.vdvs.vmgroup.create">
             <description>Create a new vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -211,7 +211,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup create --name=$val{name} --default-datastore=$val{default-datastore} $if{description, --description='$val{description}}' $if{vm-list, --vm-list=$val{vm-list}} </execute>
         </command>
-        <command path="vdvs.vmgroup.update">
+        <command path="storage.vdvs.vmgroup.update">
             <description>Update a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -236,7 +236,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml  vmgroup update --name=$val{name} $if{new-name, --new-name=$val{new-name}} $if{description, --description='$val{description}}' $if{vm-list, --vm-list=$val{vm-list}}</execute>
         </command>
-        <command path="vdvs.vmgroup.rm">
+        <command path="storage.vdvs.vmgroup.rm">
             <description>Delete a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -255,7 +255,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup rm --name=$val{name} $if{remove-volumes, --remove-volumes=$val{remove-volumes}}</execute>
         </command>
-        <command path="vdvs.vmgroup.ls">
+        <command path="storage.vdvs.vmgroup.ls">
             <description>List vmgroups and the VMs they are applied to</description>
             <input-spec></input-spec>
             <output-spec>
@@ -287,8 +287,8 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup ls</execute>
         </command>
         <!-- vmgroup vm commands -->
-        <command path="vdvs.vmgroup.vm.add">
-            <description>Add VM(s)  to a vmgroup</description>
+        <command path="storage.vdvs.vmgroup.vm.add">
+            <description>Add VM(s) to a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
                     <description>The name of the vmgroup</description>
@@ -306,7 +306,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm add --name=$val{name} --vm-list=$val{vm-list}</execute>
         </command>
-        <command path="vdvs.vmgroup.vm.rm">
+        <command path="storage.vdvs.vmgroup.vm.rm">
             <description>Remove VM(s) from a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -325,7 +325,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm rm --name=$val{name} --vm-list=$val{vm-list}</execute>
         </command>
-        <command path="vdvs.vmgroup.vm.replace">
+        <command path="storage.vdvs.vmgroup.vm.replace">
             <description>Replace VM(s) for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -344,7 +344,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm replace --name=$val{name} --vm-list=$val{vm-list}</execute>
         </command>
-        <command path="vdvs.vmgroup.vm.ls">
+        <command path="storage.vdvs.vmgroup.vm.ls">
             <description>list VMs in a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -371,7 +371,7 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm ls --name=$val{name}</execute>
         </command>
         <!-- vmgroup access commands -->
-        <command path="vdvs.vmgroup.access.add">
+        <command path="storage.vdvs.vmgroup.access.add">
             <description>Add a datastore access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -380,7 +380,7 @@
                 <parameter name="datastore" type="string" required="true">
                     <description>Datastore name</description>
                 </parameter>
-                <parameter name="allow-create" type="bool" required="false">
+                <parameter name="allow-create" type="flag" required="false">
                     <description>Allow create and delete on datastore if set</description>
                 </parameter>
                 <parameter name="volume-maxsize" type="string" required="false">
@@ -398,7 +398,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access add --name=$val{name} --datastore=$val{datastore} $if{allow-create, --allow-create} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
         </command>
-        <command path="vdvs.vmgroup.access.set">
+        <command path="storage.vdvs.vmgroup.access.set">
             <description>Modify datastore access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -408,7 +408,7 @@
                     <description>Datastore name</description>
                 </parameter>
                 <parameter name="allow-create" type="bool" required="false">
-                    <description>Allow create and delete on datastore if set</description>
+                    <description>Allow create and delete on datastore if set to True. This value can also be set to False by user.</description>
                 </parameter>
                 <parameter name="volume-maxsize" type="string" required="false">
                     <description>Maximum size of the volume that can be created</description>
@@ -426,8 +426,8 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access set --name=$val{name} --datastore=$val{datastore} $if{allow-create, --allow-create=$val{allow-create}} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
         </command>
-        <command path="vdvs.vmgroup.access.rm">
-            <description>Modify datastore access for a vmgroup</description>
+        <command path="storage.vdvs.vmgroup.access.rm">
+            <description>Remove datastore access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
                     <description>The name of the vmgroup</description>
@@ -445,8 +445,8 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access rm --name=$val{name} --datastore=$val{datastore}</execute>
         </command>
-        <command path="vdvs.vmgroup.access.ls">
-            <description>list access for a vmgroup</description>
+        <command path="storage.vdvs.vmgroup.access.ls">
+            <description>List access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
                     <description>Vmgroup name</description>
@@ -478,7 +478,7 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access ls --name=$val{name}</execute>
         </command>
         <!-- vmgroup config commands -->
-        <command path="vdvs.status">
+        <command path="storage.vdvs.status">
             <description>Status of vdvs service</description>
             <input-spec>
                 <parameter name="fast" type="flag" required="false">
@@ -493,7 +493,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml status $if{fast, --fast}</execute>
         </command>
-        <command path="vdvs.config.init">
+        <command path="storage.vdvs.config.init">
             <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>
             <input-spec>
                 <parameter name="datastore" type="string" required="false">
@@ -514,11 +514,11 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config init $if{datastore, --datastore=$val{datastore}} $if{local, --local} $if{force, --force}</execute>
         </command>
-        <command path="vdvs.config.rm">
+        <command path="storage.vdvs.config.rm">
             <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>
             <input-spec>
                 <parameter name="unlink" type="flag" required="false">
-                    <description>Remove the local link to shared DB'</description>
+                    <description>Remove the local link to shared DB</description>
                 </parameter>
                 <parameter name="local" type="flag" required="false">
                     <description>Remove only local link or local DB</description>
@@ -538,7 +538,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config rm $if{local, --local} $if{unlink, --unlink} $if{no-backup, --no-backup} $if{confirm, --confirm}</execute>
         </command>
-        <command path="vdvs.config.mv">
+        <command path="storage.vdvs.config.mv">
             <description>Relocate config file from its current location [NOT SUPPORTED YET]</description>
             <input-spec>
                 <parameter name="to" type="string" required="true">
@@ -556,7 +556,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config mv --to=$val{to} $if{force, --force}</execute>
         </command>
-        <command path="vdvs.config.status">
+        <command path="storage.vdvs.config.status">
             <description>Show the status of the Config DB</description>
             <input-spec></input-spec>
             <output-spec>

--- a/esx_service/cli/vmdkops_admin.xml
+++ b/esx_service/cli/vmdkops_admin.xml
@@ -1,0 +1,571 @@
+<?xml version="1.0"?>
+<plugin
+    xmlns="http://www.vmware.com/Products/ESX/6.0/esxcli/">
+    <!-- esxcli extension syntax version -->
+    <version>1.0.0</version>
+    <namespaces>
+        <namespace path="vdvs">
+            <description>vSphere Docker Volume Service admin CLI</description>
+        </namespace>
+        <namespace path="vdvs.volume">
+            <description>Manage vDVS volumes</description>
+        </namespace>
+        <namespace path="vdvs.policy">
+            <description>Configure and display storage policy information</description>
+        </namespace>
+        <namespace path="vdvs.vmgroup">
+            <description>Administer and monitor volume access control</description>
+        </namespace>
+        <namespace path="vdvs.vmgroup.vm">
+            <description>Add, removes, replaces and lists VMs in a vmgroup</description>
+        </namespace>
+        <namespace path="vdvs.vmgroup.access">
+            <description>Add or remove Datastore access and quotas for a vmgroup</description>
+        </namespace>
+        <namespace path="vdvs.config">
+            <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>
+        </namespace>
+    </namespaces>
+    <commands>
+        <!-- Volume commands -->
+        <command path="vdvs.volume.ls">
+            <description>'List volumes'</description>
+            <input-spec>
+                <parameter name="vmgroup" type="string" required="false">
+                    <description>Displays volumes for a given vmgroup</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <list type="structure">
+                    <structure typeName="vdvs">
+                        <field name="Volume">
+                            <string/>
+                        </field>
+                        <field name="Datastore">
+                            <string/>
+                        </field>
+                        <field name="VMGroup">
+                            <string/>
+                        </field>
+                        <field name="Capacity">
+                            <string/>
+                        </field>
+                        <field name="Used">
+                            <string/>
+                        </field>
+                        <field name="Filesystem">
+                            <string/>
+                        </field>
+                        <field name="Policy">
+                            <string/>
+                        </field>
+                        <field name="Disk Format">
+                            <string/>
+                        </field>
+                        <field name="Attached-to">
+                            <string/>
+                        </field>
+                        <field name="Access">
+                            <string/>
+                        </field>
+                        <field name="Attach-as">
+                            <string/>
+                        </field>
+                        <field name="Created By">
+                            <string/>
+                        </field>
+                        <field name="Created Date">
+                            <string/>
+                        </field>
+                    </structure>
+                </list>
+            </output-spec>
+            <has-updates value="true"/>
+            <format-parameters>
+                <formatter>table</formatter>
+                <format-parameter name="fields:vdvs">Volume,Datastore,VMGroup,Capacity,Used,Filesystem,Policy,Disk Format,Attached-to,Access,Attach-as,Created By,Created Date</format-parameter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume ls $if{vmgroup, --vmgroup $val{vmgroup}}</execute>
+        </command>
+        <command path="vdvs.volume.set">
+            <description>Edit settings for a given volume</description>
+            <input-spec>
+                <parameter name="volume" type="string" required="true">
+                    <description>Volume to set options for, specified as "volume@datastore"</description>
+                </parameter>
+                <parameter name="vmgroup" type="string" required="true">
+                    <description>Name of the vmgroup the volume belongs to</description>
+                </parameter>
+                <parameter name="options" type="string" required="true">
+                    <description>Options (specifically, access) to be set on the volume</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string/>
+            </output-spec>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume set --vmgroup=$val{vmgroup} --volume=$val{volume} --options=$val{options}</execute>
+        </command>
+        <!-- Policy commands -->
+        <command path="vdvs.policy.create">
+            <description>Create a storage policy</description>
+            <input-spec>
+                <parameter name="name" type="string" required="true">
+                    <description>The name of the policy</description>
+                </parameter>
+                <parameter name="content" type="string" required="true">
+                    <description>The VSAN policy string</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string/>
+            </output-spec>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy create --name=$val{name} --content='$val{content}'</execute>
+        </command>
+        <command path="vdvs.policy.rm">
+            <description>'Remove a storage policy'</description>
+            <input-spec>
+                <parameter name="name" type="string" required="true">
+                    <description>The name of the policy</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string/>
+            </output-spec>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy rm --name=$val{name}</execute>
+        </command>
+        <command path="vdvs.policy.ls">
+            <description>List storage policies and volumes using those policies</description>
+            <input-spec></input-spec>
+            <output-spec>
+                <list type="structure">
+                    <structure typeName="vdvs">
+                        <field name="Policy Name">
+                            <string/>
+                        </field>
+                        <field name="Policy Content">
+                            <string/>
+                        </field>
+                        <field name="Active">
+                            <string/>
+                        </field>
+                    </structure>
+                </list>
+            </output-spec>
+            <has-updates value="true"/>
+            <format-parameters>
+                <formatter>table</formatter>
+                <format-parameter name="fields:vdvs">Policy Name,Policy Content,Active</format-parameter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy ls</execute>
+        </command>
+        <command path="vdvs.policy.update">
+            <description>'Update the definition of a storage policy and all VSAN objects using that policy'</description>
+            <input-spec>
+                <parameter name="name" type="string" required="true">
+                    <description>The name of the policy</description>
+                </parameter>
+                <parameter name="content" type="string" required="true">
+                    <description>The VSAN policy string</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string/>
+            </output-spec>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy update --name=$val{name} --content='$val{content}'</execute>
+        </command>
+        <!-- vmgroup commands -->
+        <command path="vdvs.vmgroup.create">
+            <description>Create a new vmgroup</description>
+            <input-spec>
+                <parameter name="name" type="string" required="true">
+                    <description>The name of the vmgroup</description>
+                </parameter>
+                <parameter name="description" type="string" required="false">
+                    <description>The description of the vmgroup</description>
+                </parameter>
+                <parameter name="vm-list" type="string" required="false">
+                    <description>A list of VM names to place in this vmgroup</description>
+                </parameter>
+                <parameter name="default-datastore" type="string" required="true">
+                    <description>Datastore to be used by default for volumes placement</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string />
+            </output-spec>
+            <has-updates value="true"/>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup create --name=$val{name} --default-datastore=$val{default-datastore} $if{description, --description='$val{description}}' $if{vm-list, --vm-list=$val{vm-list}} </execute>
+        </command>
+        <command path="vdvs.vmgroup.update">
+            <description>Update a vmgroup</description>
+            <input-spec>
+                <parameter name="name" type="string" required="true">
+                    <description>The name of the vmgroup</description>
+                </parameter>
+                <parameter name="new-name" type="string" required="false">
+                    <description>The new name of the vmgroup</description>
+                </parameter>
+                <parameter name="description" type="string" required="false">
+                    <description>The new description of the vmgroup</description>
+                </parameter>
+                <parameter name="default-datastore" type="string" required="false">
+                    <description>Datastore to be used by default for volumes placement</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string />
+            </output-spec>
+            <has-updates value="true"/>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml  vmgroup update --name=$val{name} $if{new-name, --new-name=$val{new-name}} $if{description, --description='$val{description}}' $if{vm-list, --vm-list=$val{vm-list}}</execute>
+        </command>
+        <command path="vdvs.vmgroup.rm">
+            <description>Delete a vmgroup</description>
+            <input-spec>
+                <parameter name="name" type="string" required="true">
+                    <description>The name of the vmgroup</description>
+                </parameter>
+                <parameter name="remove-volumes" type="bool" required="false">
+                    <description>BE CAREFUL: Removes this vmgroup volumes when removing a vmgroup</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string />
+            </output-spec>
+            <has-updates value="true"/>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup rm --name=$val{name} $if{remove-volumes, --remove-volumes=$val{remove-volumes}}</execute>
+        </command>
+        <command path="vdvs.vmgroup.ls">
+            <description>List vmgroups and the VMs they are applied to</description>
+            <input-spec></input-spec>
+            <output-spec>
+                <list type="structure">
+                    <structure typeName="vdvs">
+                        <field name="Uuid">
+                            <string/>
+                        </field>
+                        <field name="Name">
+                            <string/>
+                        </field>
+                        <field name="Description">
+                            <string/>
+                        </field>
+                        <field name="Default_datastore">
+                            <string/>
+                        </field>
+                        <field name="VM_list">
+                            <string/>
+                        </field>
+                    </structure>
+                </list>
+            </output-spec>
+            <has-updates value="true"/>
+            <format-parameters>
+                <formatter>table</formatter>
+                <format-parameter name="fields:vdvs">Uuid, Name, Description, Default_datastore, VM_list</format-parameter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup ls</execute>
+        </command>
+        <!-- vmgroup vm commands -->
+        <command path="vdvs.vmgroup.vm.add">
+            <description>Add VM(s)  to a vmgroup</description>
+            <input-spec>
+                <parameter name="name" type="string" required="true">
+                    <description>The name of the vmgroup</description>
+                </parameter>
+                <parameter name="vm-list" type="string" required="true">
+                    <description>A list of VM names to place in this vmgroup</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string />
+            </output-spec>
+            <has-updates value="true"/>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm add --name=$val{name} --vm-list=$val{vm-list}</execute>
+        </command>
+        <command path="vdvs.vmgroup.vm.rm">
+            <description>Remove VM(s) from a vmgroup</description>
+            <input-spec>
+                <parameter name="name" type="string" required="true">
+                    <description>Vmgroup to remove the VM from</description>
+                </parameter>
+                <parameter name="vm-list" type="string" required="true">
+                    <description>A list of VM names to rm from this vmgroup</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string />
+            </output-spec>
+            <has-updates value="true"/>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm rm --name=$val{name} --vm-list=$val{vm-list}</execute>
+        </command>
+        <command path="vdvs.vmgroup.vm.replace">
+            <description>Replace VM(s) for a vmgroup</description>
+            <input-spec>
+                <parameter name="name" type="string" required="true">
+                    <description>Vmgroup to replace the VM for</description>
+                </parameter>
+                <parameter name="vm-list" type="string" required="true">
+                    <description>A list of VM names to replace for this vmgroup</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string />
+            </output-spec>
+            <has-updates value="true"/>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm replace --name=$val{name} --vm-list=$val{vm-list}</execute>
+        </command>
+        <command path="vdvs.vmgroup.vm.ls">
+            <description>list VMs in a vmgroup</description>
+            <input-spec>
+                <parameter name="name" type="string" required="true">
+                    <description>Vmgroup name</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <list type="structure">
+                    <structure typeName="vdvs">
+                        <field name="Uuid">
+                            <string/>
+                        </field>
+                        <field name="Name">
+                            <string/>
+                        </field>
+                    </structure>
+                </list>
+            </output-spec>
+            <has-updates value="true"/>
+            <format-parameters>
+                <formatter>table</formatter>
+                <format-parameter name="fields:vdvs">Uuid, Name</format-parameter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm ls --name=$val{name}</execute>
+        </command>
+        <!-- vmgroup access commands -->
+        <command path="vdvs.vmgroup.access.add">
+            <description>Add a datastore access for a vmgroup</description>
+            <input-spec>
+                <parameter name="name" type="string" required="true">
+                    <description>The name of the vmgroup</description>
+                </parameter>
+                <parameter name="datastore" type="string" required="true">
+                    <description>Datastore name</description>
+                </parameter>
+                <parameter name="allow-create" type="bool" required="false">
+                    <description>Allow create and delete on datastore if set</description>
+                </parameter>
+                <parameter name="volume-maxsize" type="string" required="false">
+                    <description>Maximum size of the volume that can be created</description>
+                </parameter>
+                <parameter name="volume-totalsize" type="string" required="false">
+                    <description>Maximum total size of all volume that can be created on the datastore for this vmgroup</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string/>
+            </output-spec>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access add --name=$val{name} --datastore=$val{datastore} $if{allow-create, --allow-create} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
+        </command>
+        <command path="vdvs.vmgroup.access.set">
+            <description>Modify datastore access for a vmgroup</description>
+            <input-spec>
+                <parameter name="name" type="string" required="true">
+                    <description>The name of the vmgroup</description>
+                </parameter>
+                <parameter name="datastore" type="string" required="true">
+                    <description>Datastore name</description>
+                </parameter>
+                <parameter name="allow-create" type="bool" required="false">
+                    <description>Allow create and delete on datastore if set</description>
+                </parameter>
+                <parameter name="volume-maxsize" type="string" required="false">
+                    <description>Maximum size of the volume that can be created</description>
+                </parameter>
+                <parameter name="volume-totalsize" type="string" required="false">
+                    <description>Maximum total size of all volume that can be created on the datastore for this vmgroup</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string />
+            </output-spec>
+            <has-updates value="true"/>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access set --name=$val{name} --datastore=$val{datastore} $if{allow-create, --allow-create=$val{allow-create}} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
+        </command>
+        <command path="vdvs.vmgroup.access.rm">
+            <description>Modify datastore access for a vmgroup</description>
+            <input-spec>
+                <parameter name="name" type="string" required="true">
+                    <description>The name of the vmgroup</description>
+                </parameter>
+                <parameter name="datastore" type="string" required="true">
+                    <description>Datastore name</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string />
+            </output-spec>
+            <has-updates value="true"/>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access rm --name=$val{name} --datastore=$val{datastore}</execute>
+        </command>
+        <command path="vdvs.vmgroup.access.ls">
+            <description>list access for a vmgroup</description>
+            <input-spec>
+                <parameter name="name" type="string" required="true">
+                    <description>Vmgroup name</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <list type="structure">
+                    <structure typeName="vdvs">
+                        <field name="Datastore">
+                            <string/>
+                        </field>
+                        <field name="Allow_create">
+                            <string/>
+                        </field>
+                        <field name="Max_volume_size">
+                            <string/>
+                        </field>
+                        <field name="Total_size">
+                            <string/>
+                        </field>
+                    </structure>
+                </list>
+            </output-spec>
+            <has-updates value="true"/>
+            <format-parameters>
+                <formatter>table</formatter>
+                <format-parameter name="fields:vdvs">Datastore, Allow_create, Max_volume_size, Total_size</format-parameter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access ls --name=$val{name}</execute>
+        </command>
+        <!-- vmgroup config commands -->
+        <command path="vdvs.status">
+            <description>Status of vdvs service</description>
+            <input-spec>
+                <parameter name="fast" type="flag" required="false">
+                    <description>Skip some of the data collection (port, version)</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string/>
+            </output-spec>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml status $if{fast, --fast}</execute>
+        </command>
+        <command path="vdvs.config.init">
+            <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>
+            <input-spec>
+                <parameter name="datastore" type="string" required="false">
+                    <description>Config file will be placed on a datastore</description>
+                </parameter>
+                <parameter name="local" type="flag" required="false">
+                    <description>Allows local (SingleNode) Init</description>
+                </parameter>
+                <parameter name="force" type="flag" required="false">
+                    <description>Force operation, ignore warnings</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string/>
+            </output-spec>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config init $if{datastore, --datastore=$val{datastore}} $if{local, --local} $if{force, --force}</execute>
+        </command>
+        <command path="vdvs.config.rm">
+            <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>
+            <input-spec>
+                <parameter name="unlink" type="flag" required="false">
+                    <description>Remove the local link to shared DB'</description>
+                </parameter>
+                <parameter name="local" type="flag" required="false">
+                    <description>Remove only local link or local DB</description>
+                </parameter>
+                <parameter name="no-backup" type="flag" required="false">
+                    <description>Do not create DB backup before removing</description>
+                </parameter>
+                <parameter name="confirm" type="flag" required="false">
+                    <description>Explicitly confirm the operation</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string/>
+            </output-spec>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config rm $if{local, --local} $if{unlink, --unlink} $if{no-backup, --no-backup} $if{confirm, --confirm}</execute>
+        </command>
+        <command path="vdvs.config.mv">
+            <description>Relocate config file from its current location [NOT SUPPORTED YET]</description>
+            <input-spec>
+                <parameter name="to" type="string" required="true">
+                    <description>Allows local (SingleNode) Init</description>
+                </parameter>
+                <parameter name="force" type="flag" required="false">
+                    <description>Force operation, ignore warnings</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <string/>
+            </output-spec>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config mv --to=$val{to} $if{force, --force}</execute>
+        </command>
+        <command path="vdvs.config.status">
+            <description>Show the status of the Config DB</description>
+            <input-spec></input-spec>
+            <output-spec>
+                <string/>
+            </output-spec>
+            <format-parameters>
+                <formatter>simple</formatter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config status</execute>
+        </command>
+    </commands>
+</plugin>

--- a/esx_service/cli/vmdkops_admin_test.py
+++ b/esx_service/cli/vmdkops_admin_test.py
@@ -1011,7 +1011,7 @@ class TestTenant(unittest.TestCase):
 
             args = self.parser.parse_args(command.split())
             error_info = vmdkops_admin.tenant_access_set(args)
-            expected_message = "Invalid value {0} for allow-create option".format(val)
+            expected_message = "ERROR:Invalid value {0} for allow-create option".format(val)
             self.assertEqual(expected_message, error_info)
 
         if self.datastore1_name:

--- a/esx_service/utils/cli_xml.py
+++ b/esx_service/utils/cli_xml.py
@@ -1,0 +1,98 @@
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+# A small module for creating vmdkops admin cli command outputs in xml format
+
+import xml.dom.minidom
+
+# top level tag in output requires esxcli namespace declared
+ESXCLI_NS = "http://www.vmware.com/Products/ESX/6.0/esxcli/"
+
+LIST_TAG = "list"
+STRUCT_TAG = "structure"
+STRUCT_NAME = "vdvs"
+STR_TAG = "string"
+FIELD_TAG = "field"
+OUTPUT_TAG = "output"
+
+
+def createDocXML():
+    """
+    Generates the main output object with namespace attribute defined
+    """
+    doc = xml.dom.minidom.Document()
+    output_elem = doc.createElementNS(ESXCLI_NS, OUTPUT_TAG)
+    output_elem.setAttribute("xmlns", ESXCLI_NS)
+    doc.appendChild(output_elem)
+    return doc, output_elem
+
+
+def createFieldList(doc, struct_elem, header, text):
+    """
+    Generates a field tag against header value and appends it to parent
+    struct element
+    """
+    field_elem = doc.createElement(FIELD_TAG)
+    field_elem.setAttribute("name", header)
+    struct_elem.appendChild(field_elem)
+    str_elem = doc.createElement(STR_TAG)
+    field_elem.appendChild(str_elem)
+    str_elem.appendChild(doc.createTextNode(text))
+
+
+def createStruct(doc, list_elem):
+    """
+    Generates a struct tag element and appends it to the list element
+    Returns the struct tag element
+    """
+    struct_elem = doc.createElement(STRUCT_TAG)
+    struct_elem.setAttribute("typeName", STRUCT_NAME)
+    list_elem.appendChild(struct_elem)
+    return struct_elem
+
+
+def create(header, rows):
+    """
+    Generates xml with output tag. It internally contains a list of tags
+    representating each row in rows against the header
+    Returns formatted xml doc object
+    """
+    doc, output_elem = createDocXML()
+    list_elem = doc.createElement(LIST_TAG)
+    list_elem.setAttribute("type", STRUCT_TAG)
+    output_elem.appendChild(list_elem)
+
+    if not rows:
+        struct_elem = createStruct(doc, list_elem)
+        for h_iter in header:
+            createFieldList(doc, struct_elem, h_iter, "")
+
+    else:
+        for r_iter in rows:
+            struct_elem = createStruct(doc, list_elem)
+            for i, cell in enumerate(r_iter):
+                createFieldList(doc, struct_elem, header[i], cell)
+
+    return doc.toprettyxml()
+
+def createMessage(message):
+    """
+    Generates xml with output tag with a string field for representing message
+    Returns formatted xml doc object
+    """
+    doc, output_elem = createDocXML()
+    str_elem = doc.createElement(STR_TAG)
+    output_elem.appendChild(str_elem)
+    str_elem.appendChild(doc.createTextNode(message))
+    return doc.toprettyxml()

--- a/esx_service/vsan_policy.py
+++ b/esx_service/vsan_policy.py
@@ -115,7 +115,6 @@ def update_vsan_objects_with_policy(name, content):
     update_count = 0
     failed_updates = []
     dockvols_path = vsan_info.get_vsan_dockvols_path()
-    print("This operation may take a while. Please be patient.")
     for v in list_volumes_and_policies():
         if v['policy'] == name:
             volume_name = v['volume']
@@ -204,12 +203,12 @@ def delete(name):
 
     vmdk = policy_in_use(path, name)
     if vmdk:
-        return 'Error: Cannot remove. Policy is in use by {0}'.format(vmdk)
+        return 'Cannot remove. Policy is in use by {0}'.format(vmdk)
     try:
         os.remove(policy_path(name))
     except:
         logging.exception("Failed to remove %s policy file", name)
-        return 'Error: {0} does not exist'.format(name)
+        return 'Policy {0} does not exist'.format(name)
 
     return None
 

--- a/misc/scripts/deploy-tools.sh
+++ b/misc/scripts/deploy-tools.sh
@@ -209,7 +209,7 @@ function deployESXInstall {
         exit 2
     fi
 
-    # restart hostd so that esxcli extension file is read
+    # Restart hostd so that esxcli extension file is read
     $SSH $TARGET $HOSTD restart
 }
 

--- a/misc/scripts/deploy-tools.sh
+++ b/misc/scripts/deploy-tools.sh
@@ -44,6 +44,7 @@ WIN_TEMP_DIR=C:\\Users\\root\\AppData\\Local\\Temp
 WIN_PLUGIN_SRC_DIR=C:\\Users\\root\\go\\src\\github.com\\vmware\\docker-volume-vsphere
 WIN_PLUGIN_BIN_ZIP_LOC=$WIN_PLUGIN_SRC_DIR\\build\\windows\\docker-volume-vsphere.zip
 WIN_BUILD_DIR=build/windows/
+HOSTD=/etc/init.d/hostd
 
 # VM Functions
 
@@ -210,6 +211,8 @@ function deployESXInstall {
 }
 
 function deployESXPost {
+    # restart hostd so that esxcli extension file is read
+    $SSH $TARGET $HOSTD restart
     $SSH $TARGET $VMDK_OPSD status
     if [ $? -ne 0 ]
     then

--- a/misc/scripts/deploy-tools.sh
+++ b/misc/scripts/deploy-tools.sh
@@ -208,11 +208,12 @@ function deployESXInstall {
         log "deployESXInstall: Installation hit an error on $TARGET"
         exit 2
     fi
+
+    # restart hostd so that esxcli extension file is read
+    $SSH $TARGET $HOSTD restart
 }
 
 function deployESXPost {
-    # restart hostd so that esxcli extension file is read
-    $SSH $TARGET $HOSTD restart
     $SSH $TARGET $VMDK_OPSD status
     if [ $? -ne 0 ]
     then

--- a/tests/e2e/defaultvmgroup_test.go
+++ b/tests/e2e/defaultvmgroup_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	vgErrorMsg = "This feature is not supported for vmgroup _DEFAULT."
+	vgErrorMsg = "ERROR:This feature is not supported for vmgroup _DEFAULT."
 )
 
 type DefaultVMGroupTestSuite struct {

--- a/tests/e2e/vsan_test.go
+++ b/tests/e2e/vsan_test.go
@@ -177,7 +177,7 @@ func (s *VsanTestSuite) TestDeleteVsanPolicyAlreadyInUse(c *C) {
 
 	out, err = admincli.RemovePolicy(s.config.EsxHost, adminclicon.PolicyName)
 	log.Printf("Remove vsanPolicy \"%s\" returns with %s", adminclicon.PolicyName, out)
-	c.Assert(out, Matches, "Error: Cannot remove.*", Commentf("vsanPolicy is still used by volumes and cannot be removed"))
+	c.Assert(out, Matches, "ERROR:Cannot remove.*", Commentf("vsanPolicy is still used by volumes and cannot be removed"))
 
 	misc.LogTestEnd(c.TestName())
 


### PR DESCRIPTION
## Description

This PR introduces xml based extension to integrate vmdkops admin cli commands with esxcli.
The xml file introduces vdvs namespace and furthermore nested namespace parallel to admin cli commandset. The experience is exactly the same (see manual test results below).
Essentially, each command fired through esxcli is mapped to a vmdkops_admin command. Input parameters and output formatting is specified with this.

Esxcli requires the actual command to generate output in xml format, hence the introduction of additional flag to specify output-format. Default is still plaintext.

The xml based extension is copied to appropriate location (required by esxcli) during the deploy-esx target. After VIB installation, admin can directly start using vdvs commands through esxcli

Note: currently I have used "vdvs". It's small and sweet but needs to be changed. Please suggest a better name.

## Testing
As of now, I have done manual testing of all the commands.
I plan to do automated tests and documentation update as separate PR.
```


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs volume ls
Volume      Datastore     VMGroup   Capacity  Used  Filesystem  Policy  Disk Format  Attached-to  Access      Attach-as               Created By    Created Date
----------  ------------  --------  --------  ----  ----------  ------  -----------  -----------  ----------  ----------------------  ------------  ------------------------
test_vol_1  sharedVmfs-0  _DEFAULT  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  ubuntu-VM0.0  Thu Aug 10 07:25:08 2017
test_vol_2  sharedVmfs-0  _DEFAULT  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  ubuntu-VM0.0  Thu Aug 10 07:25:12 2017

[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs volume set --volume=test_vol_1@sharedVmfs-0 --vmgroup=_DEFAULT --options="access=read-only"
Successfully updated settings for test_vol_1@sharedVmfs-0

[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs policy create --name some-policy --content '(("proportionalCapacity" i0)("hostFailuresToTolerate" i0))'
Successfully created policy: some-policy

[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs policy ls
Policy Name  Policy Content                                              Active
-----------  ----------------------------------------------------------  ------
some-policy  (("proportionalCapacity" i0)("hostFailuresToTolerate" i0))  Unused


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs policy update --name some-policy --content '(("proportionalCapacity" i1))'
Successfully updated policy some-policy

[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs policy rm --name=some-policy
Successfully removed policy: some-policy

[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs vmgroup ls
Uuid                                  Name      Description                  Default_datastore  VM_list
------------------------------------  --------  ---------------------------  -----------------  -------
11111111-1111-1111-1111-111111111111  _DEFAULT  This is the default vmgroup  _VM_DS

[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs vmgroup create --name=vmgroup1 --default-datastore=vsandatastore --vm-list=ubuntu-VM1.0
vmgroup 'vmgroup1' is created. Do not forget to run 'vmgroup vm add' to add vm to vmgroup.

[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs vmgroup update --name=vmgroup1 --description="New description of vmgroup1" --new-name=new-vmgroup1 --default-datastore=sharedVmfs-1
vmgroup modify succeeded

[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs vmgroup vm add --name=new-vmgroup1 --vm-list=ubuntu-VM0.0
vmgroup vm add succeeded

[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs vmgroup vm ls --name=new-vmgroup1
Uuid                                  Name
------------------------------------  ------------
564dfd1e-5a41-7007-6a8c-2936c51542c2  ubuntu-VM1.0
564d93b9-6908-6888-0514-fa7571b2e095  ubuntu-VM0.0

[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs vmgroup vm rm --name=new-vmgroup1 --vm-list=ubuntu-VM0.0
vmgroup vm rm succeeded


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs vmgroup vm replace --name=new-vmgroup1 --vm-list=ubuntu-VM1.0
VM 'ubuntu-VM1.0' has already been associated with tenant 'new-vmgroup1', can't add it
[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs vmgroup vm replace --name=new-vmgroup1 --vm-list=ubuntu-VM0.0
vmgroup vm replace succeeded



[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs vmgroup access ls --name new-vmgroup1
Datastore      Allow_create  Max_volume_size  Total_size
-------------  ------------  ---------------  ----------
vsandatastore  True          Unset            Unset

[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs vmgroup access add --name=new-vmgroup1 --datastore=sharedVmfs-0  --volume-maxsize=500MB --volume-totalsize=1GB
vmgroup access add succeeded

[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs vmgroup access rm --name=new-vmgroup1 --datastore=sharedVmfs-0
vmgroup access rm succeeded

[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs vmgroup access set --name=new-vmgroup1 --datastore=vsandatastore  --allow-create=True  --volume-maxsize=1000MB  --volume-totalsize=2GB
vmgroup access set succeeded


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs config status
DB_Mode: SingleNode (local DB exists)
DB_SharedLocation: N/A
DB_LocalPath: /etc/vmware/vmdkops/auth-db

[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs config rm --local --confirm
Moved /etc/vmware/vmdkops/auth-db to backup file /etc/vmware/vmdkops/auth-db.bak_Thu_Aug_10_08:05:20_2017


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs config init --local
Warning: this feature is EXPERIMENTAL
Creating new DB at /etc/vmware/vmdkops/auth-db
Warning: Local configuration will not survive ESXi reboot. See KB2043564 for details


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs config init --datastore=vsandatastore
Found Config DB on other datastores. . Add '--force' flag to force the request execution. Additional information: [('local.0-0', '/vmfs/volumes/local.0-0/dockvols/vmdkops_config.db')]
[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs config init --datastore=vsandatastore --force
Warning: this feature is EXPERIMENTAL
Creating new DB at /vmfs/volumes/vsandatastore/dockvols/vmdkops_config.db
Creating a symlink to /vmfs/volumes/vsandatastore/dockvols/vmdkops_config.db at /etc/vmware/vmdkops/auth-db
Updating /etc/rc.local.d/local.sh

[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli vdvs config rm --unlink --confirm
Removed link /etc/vmware/vmdkops/auth-db
Updating /etc/rc.local.d/local.sh
```


## The help sections of the commands look like below:
```
root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs —help
Usage: esxcli storage vdvs {cmd} [cmd options]

Available Namespaces:
  vmgroup               Administer and monitor volume access control
  config                Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]
  policy                Configure and display storage policy information
  volume                Manage vDVS volumes

Available Commands:
  status                Status of vdvs service


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs volume —help
Usage: esxcli storage vdvs volume {cmd} [cmd options]

Available Commands:
  ls                    List volumes
  set                   Edit settings for a given volume


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs volume ls --help
Usage: esxcli storage vdvs volume ls [cmd options]

Description:
  ls                    List volumes

Cmd options:
  --vmgroup=<str>       Displays volumes for a given vmgroup


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs volume set --help
Usage: esxcli storage vdvs volume set [cmd options]

Description:
  set                   Edit settings for a given volume

Cmd options:
  --options=<str>       Options (specifically, access) to be set on the volume (required)
  --vmgroup=<str>       Name of the vmgroup the volume belongs to (required)
  --volume=<str>        Volume to set options for, specified as "volume@datastore" (required)


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs volume  --help
Usage: esxcli storage vdvs volume {cmd} [cmd options]

Available Commands:
  ls                    List volumes
  set                   Edit settings for a given volume


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs policy  --help
Usage: esxcli storage vdvs policy {cmd} [cmd options]

Available Commands:
  create                Create a storage policy
  ls                    List storage policies and volumes using those policies
  rm                    Remove a storage policy
  update                Update the definition of a storage policy and all VSAN objects using that policy


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs policy ls --help
Usage: esxcli storage vdvs policy ls [cmd options]

Description:
  ls                    List storage policies and volumes using those policies

Cmd options:


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs policy create --help
Usage: esxcli storage vdvs policy create [cmd options]

Description:
  create                Create a storage policy

Cmd options:
  --content=<str>       The VSAN policy string (required)
  --name=<str>          The name of the policy (required)


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs policy rm --help
Usage: esxcli storage vdvs policy rm [cmd options]

Description:
  rm                    Remove a storage policy

Cmd options:
  --name=<str>          The name of the policy (required)


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs config init --help
Usage: esxcli storage vdvs config init [cmd options]

Description:
  init                  Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]

Cmd options:
  --datastore=<str>     Config file will be placed on a datastore
  --force               Force operation, ignore warnings
  --local               Allows local (SingleNode) Init


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs config rm --help
Usage: esxcli storage vdvs config rm [cmd options]

Description:
  rm                    Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]

Cmd options:
  --confirm             Explicitly confirm the operation
  --local               Remove only local link or local DB
  --no-backup           Do not create DB backup before removing
  --unlink              Remove the local link to shared DB


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs config mv --help
Usage: esxcli storage vdvs config mv [cmd options]

Description:
  mv                    Relocate config file from its current location [NOT SUPPORTED YET]

Cmd options:
  --force               Force operation, ignore warnings
  --to=<str>            Allows local (SingleNode) Init (required)


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs config status --help
Usage: esxcli storage vdvs config status [cmd options]

Description:
  status                Show the status of the Config DB

Cmd options:


root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs vmgroup --help
Usage: esxcli storage vdvs vmgroup {cmd} [cmd options]

Available Namespaces:
  access                Add or remove Datastore access and quotas for a vmgroup
  vm                    Add, removes, replaces and lists VMs in a vmgroup

Available Commands:
  create                Create a new vmgroup
  ls                    List vmgroups and the VMs they are applied to
  rm                    Delete a vmgroup
  update                Update a vmgroup


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs vmgroup create --help
Usage: esxcli storage vdvs vmgroup create [cmd options]

Description:
  create                Create a new vmgroup

Cmd options:
  --default-datastore=<str>
                        Datastore to be used by default for volumes placement (required)
  --description=<str>   The description of the vmgroup
  --name=<str>          The name of the vmgroup (required)
  --vm-list=<str>       A list of VM names to place in this vmgroup


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs vmgroup ls --help
Usage: esxcli storage vdvs vmgroup ls [cmd options]

Description:
  ls                    List vmgroups and the VMs they are applied to

Cmd options:


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs vmgroup rm --help
Usage: esxcli storage vdvs vmgroup rm [cmd options]

Description:
  rm                    Delete a vmgroup

Cmd options:
  --name=<str>          The name of the vmgroup (required)
  --remove-volumes      BE CAREFUL: Removes this vmgroup volumes when removing a vmgroup


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs vmgroup update --help
Usage: esxcli storage vdvs vmgroup update [cmd options]

Description:
  update                Update a vmgroup

Cmd options:
  --default-datastore=<str>
                        Datastore to be used by default for volumes placement
  --description=<str>   The new description of the vmgroup
  --name=<str>          The name of the vmgroup (required)
  --new-name=<str>      The new name of the vmgroup


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs vmgroup vm --help
Usage: esxcli storage vdvs vmgroup vm {cmd} [cmd options]

Available Commands:
  add                   Add VM(s) to a vmgroup
  ls                    list VMs in a vmgroup
  replace               Replace VM(s) for a vmgroup
  rm                    Remove VM(s) from a vmgroup


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs vmgroup vm add --help
Usage: esxcli storage vdvs vmgroup vm add [cmd options]

Description:
  add                   Add VM(s) to a vmgroup

Cmd options:
  --name=<str>          The name of the vmgroup (required)
  --vm-list=<str>       A list of VM names to place in this vmgroup (required)


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs vmgroup vm ls --help
Usage: esxcli storage vdvs vmgroup vm ls [cmd options]

Description:
  ls                    list VMs in a vmgroup

Cmd options:
  --name=<str>          Vmgroup name (required)


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs vmgroup vm rm --help
Usage: esxcli storage vdvs vmgroup vm rm [cmd options]

Description:
  rm                    Remove VM(s) from a vmgroup

Cmd options:
  --name=<str>          Vmgroup to remove the VM from (required)
  --vm-list=<str>       A list of VM names to rm from this vmgroup (required)


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs vmgroup vm replace --help
Usage: esxcli storage vdvs vmgroup vm replace [cmd options]

Description:
  replace               Replace VM(s) for a vmgroup

Cmd options:
  --name=<str>          Vmgroup to replace the VM for (required)
  --vm-list=<str>       A list of VM names to replace for this vmgroup (required)


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs vmgroup access --help
Usage: esxcli storage vdvs vmgroup access {cmd} [cmd options]

Available Commands:
  add                   Add a datastore access for a vmgroup
  ls                    List access for a vmgroup
  rm                    Remove datastore access for a vmgroup
  set                   Modify datastore access for a vmgroup


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs vmgroup access add --help
Usage: esxcli storage vdvs vmgroup access add [cmd options]

Description:
  add                   Add a datastore access for a vmgroup

Cmd options:
  --allow-create        Allow create and delete on datastore if set
  --datastore=<str>     Datastore name (required)
  --name=<str>          The name of the vmgroup (required)
  --volume-maxsize=<str>
                        Maximum size of the volume that can be created
  --volume-totalsize=<str>
                        Maximum total size of all volume that can be created on the datastore for this vmgroup


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs vmgroup access ls --help
Usage: esxcli storage vdvs vmgroup access ls [cmd options]

Description:
  ls                    List access for a vmgroup

Cmd options:
  --name=<str>          Vmgroup name (required)


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs vmgroup access set --help
Usage: esxcli storage vdvs vmgroup access set [cmd options]

Description:
  set                   Modify datastore access for a vmgroup

Cmd options:
  --allow-create        Allow create and delete on datastore if set
  --datastore=<str>     Datastore name (required)
  --name=<str>          The name of the vmgroup (required)
  --volume-maxsize=<str>
                        Maximum size of the volume that can be created
  --volume-totalsize=<str>
                        Maximum total size of all volume that can be created on the datastore for this vmgroup


[root@sc2-rdops-vm03-dhcp-118-213:~] esxcli storage vdvs vmgroup access rm --help
Usage: esxcli storage vdvs vmgroup access rm [cmd options]

Description:
  rm                    Remove datastore access for a vmgroup

Cmd options:
  --datastore=<str>     Datastore name (required)
  --name=<str>          The name of the vmgroup (required)
```