### PR TITLE
vShared: remove orphan services and internal volumes

### DIFF
--- a/client_plugin/drivers/shared/dockerops/dockerops.go
+++ b/client_plugin/drivers/shared/dockerops/dockerops.go
@@ -358,7 +358,7 @@ func (d *DockerOps) isFileServiceRunning(servID string, volName string) (uint32,
 //      error:   error returned when it can not can service ID and port number
 func (d *DockerOps) getServiceIDAndPort(volName string) (string, uint32, error) {
 	// Grep the samba service running using service name
-	serviceName := volName + serviceNamePostfix
+	serviceName := serviceNamePrefix + volName
 	serviceFilters := filters.NewArgs()
 	serviceFilters.Add("name", serviceName)
 	services, err := d.Dockerd.ServiceList(context.Background(),

--- a/client_plugin/drivers/shared/dockerops/dockerops.go
+++ b/client_plugin/drivers/shared/dockerops/dockerops.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -42,7 +43,7 @@ const (
 	// dockerUSocket: Unix socket on which Docker engine is listening
 	dockerUSocket = "unix:///var/run/docker.sock"
 	// Postfix added to names of Samba services for volumes
-	serviceNamePostfix = "fileServer"
+	serviceNamePrefix = "vSharedServer_"
 	// Path where the file server image resides in plugin
 	fileServerPath = "/usr/lib/vmware/samba.tar"
 	// Driver for the network which Samba services will use
@@ -62,6 +63,8 @@ const (
 	// Time between successive checks for Samba service
 	// status to see if service container was launched
 	checkDuration = 5 * time.Second
+	// Time between successive checks for deleting a volume
+	checkSleepDuration = time.Second
 	// Timeout to mark Samba service launch as unsuccessful
 	sambaRequestTimeout = 30 * time.Second
 	// Prefix for internal volume names
@@ -193,7 +196,7 @@ func (d *DockerOps) StartSMBServer(volName string) (int, string, bool) {
 	var options dockerTypes.ServiceCreateOptions
 
 	// Name of the service
-	service.Name = volName + serviceNamePostfix
+	service.Name = serviceNamePrefix + volName
 	// The Docker image to run in this service
 	service.TaskTemplate.ContainerSpec.Image = sambaImageName
 
@@ -279,7 +282,7 @@ func (d *DockerOps) StartSMBServer(volName string) (int, string, bool) {
 			log.Infof("Checking status of file server container...")
 			port, isRunning := d.isFileServiceRunning(resp.ID, volName)
 			if isRunning {
-				return int(port), volName + serviceNamePostfix, isRunning
+				return int(port), serviceNamePrefix + volName, isRunning
 			}
 		case <-timer.C:
 			log.Warningf("Timeout reached while waiting for file server container for volume %s",
@@ -379,6 +382,84 @@ func (d *DockerOps) getServiceIDAndPort(volName string) (string, uint32, error) 
 	}
 
 	return services[0].ID, port, nil
+}
+
+// ListVolumesFromServices - List shared volumes according to current docker services
+func (d *DockerOps) ListVolumesFromServices() ([]string, error) {
+	var volumes []string
+	// Get all the samba service for vShared plugin
+	filter := filters.NewArgs()
+	filter.Add("name", serviceNamePrefix)
+	services, err := d.Dockerd.ServiceList(context.Background(),
+		dockerTypes.ServiceListOptions{Filter: filter})
+	if err != nil {
+		log.Errorf("Failed to get a list of docker services. Error: %v", err)
+		return volumes, err
+	}
+
+	for _, service := range services {
+		volumes = append(volumes,
+			strings.TrimPrefix(service.Spec.Name, serviceNamePrefix))
+	}
+
+	return volumes, nil
+}
+
+// ListVolumesFromInternalVol - List shared volumes according to current internal volumes
+func (d *DockerOps) ListVolumesFromInternalVol() ([]string, error) {
+	var volumes []string
+	filter := filters.NewArgs()
+	filter.Add("name", internalVolumePrefix)
+	volumeResponse, err := d.Dockerd.VolumeList(context.Background(),
+		filter)
+	if err != nil {
+		log.Errorf("Failed to get a list of internal volumes. Error: %v", err)
+		return volumes, err
+	}
+
+	for _, volume := range volumeResponse.Volumes {
+		volumes = append(volumes,
+			strings.TrimPrefix(volume.Name, internalVolumePrefix))
+	}
+
+	return volumes, nil
+}
+
+// DeleteVolume - delete the internal volume
+func (d *DockerOps) DeleteInternalVolume(volName string) {
+	internalVolname := internalVolumePrefix + volName
+	ticker := time.NewTicker(checkSleepDuration)
+	defer ticker.Stop()
+	// timeout set to sambaRequestTimeout because the internal volume maybe
+	// still in use due to stop of SMB server in progress
+	timer := time.NewTimer(sambaRequestTimeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			err := d.VolumeRemove(internalVolname)
+			if err != nil {
+				msg := fmt.Sprintf("Failed to remove internal volume for volume %s. Reason: %v.",
+					volName, err)
+
+				err = d.VolumeInspect(internalVolname)
+				if err != nil {
+					msg += fmt.Sprintf(" Failed to inspect internal volume. Error: %v.", err)
+					log.Warningf(msg)
+					return
+				}
+				// volume exists, continue waiting and retry removing
+				msg += fmt.Sprintf(" Internal volume still in use. Wait and retry before timeout.")
+				log.Warningf(msg)
+			}
+		case <-timer.C:
+			// The deletion of internal volume will be handled by garbage collector
+			log.Warningf("Timeout to remove internal volume for volume %s.",
+				volName)
+			return
+		}
+	}
 }
 
 // StopSMBServer - Stop SMB server

--- a/client_plugin/drivers/shared/dockerops/dockerops.go
+++ b/client_plugin/drivers/shared/dockerops/dockerops.go
@@ -43,7 +43,7 @@ const (
 	// dockerUSocket: Unix socket on which Docker engine is listening
 	dockerUSocket = "unix:///var/run/docker.sock"
 	// Postfix added to names of Samba services for volumes
-	serviceNamePrefix = "vSharedServer_"
+	serviceNamePrefix = "vSharedServer"
 	// Path where the file server image resides in plugin
 	fileServerPath = "/usr/lib/vmware/samba.tar"
 	// Driver for the network which Samba services will use

--- a/client_plugin/drivers/shared/kvstore/etcdops/etcdops.go
+++ b/client_plugin/drivers/shared/kvstore/etcdops/etcdops.go
@@ -45,6 +45,7 @@ import (
    requestTimeout:             After how long should an etcd request timeout
    checkSleepDuration:         How long to wait in any busy waiting situation
                                before checking again
+   gcTicker:                   ticker for garbage collector to run a collection
    etcdClientCreateError:      Error indicating failure to create etcd client
    etcdSingleRef:              if global refcount 0 -> 1, start SMB server
    etcdNoRef:                  if global refcount 1 -> 0, shut down SMB server
@@ -59,6 +60,7 @@ const (
 	etcdClusterStateExisting = "existing"
 	requestTimeout           = 5 * time.Second
 	checkSleepDuration       = time.Second
+	gcTicker                 = 5 * time.Second
 	etcdClientCreateError    = "Failed to create etcd client"
 	etcdSingleRef            = "1"
 	etcdNoRef                = "0"
@@ -312,6 +314,7 @@ func (e *EtcdKVS) checkLocalEtcd() error {
 				).Warningf("Failed to get ETCD client, retry before timeout ")
 			} else {
 				go e.etcdWatcher(cli)
+				go e.serviceAndVolumeGC(cli)
 				return nil
 			}
 		case <-timer.C:
@@ -328,6 +331,63 @@ func (e *EtcdKVS) etcdWatcher(cli *etcdClient.Client) {
 	for wresp := range watchCh {
 		for _, ev := range wresp.Events {
 			e.etcdEventHandler(ev)
+		}
+	}
+}
+
+// serviceAndVolumeGC: garbage collector for orphan services or volumes
+func (e *EtcdKVS) serviceAndVolumeGC(cli *etcdClient.Client) {
+	ticker := time.NewTicker(gcTicker)
+	quit := make(chan struct{})
+
+	for {
+		select {
+		case <-ticker.C:
+			// find all the vShared volume services
+			volumesToVerify, err := e.dockerOps.ListVolumesFromServices()
+			if err != nil {
+				log.Warningf("Failed to get vShared volumes according to docker services")
+			} else {
+				e.cleanOrphanServiceAndVolume(volumesToVerify, true)
+			}
+
+			// find all the internal volumes for vShared volume
+			volumesToVerify, err = e.dockerOps.ListVolumesFromInternalVol()
+			if err != nil {
+				log.Warningf("Failed to get internal volumes from docker")
+			} else {
+				e.cleanOrphanServiceAndVolume(volumesToVerify, false)
+			}
+		case <-quit:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+// trimVolName: trim the volume name if there is special split characters existing in the name
+func trimVolName(volName string) string {
+	// Currently we only take @ as the split character
+	// TODO: need to take care of volumes with same name but on different datastores
+	s := strings.Split(volName, "@")
+	return s[0]
+}
+
+// cleanOrphanServiceAndVolume: stop orphan services and delete orphan internal volumes
+func (e *EtcdKVS) cleanOrphanServiceAndVolume(volumesToVerify []string, stopService bool) {
+	volStates := e.kvMapFromPrefix(string(kvstore.VolPrefixState))
+	for _, volName := range volumesToVerify {
+		volName = trimVolName(volName)
+		state, found := volStates[string(kvstore.VolPrefixState)+volName]
+		if !found ||
+			state == string(kvstore.VolStateDeleting) ||
+			state == string(kvstore.VolStateError) {
+			if stopService {
+				log.Warningf("The service for vShared volume %s needs to be shutdown.", volName)
+				e.dockerOps.StopSMBServer(volName)
+			}
+			log.Warningf("The internal volume of vShared volume %s needs to be removed.", volName)
+			e.dockerOps.DeleteInternalVolume(volName)
 		}
 	}
 }
@@ -646,6 +706,32 @@ func (e *EtcdKVS) List(prefix string) ([]string, error) {
 	}
 
 	return keys, nil
+}
+
+// kvMapFromPrefix -  Create key-value pairs according to a given prefix
+func (e *EtcdKVS) kvMapFromPrefix(prefix string) map[string]string {
+	m := make(map[string]string)
+
+	client := e.createEtcdClient()
+	if client == nil {
+		log.Errorf(etcdClientCreateError)
+		return nil
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	resp, err := client.Get(ctx, prefix, etcdClient.WithPrefix(),
+		etcdClient.WithSort(etcdClient.SortByKey, etcdClient.SortDescend))
+	cancel()
+	if err != nil {
+		return nil
+	}
+
+	for _, ev := range resp.Kvs {
+		m[string(ev.Key)] = string(ev.Value)
+	}
+
+	return m
 }
 
 // WriteMetaData - Update or Create metadata in KV store

--- a/client_plugin/drivers/shared/kvstore/etcdops/etcdops.go
+++ b/client_plugin/drivers/shared/kvstore/etcdops/etcdops.go
@@ -60,7 +60,7 @@ const (
 	etcdClusterStateExisting = "existing"
 	requestTimeout           = 5 * time.Second
 	checkSleepDuration       = time.Second
-	gcTicker                 = 5 * time.Second
+	gcTicker                 = 30 * time.Second
 	etcdClientCreateError    = "Failed to create etcd client"
 	etcdSingleRef            = "1"
 	etcdNoRef                = "0"

--- a/client_plugin/drivers/shared/kvstore/etcdops/etcdops.go
+++ b/client_plugin/drivers/shared/kvstore/etcdops/etcdops.go
@@ -380,12 +380,12 @@ func (e *EtcdKVS) cleanOrphanServiceAndVolume(volumesToVerify []string, stopServ
 		volName = trimVolName(volName)
 		state, found := volStates[string(kvstore.VolPrefixState)+volName]
 		if !found ||
-			state == string(kvstore.VolStateDeleting) ||
-			state == string(kvstore.VolStateError) {
+			state == string(kvstore.VolStateDeleting) {
 			if stopService {
 				log.Warningf("The service for vShared volume %s needs to be shutdown.", volName)
 				e.dockerOps.StopSMBServer(volName)
 			}
+
 			log.Warningf("The internal volume of vShared volume %s needs to be removed.", volName)
 			e.dockerOps.DeleteInternalVolume(volName)
 		}

--- a/client_plugin/drivers/shared/shared_driver.go
+++ b/client_plugin/drivers/shared/shared_driver.go
@@ -332,7 +332,7 @@ func (d *VolumeDriver) Remove(r volume.Request) volume.Response {
 		string(kvstore.VolStateDeleting)) {
 		// Failed to change state from Ready to Deleting
 		// 1. Volume is in Mounted state -> get clients and return error
-		// 2. Volume is already in Deleting state and timeout -> continue delete
+		// 2. Volume is already in Deleting/Error/Creating/Unmounting and timeout -> continue delete
 		// 3. Volume is in other states -> return error
 
 		// Get a list of host VMs using this volume, if any
@@ -350,10 +350,10 @@ func (d *VolumeDriver) Remove(r volume.Request) volume.Response {
 		state := entries[0].Value
 		switch state {
 		case string(kvstore.VolStateDeleting):
-			msg = fmt.Sprintf("Volume already in deleting state after timeout. Continue deleting")
-			log.Warningf(msg)
 		case string(kvstore.VolStateError):
-			msg = fmt.Sprintf("Volume in error state. Continue deleting")
+		case string(kvstore.VolStateCreating):
+		case string(kvstore.VolStateUnmounting):
+			msg = fmt.Sprintf("Remove: volume in %s state after timeout. Continue deleting", state)
 			log.Warningf(msg)
 		case string(kvstore.VolStateMounted):
 			// Unmarshal Info key
@@ -378,26 +378,11 @@ func (d *VolumeDriver) Remove(r volume.Request) volume.Response {
 
 	// Delete internal volume
 	log.Infof("Attempting to delete internal volume for %s", r.Name)
-	internalVolname := internalVolumePrefix + r.Name
-	err := d.dockerOps.VolumeRemove(internalVolname)
-	if err != nil {
-		msg = fmt.Sprintf("Failed to remove internal volume from driver \"%s\" for volume %s. Reason: %v.",
-			d.internalVolumeDriver, r.Name, err)
-
-		// check the internal volume state:
-		err = d.dockerOps.VolumeInspect(internalVolname)
-		if err == nil {
-			// volume exists, return error to stop deleting
-			return volume.Response{Err: msg}
-		}
-		msg += fmt.Sprintf(" Failed to inspect internal volume too. Error: %v.", err)
-		msg += fmt.Sprintf(" Continue delete the metadata.")
-		log.Warningf(msg)
-	}
+	d.dockerOps.DeleteInternalVolume(r.Name)
 
 	// Delete metadata associated with this volume
 	log.Infof("Attempting to delete volume metadata for %s", r.Name)
-	err = d.kvStore.DeleteMetaData(r.Name)
+	err := d.kvStore.DeleteMetaData(r.Name)
 	if err != nil {
 		msg = fmt.Sprintf("Failed to delete volume metadata for %s. Reason: %v", r.Name, err)
 		return volume.Response{Err: msg}


### PR DESCRIPTION
Due to unexpected errors, the docker services and internal volumes may not be removed completely when the shared volume is deleted. The existing of those orphan services and internal volumes will result in a waste of resources and can hurt the docker performance. It can also result in error when creating volumes with the previous existed names.

This change adds handling for those orphan services and orphan internal volumes. We first query all the shared volumes and their states from kv store. Then we compare if there is any service or internal volume doesn't have a matching shared volume or state. No matching shared volume means the service or internal volume is orphan, which need to be removed.