### PR TITLE
Updating e2e tests to make use of esxcli instead of vmdkops_admin.py

### DIFF
--- a/client_plugin/Makefile
+++ b/client_plugin/Makefile
@@ -424,19 +424,19 @@ test-e2e-shared:
 .PHONY: test-e2e-runalways test-e2e-runonce test-e2e-runonce-windows
 test-e2e-runalways:
 	$(log_target)
-	$(GO) test -v -timeout 40m -tags "runalways" $(E2E_Tests)
+	$(GO) test -v -timeout 50m -tags "runalways" $(E2E_Tests)
 
 test-e2e-runonce:
 	$(log_target)
-	$(GO) test -v -timeout 40m -tags "runonce" $(E2E_Tests)
+	$(GO) test -v -timeout 50m -tags "runonce" $(E2E_Tests)
 
 test-e2e-runonce-windows:
 	$(log_target)
-	$(GO) test -v -timeout 40m -tags "runoncewin winutil" $(E2E_Tests)
+	$(GO) test -v -timeout 50m -tags "runoncewin winutil" $(E2E_Tests)
 
 test-e2e-runonce-shared:
 	$(log_target)
-	$(GO) test -v -timeout 40m -tags "runonceshared" $(E2E_Tests)
+	$(GO) test -v -timeout 50m -tags "runonceshared" $(E2E_Tests)
 
 .PHONY:clean-vm clean-esx clean-all clean-docker
 clean-vm:

--- a/esx_service/cli/vmdkops_admin.xml
+++ b/esx_service/cli/vmdkops_admin.xml
@@ -4,31 +4,31 @@
     <!-- esxcli extension syntax version -->
     <version>1.0.0</version>
     <namespaces>
-        <namespace path="storage.vdvs">
-            <description>Admin commands to manage volumes consumed by vdvs</description>
+        <namespace path="storage.dvol">
+            <description>Admin commands to manage volumes consumed by containers running on host VM </description>
         </namespace>
-        <namespace path="storage.vdvs.volume">
+        <namespace path="storage.dvol.volume">
             <description>Manage vDVS volumes</description>
         </namespace>
-        <namespace path="storage.vdvs.policy">
+        <namespace path="storage.dvol.policy">
             <description>Configure and display storage policy information</description>
         </namespace>
-        <namespace path="storage.vdvs.vmgroup">
+        <namespace path="storage.dvol.vmgroup">
             <description>Administer and monitor volume access control</description>
         </namespace>
-        <namespace path="storage.vdvs.vmgroup.vm">
+        <namespace path="storage.dvol.vmgroup.vm">
             <description>Add, removes, replaces and lists VMs in a vmgroup</description>
         </namespace>
-        <namespace path="storage.vdvs.vmgroup.access">
+        <namespace path="storage.dvol.vmgroup.access">
             <description>Add or remove Datastore access and quotas for a vmgroup</description>
         </namespace>
-        <namespace path="storage.vdvs.config">
+        <namespace path="storage.dvol.config">
             <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>
         </namespace>
     </namespaces>
     <commands>
         <!-- Volume commands -->
-        <command path="storage.vdvs.volume.ls">
+        <command path="storage.dvol.volume.ls">
             <description>List volumes</description>
             <input-spec>
                 <parameter name="vmgroup" type="string" required="false">
@@ -87,7 +87,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume ls $if{vmgroup, --vmgroup $val{vmgroup}}</execute>
         </command>
-        <command path="storage.vdvs.volume.set">
+        <command path="storage.dvol.volume.set">
             <description>Edit settings for a given volume</description>
             <input-spec>
                 <parameter name="volume" type="string" required="true">
@@ -109,7 +109,7 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume set --vmgroup=$val{vmgroup} --volume=$val{volume} --options=$val{options}</execute>
         </command>
         <!-- Policy commands -->
-        <command path="storage.vdvs.policy.create">
+        <command path="storage.dvol.policy.create">
             <description>Create a storage policy</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -127,7 +127,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy create --name=$val{name} --content='$val{content}'</execute>
         </command>
-        <command path="storage.vdvs.policy.rm">
+        <command path="storage.dvol.policy.rm">
             <description>Remove a storage policy</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -142,7 +142,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy rm --name=$val{name}</execute>
         </command>
-        <command path="storage.vdvs.policy.ls">
+        <command path="storage.dvol.policy.ls">
             <description>List storage policies and volumes using those policies</description>
             <input-spec></input-spec>
             <output-spec>
@@ -167,7 +167,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy ls</execute>
         </command>
-        <command path="storage.vdvs.policy.update">
+        <command path="storage.dvol.policy.update">
             <description>Update the definition of a storage policy and all VSAN objects using that policy</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -186,7 +186,7 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy update --name=$val{name} --content='$val{content}'</execute>
         </command>
         <!-- vmgroup commands -->
