### PR TITLE
vShared plugin: Address timeout error due to docker load image

### DIFF
--- a/client_plugin/drivers/shared/dockerops/dockerops.go
+++ b/client_plugin/drivers/shared/dockerops/dockerops.go
@@ -354,11 +354,11 @@ func (d *DockerOps) StopSMBServer(volName string) (int, string, bool) {
 
 // loadFileServerImage - Load the file server image present
 // in the plugin to Docker images
-func (d *DockerOps) LoadFileServerImage() bool {
+func (d *DockerOps) LoadFileServerImage() {
 	file, err := os.Open(fileServerPath)
 	if err != nil {
 		log.Errorf("Failed to open file server tarball")
-		return false
+		return
 	}
 	// ImageLoad takes the tarball as an open file, and a bool
 	// value for silently loading the image
@@ -367,12 +367,12 @@ func (d *DockerOps) LoadFileServerImage() bool {
 		true)
 	if err != nil {
 		log.Errorf("Failed to load file server image: %v", err)
-		return false
+		return
 	}
 	err = resp.Body.Close()
 	if err != nil {
 		log.Errorf("Failed to close the file server tarball: %v", err)
-		return false
+		return
 	}
-	return true
+	return
 }

--- a/client_plugin/drivers/shared/shared_driver.go
+++ b/client_plugin/drivers/shared/shared_driver.go
@@ -124,10 +124,8 @@ func NewVolumeDriver(cfg config.Config, mountDir string) *VolumeDriver {
 	}
 
 	// Load the file server image
-	if d.dockerOps.LoadFileServerImage() == false {
-		return nil
-	}
-	log.Infof("Loaded file server image")
+	go d.dockerOps.LoadFileServerImage()
+	log.Infof("Started loading file server image")
 
 	// initialize built-in etcd cluster
 	etcdKVS := etcdops.NewKvStore(d.dockerOps)

--- a/plugin_dockerbuild/Dockerfile.shared
+++ b/plugin_dockerbuild/Dockerfile.shared
@@ -20,6 +20,6 @@ RUN mkdir -p /mnt/vshared
 RUN mkdir -p /usr/lib/vmware
 RUN apk add --update ca-certificates openssl tar && \
 wget https://storage.googleapis.com/kubernetes-anywhere-for-vsphere-cna-storage/samba.tar && \
-cp samba.tar /usr/lib/vmware
+mv samba.tar /usr/lib/vmware
 COPY vsphere-shared /usr/bin
 CMD ["/usr/bin/vsphere-shared"]


### PR DESCRIPTION
The loading of SMB server image can take more time than expected.
And a delay in the initialization of the plugin can cause error:
"shared.sock: connect: no such file or directory"

This fix changes the load image function into a separate thread.
Thus initialization won't be blocked on image loading.