### PR TITLE
Server side Mounting

### DIFF
--- a/plugin_dockerbuild/Dockerfile.shared
+++ b/plugin_dockerbuild/Dockerfile.shared
@@ -17,5 +17,9 @@ mv etcd-v3.2.3-linux-amd64/etcd* /bin/ && \
 apk del --purge tar openssl && \
 rm -Rf etcd-v3.2.3-linux-amd64* /var/cache/apk/*
 RUN mkdir -p /mnt/vshared
+RUN mkdir -p /usr/lib/vmware
+RUN apk add --update ca-certificates openssl tar && \
+wget https://storage.googleapis.com/kubernetes-anywhere-for-vsphere-cna-storage/samba.tar && \
+cp samba.tar /usr/lib/vmware
 COPY vsphere-shared /usr/bin
 CMD ["/usr/bin/vsphere-shared"]


### PR DESCRIPTION
**About the PR**
Automatically loads Samba container into Docker on install
Starts Samba server when volume global refcount goes from 0 -> 1
Waits till Samba container comes up
Updates volume metadata accordingly

**Testing done**
Create volumes from manager and worker nodes
Use Etcdctl to up the global refcount(client mounting code being written)
Watch the file server container come up as part of Samba service
Repeat for other volumes
Delete Samba service manually
Bring volume Refcount, Status to 0, Ready using etcdctl
Delete the volumes

**Logs**

```
root@ubuntu16B ~: docker volume ls
DRIVER              VOLUME NAME
local               428d9e505ee6154dbf2ea85ce2f8236b683b59edd1b63d55f6c66e55472bf05a
vsphere:latest      InternalVolcat1@datastore1
vsphere:latest      InternalVolvol1@datastore1
kahuna:latest       cat1
kahuna:latest       vol1
root@ubuntu16B ~: 
root@ubuntu16B ~: docker service ls
ID                  NAME                MODE                REPLICAS            IMAGE                  PORTS
o860evvlzpxy        vol1fileServer      replicated          1/1                 dperson/samba:latest   *:0->445/tcp
suwue94lgeeo        cat1fileServer      replicated          1/1                 dperson/samba:latest   *:0->445/tcp
root@ubuntu16B ~: 
root@ubuntu16B ~: docker volume inspect cat1
[
    {
        "Driver": "kahuna:latest",
        "Labels": {},
        "Mountpoint": "/mnt/vmdk/cat1",
        "Name": "cat1",
        "Options": {},
        "Scope": "global",
        "Status": {
            "Clients": null,
            "File server Port": 30001,
            "Global Refcount": 1,
            "Service name": "cat1fileServer",
            "Volume Status": "Mounted"
        }
    }
]
root@ubuntu16B ~: 
```

```
2017-08-10 17:57:31.634402577 -0700 PDT [INFO] Attempting to create internal volume for cat1
2017-08-10 17:57:32.364146854 -0700 PDT [INFO] Attempting to update volume state to ready for volume: cat1
2017-08-10 17:57:32.379628157 -0700 PDT [INFO] Successfully created volume: cat1
2017-08-10 17:57:41.168559747 -0700 PDT [INFO] Watcher on global refcount returns event type=PUT
2017-08-10 17:59:20.328577314 -0700 PDT [INFO] VolumeDriver Get: cat1
2017-08-10 17:59:36.50982949 -0700 PDT [INFO] Watcher on global refcount returns event type=PUT
2017-08-10 17:59:37.510754501 -0700 PDT [INFO] Attempting to change volume state to Mounting
2017-08-10 17:59:44.050209024 -0700 PDT [INFO] Checking status of file server container...
2017-08-10 17:59:44.05406241 -0700 PDT [INFO] Updating port and file service name for cat1
```