-        <command path="storage.vdvs.vmgroup.create">
+        <command path="storage.dvol.vmgroup.create">
             <description>Create a new vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -209,9 +209,9 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup create --name=$val{name} --default-datastore=$val{default-datastore} $if{description, --description='$val{description}}' $if{vm-list, --vm-list=$val{vm-list}} </execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup create --name=$val{name} --default-datastore='$val{default-datastore}' $if{description, --description='$val{description}'} $if{vm-list, --vm-list=$val{vm-list}} </execute>
         </command>
-        <command path="storage.vdvs.vmgroup.update">
+        <command path="storage.dvol.vmgroup.update">
             <description>Update a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -234,15 +234,15 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml  vmgroup update --name=$val{name} $if{new-name, --new-name=$val{new-name}} $if{description, --description='$val{description}}' $if{vm-list, --vm-list=$val{vm-list}}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml  vmgroup update --name=$val{name} $if{new-name, --new-name=$val{new-name}} $if{description, --description='$val{description}'} $if{vm-list, --vm-list=$val{vm-list}}  $if{default-datastore, --default-datastore='$val{default-datastore}'}</execute>
         </command>
-        <command path="storage.vdvs.vmgroup.rm">
+        <command path="storage.dvol.vmgroup.rm">
             <description>Delete a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
                     <description>The name of the vmgroup</description>
                 </parameter>
-                <parameter name="remove-volumes" type="bool" required="false">
+                <parameter name="remove-volumes" type="flag" required="false">
                     <description>BE CAREFUL: Removes this vmgroup volumes when removing a vmgroup</description>
                 </parameter>
             </input-spec>
@@ -253,9 +253,9 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup rm --name=$val{name} $if{remove-volumes, --remove-volumes=$val{remove-volumes}}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup rm --name=$val{name} $if{remove-volumes, --remove-volumes}</execute>
         </command>
-        <command path="storage.vdvs.vmgroup.ls">
+        <command path="storage.dvol.vmgroup.ls">
             <description>List vmgroups and the VMs they are applied to</description>
             <input-spec></input-spec>
             <output-spec>
@@ -287,7 +287,7 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup ls</execute>
         </command>
         <!-- vmgroup vm commands -->
-        <command path="storage.vdvs.vmgroup.vm.add">
+        <command path="storage.dvol.vmgroup.vm.add">
             <description>Add VM(s) to a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -306,7 +306,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm add --name=$val{name} --vm-list=$val{vm-list}</execute>
         </command>
-        <command path="storage.vdvs.vmgroup.vm.rm">
+        <command path="storage.dvol.vmgroup.vm.rm">
             <description>Remove VM(s) from a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -325,7 +325,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm rm --name=$val{name} --vm-list=$val{vm-list}</execute>
         </command>
-        <command path="storage.vdvs.vmgroup.vm.replace">
+        <command path="storage.dvol.vmgroup.vm.replace">
             <description>Replace VM(s) for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -344,7 +344,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm replace --name=$val{name} --vm-list=$val{vm-list}</execute>
         </command>
-        <command path="storage.vdvs.vmgroup.vm.ls">
+        <command path="storage.dvol.vmgroup.vm.ls">
             <description>list VMs in a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -371,7 +371,7 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm ls --name=$val{name}</execute>
         </command>
         <!-- vmgroup access commands -->
-        <command path="storage.vdvs.vmgroup.access.add">
+        <command path="storage.dvol.vmgroup.access.add">
             <description>Add a datastore access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -398,7 +398,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access add --name=$val{name} --datastore=$val{datastore} $if{allow-create, --allow-create} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
         </command>
-        <command path="storage.vdvs.vmgroup.access.set">
+        <command path="storage.dvol.vmgroup.access.set">
             <description>Modify datastore access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -426,7 +426,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access set --name=$val{name} --datastore=$val{datastore} $if{allow-create, --allow-create=$val{allow-create}} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
         </command>
-        <command path="storage.vdvs.vmgroup.access.rm">
+        <command path="storage.dvol.vmgroup.access.rm">
             <description>Remove datastore access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -445,7 +445,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access rm --name=$val{name} --datastore=$val{datastore}</execute>
         </command>
-        <command path="storage.vdvs.vmgroup.access.ls">
+        <command path="storage.dvol.vmgroup.access.ls">
             <description>List access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -478,7 +478,7 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access ls --name=$val{name}</execute>
         </command>
         <!-- vmgroup config commands -->
-        <command path="storage.vdvs.status">
+        <command path="storage.dvol.status">
             <description>Status of vdvs service</description>
             <input-spec>
                 <parameter name="fast" type="flag" required="false">
@@ -493,7 +493,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml status $if{fast, --fast}</execute>
         </command>
-        <command path="storage.vdvs.config.init">
+        <command path="storage.dvol.config.init">
             <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>
             <input-spec>
                 <parameter name="datastore" type="string" required="false">
@@ -514,7 +514,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config init $if{datastore, --datastore=$val{datastore}} $if{local, --local} $if{force, --force}</execute>
         </command>
-        <command path="storage.vdvs.config.rm">
+        <command path="storage.dvol.config.rm">
             <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>
             <input-spec>
                 <parameter name="unlink" type="flag" required="false">
@@ -538,7 +538,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config rm $if{local, --local} $if{unlink, --unlink} $if{no-backup, --no-backup} $if{confirm, --confirm}</execute>
         </command>
-        <command path="storage.vdvs.config.mv">
+        <command path="storage.dvol.config.mv">
             <description>Relocate config file from its current location [NOT SUPPORTED YET]</description>
             <input-spec>
                 <parameter name="to" type="string" required="true">
@@ -556,7 +556,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config mv --to=$val{to} $if{force, --force}</execute>
         </command>
-        <command path="storage.vdvs.config.status">
+        <command path="storage.dvol.config.status">
             <description>Show the status of the Config DB</description>
             <input-spec></input-spec>
             <output-spec>

--- a/esx_service/cli/vmdkops_admin.xml
+++ b/esx_service/cli/vmdkops_admin.xml
@@ -85,7 +85,66 @@
                 <formatter>table</formatter>
                 <format-parameter name="fields:vdvs">Volume,Datastore,VMGroup,Capacity,Used,Filesystem,Policy,Disk Format,Attached-to,Access,Attach-as,Created By,Created Date</format-parameter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume ls $if{vmgroup, --vmgroup $val{vmgroup}}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume ls $if{vmgroup, --vmgroup '$val{vmgroup}'}</execute>
+        </command>
+        <command path="storage.guestvol.volume.shortls">
+            <description>List volumes with limited information</description>
+            <input-spec>
+                <parameter name="vmgroup" type="string" required="false">
+                    <description>Displays volumes for a given vmgroup</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <list type="structure">
+                    <structure typeName="vdvs">
+                        <field name="Volume">
+                            <string/>
+                        </field>
+                        <field name="Datastore">
+                            <string/>
+                        </field>
+                        <field name="VMGroup">
+                            <string/>
+                        </field>
+                        <field name="Capacity">
+                            <string/>
+                        </field>
+                        <field name="Used">
+                            <string/>
+                        </field>
+                        <field name="Filesystem">
+                            <string/>
+                        </field>
+                        <field name="Policy">
+                            <string/>
+                        </field>
+                        <field name="Disk Format">
+                            <string/>
+                        </field>
+                        <field name="Attached-to">
+                            <string/>
+                        </field>
+                        <field name="Access">
+                            <string/>
+                        </field>
+                        <field name="Attach-as">
+                            <string/>
+                        </field>
+                        <field name="Created By">
+                            <string/>
+                        </field>
+                        <field name="Created Date">
+                            <string/>
+                        </field>
+                    </structure>
+                </list>
+            </output-spec>
+            <has-updates value="true"/>
+            <format-parameters>
+                <formatter>table</formatter>
+                <format-parameter name="fields:vdvs">Volume,Capacity,Disk Format,Attached-to</format-parameter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume ls $if{vmgroup, --vmgroup '$val{vmgroup}'}</execute>
         </command>
         <command path="storage.guestvol.volume.set">
             <description>Edit settings for a given volume</description>
@@ -106,7 +165,7 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume set --vmgroup=$val{vmgroup} --volume=$val{volume} --options=$val{options}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume set --vmgroup='$val{vmgroup}' --volume='$val{volume}' --options=$val{options}</execute>
         </command>
         <!-- Policy commands -->
         <command path="storage.guestvol.policy.create">
@@ -125,7 +184,7 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy create --name=$val{name} --content='$val{content}'</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy create --name='$val{name}' --content='$val{content}'</execute>
         </command>
         <command path="storage.guestvol.policy.rm">
             <description>Remove a storage policy</description>
@@ -140,7 +199,7 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy rm --name=$val{name}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy rm --name='$val{name}'</execute>
         </command>
         <command path="storage.guestvol.policy.ls">
             <description>List storage policies and volumes using those policies</description>
@@ -183,7 +242,7 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy update --name=$val{name} --content='$val{content}'</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy update --name='$val{name}' --content='$val{content}'</execute>
         </command>
         <!-- vmgroup commands -->
         <command path="storage.guestvol.vmgroup.create">
@@ -209,7 +268,7 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup create --name=$val{name} --default-datastore='$val{default-datastore}' $if{description, --description='$val{description}'} $if{vm-list, --vm-list=$val{vm-list}} </execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup create --name='$val{name}' --default-datastore='$val{default-datastore}' $if{description, --description='$val{description}'} $if{vm-list, --vm-list=$val{vm-list}} </execute>
         </command>
         <command path="storage.guestvol.vmgroup.update">
             <description>Update a vmgroup</description>
@@ -234,7 +293,7 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml  vmgroup update --name=$val{name} $if{new-name, --new-name=$val{new-name}} $if{description, --description='$val{description}'} $if{vm-list, --vm-list=$val{vm-list}}  $if{default-datastore, --default-datastore='$val{default-datastore}'}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml  vmgroup update --name='$val{name}' $if{new-name, --new-name='$val{new-name}'} $if{description, --description='$val{description}'} $if{vm-list, --vm-list=$val{vm-list}}  $if{default-datastore, --default-datastore='$val{default-datastore}'}</execute>
         </command>
         <command path="storage.guestvol.vmgroup.rm">
             <description>Delete a vmgroup</description>
@@ -304,7 +363,7 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm add --name=$val{name} --vm-list=$val{vm-list}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm add --name='$val{name}' --vm-list=$val{vm-list}</execute>
         </command>
         <command path="storage.guestvol.vmgroup.vm.rm">
             <description>Remove VM(s) from a vmgroup</description>
@@ -323,7 +382,7 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm rm --name=$val{name} --vm-list=$val{vm-list}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm rm --name='$val{name}' --vm-list=$val{vm-list}</execute>
         </command>
         <command path="storage.guestvol.vmgroup.vm.replace">
             <description>Replace VM(s) for a vmgroup</description>
@@ -342,7 +401,7 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm replace --name=$val{name} --vm-list=$val{vm-list}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm replace --name='$val{name}' --vm-list=$val{vm-list}</execute>
         </command>
         <command path="storage.guestvol.vmgroup.vm.ls">
             <description>list VMs in a vmgroup</description>
@@ -368,7 +427,7 @@
                 <formatter>table</formatter>
                 <format-parameter name="fields:vdvs">Uuid, Name</format-parameter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm ls --name=$val{name}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm ls --name='$val{name}'</execute>
         </command>
         <!-- vmgroup access commands -->
         <command path="storage.guestvol.vmgroup.access.add">
@@ -396,7 +455,7 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access add --name=$val{name} --datastore=$val{datastore} $if{allow-create, --allow-create} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access add --name='$val{name}' --datastore='$val{datastore}' $if{allow-create, --allow-create} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
         </command>
         <command path="storage.guestvol.vmgroup.access.set">
             <description>Modify datastore access for a vmgroup</description>
@@ -424,7 +483,7 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access set --name=$val{name} --datastore=$val{datastore} $if{allow-create, --allow-create=$val{allow-create}} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access set --name=$val{name} --datastore='$val{datastore}' $if{allow-create, --allow-create=$val{allow-create}} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
         </command>
         <command path="storage.guestvol.vmgroup.access.rm">
             <description>Remove datastore access for a vmgroup</description>
@@ -443,7 +502,7 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access rm --name=$val{name} --datastore=$val{datastore}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access rm --name='$val{name}' --datastore='$val{datastore}'</execute>
         </command>
         <command path="storage.guestvol.vmgroup.access.ls">
             <description>List access for a vmgroup</description>
@@ -475,7 +534,7 @@
                 <formatter>table</formatter>
                 <format-parameter name="fields:vdvs">Datastore, Allow_create, Max_volume_size, Total_size</format-parameter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access ls --name=$val{name}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access ls --name='$val{name}'</execute>
         </command>
         <!-- vmgroup config commands -->
         <command path="storage.guestvol.status">
@@ -512,7 +571,7 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config init $if{datastore, --datastore=$val{datastore}} $if{local, --local} $if{force, --force}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config init $if{datastore, --datastore='$val{datastore}'} $if{local, --local} $if{force, --force}</execute>
         </command>
         <command path="storage.guestvol.config.rm">
             <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>

--- a/esx_service/cli/vmdkops_admin.xml
+++ b/esx_service/cli/vmdkops_admin.xml
@@ -4,31 +4,31 @@
     <!-- esxcli extension syntax version -->
     <version>1.0.0</version>
     <namespaces>
-        <namespace path="storage.dvol">
-            <description>Admin commands to manage volumes consumed by containers running on host VM </description>
+        <namespace path="storage.guestvol">
+            <description>Admin commands to manage volumes consumed by containers running on guest VM </description>
         </namespace>
-        <namespace path="storage.dvol.volume">
+        <namespace path="storage.guestvol.volume">
             <description>Manage vDVS volumes</description>
         </namespace>
-        <namespace path="storage.dvol.policy">
+        <namespace path="storage.guestvol.policy">
             <description>Configure and display storage policy information</description>
         </namespace>
-        <namespace path="storage.dvol.vmgroup">
+        <namespace path="storage.guestvol.vmgroup">
             <description>Administer and monitor volume access control</description>
         </namespace>
-        <namespace path="storage.dvol.vmgroup.vm">
+        <namespace path="storage.guestvol.vmgroup.vm">
             <description>Add, removes, replaces and lists VMs in a vmgroup</description>
         </namespace>
-        <namespace path="storage.dvol.vmgroup.access">
+        <namespace path="storage.guestvol.vmgroup.access">
             <description>Add or remove Datastore access and quotas for a vmgroup</description>
         </namespace>
-        <namespace path="storage.dvol.config">
+        <namespace path="storage.guestvol.config">
             <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>
         </namespace>
     </namespaces>
     <commands>
         <!-- Volume commands -->
-        <command path="storage.dvol.volume.ls">
+        <command path="storage.guestvol.volume.ls">
             <description>List volumes</description>
             <input-spec>
                 <parameter name="vmgroup" type="string" required="false">
@@ -87,7 +87,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume ls $if{vmgroup, --vmgroup $val{vmgroup}}</execute>
         </command>
-        <command path="storage.dvol.volume.set">
+        <command path="storage.guestvol.volume.set">
             <description>Edit settings for a given volume</description>
             <input-spec>
                 <parameter name="volume" type="string" required="true">
@@ -109,7 +109,7 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume set --vmgroup=$val{vmgroup} --volume=$val{volume} --options=$val{options}</execute>
         </command>
         <!-- Policy commands -->
-        <command path="storage.dvol.policy.create">
+        <command path="storage.guestvol.policy.create">
             <description>Create a storage policy</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -127,7 +127,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy create --name=$val{name} --content='$val{content}'</execute>
         </command>
-        <command path="storage.dvol.policy.rm">
+        <command path="storage.guestvol.policy.rm">
             <description>Remove a storage policy</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -142,7 +142,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy rm --name=$val{name}</execute>
         </command>
-        <command path="storage.dvol.policy.ls">
+        <command path="storage.guestvol.policy.ls">
             <description>List storage policies and volumes using those policies</description>
             <input-spec></input-spec>
             <output-spec>
@@ -167,7 +167,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy ls</execute>
         </command>
-        <command path="storage.dvol.policy.update">
+        <command path="storage.guestvol.policy.update">
             <description>Update the definition of a storage policy and all VSAN objects using that policy</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -186,7 +186,7 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy update --name=$val{name} --content='$val{content}'</execute>
         </command>
         <!-- vmgroup commands -->
-        <command path="storage.dvol.vmgroup.create">
+        <command path="storage.guestvol.vmgroup.create">
             <description>Create a new vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -211,7 +211,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup create --name=$val{name} --default-datastore='$val{default-datastore}' $if{description, --description='$val{description}'} $if{vm-list, --vm-list=$val{vm-list}} </execute>
         </command>
-        <command path="storage.dvol.vmgroup.update">
+        <command path="storage.guestvol.vmgroup.update">
             <description>Update a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -236,7 +236,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml  vmgroup update --name=$val{name} $if{new-name, --new-name=$val{new-name}} $if{description, --description='$val{description}'} $if{vm-list, --vm-list=$val{vm-list}}  $if{default-datastore, --default-datastore='$val{default-datastore}'}</execute>
         </command>
-        <command path="storage.dvol.vmgroup.rm">
+        <command path="storage.guestvol.vmgroup.rm">
             <description>Delete a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -255,7 +255,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup rm --name=$val{name} $if{remove-volumes, --remove-volumes}</execute>
         </command>
-        <command path="storage.dvol.vmgroup.ls">
+        <command path="storage.guestvol.vmgroup.ls">
             <description>List vmgroups and the VMs they are applied to</description>
             <input-spec></input-spec>
             <output-spec>
@@ -287,7 +287,7 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup ls</execute>
         </command>
         <!-- vmgroup vm commands -->
-        <command path="storage.dvol.vmgroup.vm.add">
+        <command path="storage.guestvol.vmgroup.vm.add">
             <description>Add VM(s) to a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -306,7 +306,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm add --name=$val{name} --vm-list=$val{vm-list}</execute>
         </command>
-        <command path="storage.dvol.vmgroup.vm.rm">
+        <command path="storage.guestvol.vmgroup.vm.rm">
             <description>Remove VM(s) from a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -325,7 +325,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm rm --name=$val{name} --vm-list=$val{vm-list}</execute>
         </command>
-        <command path="storage.dvol.vmgroup.vm.replace">
+        <command path="storage.guestvol.vmgroup.vm.replace">
             <description>Replace VM(s) for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -344,7 +344,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm replace --name=$val{name} --vm-list=$val{vm-list}</execute>
         </command>
-        <command path="storage.dvol.vmgroup.vm.ls">
+        <command path="storage.guestvol.vmgroup.vm.ls">
             <description>list VMs in a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -371,7 +371,7 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm ls --name=$val{name}</execute>
         </command>
         <!-- vmgroup access commands -->
-        <command path="storage.dvol.vmgroup.access.add">
+        <command path="storage.guestvol.vmgroup.access.add">
             <description>Add a datastore access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -398,7 +398,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access add --name=$val{name} --datastore=$val{datastore} $if{allow-create, --allow-create} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
         </command>
-        <command path="storage.dvol.vmgroup.access.set">
+        <command path="storage.guestvol.vmgroup.access.set">
             <description>Modify datastore access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -426,7 +426,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access set --name=$val{name} --datastore=$val{datastore} $if{allow-create, --allow-create=$val{allow-create}} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
         </command>
-        <command path="storage.dvol.vmgroup.access.rm">
+        <command path="storage.guestvol.vmgroup.access.rm">
             <description>Remove datastore access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -445,7 +445,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access rm --name=$val{name} --datastore=$val{datastore}</execute>
         </command>
-        <command path="storage.dvol.vmgroup.access.ls">
+        <command path="storage.guestvol.vmgroup.access.ls">
             <description>List access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -478,7 +478,7 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access ls --name=$val{name}</execute>
         </command>
         <!-- vmgroup config commands -->
-        <command path="storage.dvol.status">
+        <command path="storage.guestvol.status">
             <description>Status of vdvs service</description>
             <input-spec>
                 <parameter name="fast" type="flag" required="false">
@@ -493,7 +493,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml status $if{fast, --fast}</execute>
         </command>
-        <command path="storage.dvol.config.init">
+        <command path="storage.guestvol.config.init">
             <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>
             <input-spec>
                 <parameter name="datastore" type="string" required="false">
@@ -514,7 +514,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config init $if{datastore, --datastore=$val{datastore}} $if{local, --local} $if{force, --force}</execute>
         </command>
-        <command path="storage.dvol.config.rm">
+        <command path="storage.guestvol.config.rm">
             <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>
             <input-spec>
                 <parameter name="unlink" type="flag" required="false">
@@ -538,7 +538,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config rm $if{local, --local} $if{unlink, --unlink} $if{no-backup, --no-backup} $if{confirm, --confirm}</execute>
         </command>
-        <command path="storage.dvol.config.mv">
+        <command path="storage.guestvol.config.mv">
             <description>Relocate config file from its current location [NOT SUPPORTED YET]</description>
             <input-spec>
                 <parameter name="to" type="string" required="true">
@@ -556,7 +556,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config mv --to=$val{to} $if{force, --force}</execute>
         </command>
-        <command path="storage.dvol.config.status">
+        <command path="storage.guestvol.config.status">
             <description>Show the status of the Config DB</description>
             <input-spec></input-spec>
             <output-spec>

--- a/tests/constants/admincli/cmd.go
+++ b/tests/constants/admincli/cmd.go
@@ -18,7 +18,7 @@ package admincli
 
 const (
 	// location of the vmdkops binary
-	vmdkopsAdmin = "esxcli storage dvol "
+	vmdkopsAdmin = "esxcli storage guestvol "
 
 	// vmdkops_admin volume
 	vmdkopsAdminVolume = vmdkopsAdmin + "volume "

--- a/tests/constants/admincli/cmd.go
+++ b/tests/constants/admincli/cmd.go
@@ -26,6 +26,9 @@ const (
 	// ListVolumes referring to vmdkops_admin volume ls
 	ListVolumes = vmdkopsAdminVolume + "ls "
 
+	// ShortListVolumes referring to vmdkops_admin volume shortls listing Volume, Capacity, Disk Format, Attached-to
+	ShortListVolumes = vmdkopsAdminVolume + "shortls "
+
 	// SetVolumeAccess set volume access
 	SetVolumeAccess = vmdkopsAdminVolume + " set "
 

--- a/tests/constants/admincli/cmd.go
+++ b/tests/constants/admincli/cmd.go
@@ -18,7 +18,7 @@ package admincli
 
 const (
 	// location of the vmdkops binary
-	vmdkopsAdmin = "/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py "
+	vmdkopsAdmin = "esxcli storage dvol "
 
 	// vmdkops_admin volume
 	vmdkopsAdminVolume = vmdkopsAdmin + "volume "

--- a/tests/e2e/defaultvmgroup_test.go
+++ b/tests/e2e/defaultvmgroup_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	vgErrorMsg = "ERROR:This feature is not supported for vmgroup _DEFAULT."
+	vgErrorMsg = "This feature is not supported for vmgroup _DEFAULT."
 )
 
 type DefaultVMGroupTestSuite struct {

--- a/tests/e2e/vsan_test.go
+++ b/tests/e2e/vsan_test.go
@@ -177,7 +177,7 @@ func (s *VsanTestSuite) TestDeleteVsanPolicyAlreadyInUse(c *C) {
 
 	out, err = admincli.RemovePolicy(s.config.EsxHost, adminclicon.PolicyName)
 	log.Printf("Remove vsanPolicy \"%s\" returns with %s", adminclicon.PolicyName, out)
-	c.Assert(out, Matches, "ERROR:Cannot remove.*", Commentf("vsanPolicy is still used by volumes and cannot be removed"))
+	c.Assert(out, Matches, "Cannot remove.*", Commentf("vsanPolicy is still used by volumes and cannot be removed"))
 
 	misc.LogTestEnd(c.TestName())
 

--- a/tests/utils/admincli/cmd.go
+++ b/tests/utils/admincli/cmd.go
@@ -83,7 +83,7 @@ func GetVolumeProperties(volumeName, hostName string) []string {
 // IsVolumeAvailableOnESX returns true if the given volume is available
 // on the specified ESX
 func IsVolumeAvailableOnESX(hostName string, reqVol string) bool {
-	cmd := admincli.ListVolumes + " 2>/dev/null | awk -v OFS='\t' '{print $1}' | sed '1,2d' "
+	cmd := admincli.ShortListVolumes + " 2>/dev/null | awk -v OFS='\t' '{print $1}' | sed '1,2d' "
 	op, _ := ssh.InvokeCommand(hostName, cmd)
 
 	if strings.Contains(op, reqVol) != true {

--- a/tests/utils/admincli/cmd.go
+++ b/tests/utils/admincli/cmd.go
@@ -60,7 +60,7 @@ func UpdateVolumeAccess(ip, volName, vmgroup, access string) (string, error) {
 // properties - capacity, attached-to-vm and disk-format.
 func GetAllVolumeProperties(hostName string) map[string][]string {
 	log.Printf("Getting size, disk-format and attached-to-vm for all volumes from ESX [%s].", hostName)
-	cmd := admincli.ListVolumes + "-c volume,capacity,disk-format,attached-to 2>/dev/null | awk -v OFS='\t' '{print $1, $2, $3, $4}' | sed '1,2d'  "
+	cmd := admincli.ListVolumes + " 2>/dev/null | awk -v OFS='\t' '{print $1, $4, $8, $9}' | sed '1,2d' "
 	out, _ := ssh.InvokeCommand(hostName, cmd)
 	admincliValues := strings.Fields(out)
 	adminCliMap := make(map[string][]string)
@@ -75,7 +75,7 @@ func GetAllVolumeProperties(hostName string) map[string][]string {
 // Properties returned - capacity, attached-to-vm and disk-format field
 func GetVolumeProperties(volumeName, hostName string) []string {
 	log.Printf("Getting size, disk-format and attached-to-vm for volume [%s] from ESX [%s]. \n", volumeName, hostName)
-	cmd := admincli.ListVolumes + "-c volume,capacity,disk-format,attached-to 2>/dev/null | grep " + volumeName + " | awk -v OFS='\t' '{print $2, $3, $4}' "
+	cmd := admincli.ListVolumes + " 2>/dev/null | grep " + volumeName + " | awk -v OFS='\t' '{print $4, $8, $9}' "
 	out, _ := ssh.InvokeCommand(hostName, cmd)
 	return strings.Fields(out)
 }
@@ -83,7 +83,7 @@ func GetVolumeProperties(volumeName, hostName string) []string {
 // IsVolumeAvailableOnESX returns true if the given volume is available
 // on the specified ESX
 func IsVolumeAvailableOnESX(hostName string, reqVol string) bool {
-	cmd := admincli.ListVolumes + "-c volume"
+	cmd := admincli.ListVolumes + " 2>/dev/null | awk -v OFS='\t' '{print $1}' | sed '1,2d' "
 	op, _ := ssh.InvokeCommand(hostName, cmd)
 
 	if strings.Contains(op, reqVol) != true {

--- a/tests/utils/admincli/cmd.go
+++ b/tests/utils/admincli/cmd.go
@@ -60,7 +60,7 @@ func UpdateVolumeAccess(ip, volName, vmgroup, access string) (string, error) {
 // properties - capacity, attached-to-vm and disk-format.
 func GetAllVolumeProperties(hostName string) map[string][]string {
 	log.Printf("Getting size, disk-format and attached-to-vm for all volumes from ESX [%s].", hostName)
-	cmd := admincli.ListVolumes + " 2>/dev/null | awk -v OFS='\t' '{print $1, $4, $8, $9}' | sed '1,2d' "
+	cmd := admincli.ShortListVolumes + " 2>/dev/null | awk -v OFS='\t' '{print $1, $2, $3, $4}' | sed '1,2d' "
 	out, _ := ssh.InvokeCommand(hostName, cmd)
 	admincliValues := strings.Fields(out)
 	adminCliMap := make(map[string][]string)
@@ -75,7 +75,7 @@ func GetAllVolumeProperties(hostName string) map[string][]string {
 // Properties returned - capacity, attached-to-vm and disk-format field
 func GetVolumeProperties(volumeName, hostName string) []string {
 	log.Printf("Getting size, disk-format and attached-to-vm for volume [%s] from ESX [%s]. \n", volumeName, hostName)
-	cmd := admincli.ListVolumes + " 2>/dev/null | grep " + volumeName + " | awk -v OFS='\t' '{print $4, $8, $9}' "
+	cmd := admincli.ShortListVolumes + " 2>/dev/null | grep " + volumeName + " | awk -v OFS='\t' '{print $2, $3, $4}' "
 	out, _ := ssh.InvokeCommand(hostName, cmd)
 	return strings.Fields(out)
 }

--- a/tests/utils/admincli/vmgroupmgmt.go
+++ b/tests/utils/admincli/vmgroupmgmt.go
@@ -176,7 +176,7 @@ func IsVolumeExistInVmgroup(esxIP, vmgroupName, volName string) bool {
 // from the specified vmgroup; false otherwise.
 func IsVolumeListExistInVmgroup(esxIP, vmgroupName string, volList []string) bool {
 	log.Printf("Checking if volumes [%s] belongs to vmgroup [%s] from esx [%s] \n", volList, vmgroupName, esxIP)
-	cmd := admincli.ListVolumes + " -c volume,vmgroup 2>/dev/null | awk -v OFS='\t' '{print $1, $2}' | sed '1,2d' "
+	cmd := admincli.ListVolumes + " 2>/dev/null | awk -v OFS='\t' '{print $1, $3}' | sed '1,2d' "
 	out, _ := ssh.InvokeCommand(esxIP, cmd)
 
 	vgValues := strings.Fields(out)

--- a/tests/utils/verification/volumeproperties.go
+++ b/tests/utils/verification/volumeproperties.go
@@ -56,6 +56,7 @@ func GetVMAttachedToVolUsingAdminCli(volName string, hostname string) string {
 		log.Fatalf("Admin cli output is expected to consist of two elements only - "+
 			"volume name and attached-to-vm status. Actual output %s ", op)
 	}
+	log.Printf("Volume %s status through admin cli is: %s", volName, volProps[1])
 	return volProps[1]
 }
 

--- a/tests/utils/verification/volumeproperties.go
+++ b/tests/utils/verification/volumeproperties.go
@@ -45,7 +45,8 @@ func GetVMAttachedToVolUsingDockerCli(volName string, hostname string) string {
 
 // GetVMAttachedToVolUsingAdminCli returns attached to vm field of volume using admin cli
 func GetVMAttachedToVolUsingAdminCli(volName string, hostname string) string {
-	cmd := admincli.ListVolumes + " 2>/dev/null | grep " + volName + " | awk -v OFS='\t' '{print $1, $9}'"
+	// Print the Volume and Attached-to field
+	cmd := admincli.ShortListVolumes + " 2>/dev/null | grep " + volName + " | awk -v OFS='\t' '{print $1, $4}'"
 	op, _ := ssh.InvokeCommand(hostname, cmd)
 	volProps := strings.Fields(op)
 	if op == "" {

--- a/tests/utils/verification/volumeproperties.go
+++ b/tests/utils/verification/volumeproperties.go
@@ -45,7 +45,7 @@ func GetVMAttachedToVolUsingDockerCli(volName string, hostname string) string {
 
 // GetVMAttachedToVolUsingAdminCli returns attached to vm field of volume using admin cli
 func GetVMAttachedToVolUsingAdminCli(volName string, hostname string) string {
-	cmd := admincli.ListVolumes + "-c volume,attached-to 2>/dev/null | grep " + volName
+	cmd := admincli.ListVolumes + " 2>/dev/null | grep " + volName + " | awk -v OFS='\t' '{print $1, $9}'"
 	op, _ := ssh.InvokeCommand(hostname, cmd)
 	volProps := strings.Fields(op)
 	if op == "" {
@@ -206,7 +206,7 @@ func GetAssociatedPolicyName(hostname string, volName string) (string, error) {
 // GetVMGroupForVolume returns vmgroup field of volume using admin cli
 // If the volume does not exist, err will be filled with "exit status 1"
 func GetVMGroupForVolume(hostName string, volName string) (string, error) {
-	cmd := admincli.ListVolumes + "-c volume,vmgroup 2>/dev/null | grep " + volName
+	cmd := admincli.ListVolumes + " 2>/dev/null | awk -v OFS='\t' '{print $1, $3}' | grep " + volName
 	op, err := ssh.InvokeCommand(hostName, cmd)
 	if err != nil {
 		log.Printf("GetVMGroupForVolume return with err: %s", err.Error())

--- a/tests/utils/verification/volumeproperties.go
+++ b/tests/utils/verification/volumeproperties.go
@@ -45,20 +45,19 @@ func GetVMAttachedToVolUsingDockerCli(volName string, hostname string) string {
 
 // GetVMAttachedToVolUsingAdminCli returns attached to vm field of volume using admin cli
 func GetVMAttachedToVolUsingAdminCli(volName string, hostname string) string {
-	// Print the Volume and Attached-to field
-	cmd := admincli.ShortListVolumes + " 2>/dev/null | grep " + volName + " | awk -v OFS='\t' '{print $1, $4}'"
+	cmd := admincli.ShortListVolumes + " 2>/dev/null | grep " + volName
 	op, _ := ssh.InvokeCommand(hostname, cmd)
 	volProps := strings.Fields(op)
 	if op == "" {
 		log.Printf("Null value is returned by admin cli when looking for attached to vm field for volume %s ", volName)
 		return op
 	}
-	if len(volProps) != 2 {
-		log.Fatalf("Admin cli output is expected to consist of two elements only - "+
-			"volume name and attached-to-vm status. Actual output %s ", op)
+	if len(volProps) != 4 {
+		log.Fatalf("Admin cli volume shortls output is expected to consist of four elements only"+
+			"Actual output %s ", op)
 	}
-	log.Printf("Volume %s status through admin cli is: %s", volName, volProps[1])
-	return volProps[1]
+	// Fourth string is the attached VM name
+	return volProps[3]
 }
 
 // CheckVolumeAvailability returns true if the given volume is available


### PR DESCRIPTION
## Description

1. This PR updates our e2e tests to make use of esxcli storage vdvs
2. Since -c flag (toggle what columns we need for volume ls) isn't supported through esxcli, I had to tweak some list utils to make use of appropriate columns from volumn ls output
3. Error of a command is prefixed with string "ERROR". This string is consumed by esxcli. So it only shows the actual error message. Good thing is it does set exit status to 1 i.e. command failed.