### PR TITLE
Fixes ls failure in Windows volumes

### DIFF
--- a/client_plugin/drivers/utils/pluginDriver.go
+++ b/client_plugin/drivers/utils/pluginDriver.go
@@ -19,8 +19,10 @@ package utils
 //
 
 import (
-	"github.com/vmware/docker-volume-vsphere/client_plugin/utils/refcount"
+	"os"
 	"path/filepath"
+
+	"github.com/vmware/docker-volume-vsphere/client_plugin/utils/refcount"
 )
 
 // PluginDriver - helper struct to hold common utilities for driver interface
@@ -32,7 +34,7 @@ type PluginDriver struct {
 
 // GetMountPoint returns the mount point based on MountRoot and volume name
 func (u *PluginDriver) GetMountPoint(volName string) string {
-	return filepath.Join(u.MountRoot, volName)
+	return filepath.Join(u.MountRoot, volName) + string(os.PathSeparator)
 }
 
 // In following three operations on refcount, if refcount


### PR DESCRIPTION
Mounting disks at a `MountPoint` without a trailing slash causes weird failures on Windows. For example, after creating a volume named `vol` via the vDVS plugin, and running a container with `docker run -it -v vol:C:/mp microsoft/nanoserver powershell`, operations like `ls` inside `C:/mp` on the container fail (as shown below). This PR adds the necessary trailing slash to the response of `/VolumeDriver.Path` and `/VolumeDriver.Get` APIs.

![ls failure](https://user-images.githubusercontent.com/1722758/29194108-0cd33bdc-7ddd-11e7-9e53-92f0ed49a808.png)

Testing was done manually.