### PR TITLE
[SKIP CI] Documentation update for ESXCLI usage and minor command fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ esxcli software vib install -v /tmp/<vib_name>.vib
 
 Make sure you provide the **absolute path** to the `.vib` file or the install will fail.
 
+**Note**: To make admin commandset available on ESX host, please restart hostd after vib installation.
+```
+/etc/init.d/hostd restart
+```
+
 ### On Docker Host (VM)
 #### Managed Plugin
 1. Please make sure to uninstall older releases of DEB/RPM using following commands.
@@ -97,7 +102,7 @@ $ docker volume rm MyVolume
 
 ## Using ESXi Admin CLI
 ```
-$ /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py volume ls
+$ esxcli storage guestvol volume ls
 ```
 
 ## Logging

--- a/docs/features/tenancy.md
+++ b/docs/features/tenancy.md
@@ -26,7 +26,7 @@ Vmgroups can be created and managed via the [Admin CLI](/docs/user-guide/admin-c
 When a VM which does not belong to any vmgroup issues a request to vmdk_ops, this VM will be assumed to be in _DEFAULT vmgroup, and will get privileges associated with this vmgroup. \_DEFAULT vmgroup will be automatically created by system post install, so by default vmdk_ops will support request from any VM , thus maintaining backward compatibility and simplicity of installation.An admin can remove this vmgroup or modify privileges, thus locking down vmdk_ops to serve only explicitly configured VMs.
 
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=_DEFAULT
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name _DEFAULT
 Datastore  Allow_create  Max_volume_size  Total_size
 ---------  ------------  ---------------  ----------
 _ALL_DS   True          Unset            Unset
@@ -44,21 +44,21 @@ When a VM addresses the volume using short notation (volume_name, without @datas
 Let's consider a sample use case where there are 2 teams – Dev and Test working on Product1. Lets create separate vmgroups (namely Product1Dev and Product1Test) for each of the teams where we can put restriction on datastore consumption.
 
 ```
-[root@sc-rdops-vm17-dhcp-3-236:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=Product1Dev --default-datastore=datastore3
+[root@sc-rdops-vm17-dhcp-3-236:~] esxcli storage guestvol vmgroup create --name=Product1Dev --default-datastore=datastore3
 vmgroup 'Product1Dev' is created. Do not forget to run 'vmgroup vm add' to add vm to vmgroup.
 
-[root@sc-rdops-vm17-dhcp-3-236:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=Product1Test --default-datastore=datastore3
+[root@sc-rdops-vm17-dhcp-3-236:~] esxcli storage guestvol vmgroup create --name=Product1Test --default-datastore=datastore3
 vmgroup 'Product1Test' is created. Do not forget to run 'vmgroup vm add' to add vm to vmgroup.
 ```
 The full access privilege to default datastore("datastore3" in this example) has been created after creating vmgroup.
 
 ```
-[root@sc-rdops-vm17-dhcp-3-236:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=Product1Dev
+[root@sc-rdops-vm17-dhcp-3-236:~] esxcli storage guestvol vmgroup access ls --name=Product1Dev
 Datastore     Allow_create  Max_volume_size  Total_size
 ------------  ------------  ---------------  ----------
 datastore3    True          Unset            Unset
 
-[root@sc-rdops-vm17-dhcp-3-236:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=Product1Test
+[root@sc-rdops-vm17-dhcp-3-236:~] esxcli storage guestvol vmgroup access ls --name=Product1Test
 Datastore     Allow_create  Max_volume_size  Total_size
 ------------  ------------  ---------------  ----------
 datastore3    True          Unset            Unset
@@ -67,10 +67,10 @@ datastore3    True          Unset            Unset
 Then we removed _DEFAULT vmgroup to lock down vmdk_ops to serve only explicitly configured VMs.
 
 ```
-[root@sc-rdops-vm17-dhcp-3-236:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup rm --name=_DEFAULT
+[root@sc-rdops-vm17-dhcp-3-236:~] esxcli storage guestvol vmgroup rm --name=_DEFAULT
 vmgroup rm succeeded
 
-[root@sc-rdops-vm17-dhcp-3-236:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+[root@sc-rdops-vm17-dhcp-3-236:~] esxcli storage guestvol vmgroup ls
 Uuid                                  Name          Description  Default_datastore  VM_list
 ------------------------------------  ------------  -----------  -----------------  ------------
 ac4b7167-94b3-470e-b932-5b32f2bfa273  Product1Dev                datastore3
@@ -80,13 +80,13 @@ f15c1f6d-5df5-4a00-8f20-77c8e7a7af11  Product1Test               datastore3
 Lets add VMs (docker hosts) in respective VM groups.
 
 ```
-#/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup vm add --vm-list=Photon1,Photon2,Photon3 --name=Product1Dev
+#esxcli storage guestvol vmgroup vm add --vm-list=Photon1,Photon2,Photon3 --name=Product1Dev
 vmgroup vm add succeeded
 
-#/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup vm add --vm-list=Photon4,Photon5,Photon6 --name=Product1Test
+#esxcli storage guestvol vmgroup vm add --vm-list=Photon4,Photon5,Photon6 --name=Product1Test
 vmgroup vm add succeeded
 
-#/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+#esxcli storage guestvol vmgroup ls
 Uuid                                  Name          Description  Default_datastore  VM_list
 ------------------------------------  ------------  -----------  -----------------  -----------------------
 ac4b7167-94b3-470e-b932-5b32f2bfa273  Product1Dev                datastore3         Photon1,Photon2,Photon3
@@ -97,22 +97,22 @@ f15c1f6d-5df5-4a00-8f20-77c8e7a7af11  Product1Test               datastore3     
 Lets limit dev team to create volumes of total 20 Gb each not exceeding size of 1 GB. Similarly for QA team, lets put restriction of total 40 GB consumption with each volume size not exceeding 1 GB.
 
 ```
-[root@sc-rdops-vm17-dhcp-3-236:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access set --name=Product1Dev --datastore=datastore3  --volume-maxsize=1GB --volume-totalsize=20GB
+[root@sc-rdops-vm17-dhcp-3-236:~] esxcli storage guestvol vmgroup access set --name=Product1Dev --datastore=datastore3  --volume-maxsize=1GB --volume-totalsize=20GB
 vmgroup access set succeeded
 
-[root@sc-rdops-vm17-dhcp-3-236:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access set --name=Product1Test --datastore=datastore3  --volume-maxsize=1GB --volume-totalsize=40GB
+[root@sc-rdops-vm17-dhcp-3-236:~] esxcli storage guestvol vmgroup access set --name=Product1Test --datastore=datastore3  --volume-maxsize=1GB --volume-totalsize=40GB
 vmgroup access set succeeded
 
 ```
 Lets verify that storage restrictions have been set properly.
 
 ```
-[root@sc-rdops-vm17-dhcp-3-236:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=Product1Dev
+[root@sc-rdops-vm17-dhcp-3-236:~] esxcli storage guestvol vmgroup access ls --name=Product1Dev
 Datastore     Allow_create  Max_volume_size  Total_size
 ------------  ------------  ---------------  ----------
 datastore3    True          1.00GB           20.00GB
 
-[root@sc-rdops-vm17-dhcp-3-236:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=Product1Test
+[root@sc-rdops-vm17-dhcp-3-236:~] esxcli storage guestvol vmgroup access ls --name=Product1Test
 Datastore     Allow_create  Max_volume_size  Total_size
 ------------  ------------  ---------------  ----------
 datastore3    True          1.00GB           40.00GB

--- a/docs/user-guide/admin-cli.md
+++ b/docs/user-guide/admin-cli.md
@@ -10,57 +10,33 @@ volume service to create and delete virtual disks (VMDKs), as well as mounts the
 volumes. These virtual disks may live on any datastore accessible to the ESXi host and are managed
 by the Docker user via the Docker CLI. However, the Docker CLI is limited in what visibility it can
 provide to the user. Furthermore, it is desirable that an administrator be able to get a global view
-of all virtual disks created and in use on the host.  For these reasons, an admin CLI has been
-created that runs on the ESXi host and that provides access to information not visible from the
+of all virtual disks created and in use on the host. For these reasons, an admin CLI is provided through
+esxcli that runs on the ESXi host and that provides access to information not visible from the
 Docker CLI.
 
 The admin CLI also enables ESX admins to implement access control and basic storage quotas.
 
-Admin CLI is located at `/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py`. It supports `--help`  at
-every command and sub-command. e.g.
+Admin CLI commandset as documented below is located under namespace `esxcli storage guestvol`. It supports `--help`  at
+every command and sub-command.
+
+The entire commandset is also available for use with `/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py `.
+You need to make use of `/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py` instead of `esxcli storage guestvol`.
 
 **NOTE** Access control is not supported for Stateless ESXi , as the code relies on Authorization Config DB (aka "Config DB"), or symlink to the Confg DB, being in /etc/vmware/vmdksops/auth-db.
 
 ```
-[root@localhost:~] alias vmdkops_admin=/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py
-[root@localhost:~] vmdkops_admin --help
-usage: vmdkops_admin.py [-h] {volume,policy,status,config,vmgroup} ...
+[root@localhost:~] esxcli storage guestvol --help
+Usage: esxcli storage guestvol {cmd} [cmd options]
 
-vSphere Docker Volume Service admin CLI
+Available Namespaces:
+  vmgroup               Administer and monitor volume access control
+  config                Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]
+  policy                Configure and display storage policy information
+  volume                Manage vDVS volumes
 
-optional arguments:
-  -h, --help            show this help message and exit
-
-Manage VMDK-based Volumes for Docker:
-
-  {volume,policy,status,config,vmgroup}
-                        action
-    volume              Manipulate volumes
-    policy              Configure and display storage policy information
-    status              Show the status of the vmdk_ops service
-    config              Init and manage Config DB which enables quotas and
-                        access control
-    vmgroup            Administer and monitor volume access control
-[root@localhost:~] vmdkops_admin volume --help
-usage: vmdkops_admin.py volume [-h] {set,ls} ...
-
-optional arguments:
-  -h, --help  show this help message and exit
-
-Manipulate volumes:
-
-  {set,ls}    action
-    set       Edit settings for a given volume
-    ls        List volumes
+Available Commands:
+  status                Status of vdvs service
 ```
-
-It also prompts for available choices, e.g.
-```
-[root@localhost:~] vmdkops_admin volume hm
-usage: vmdkops_admin.py volume [-h] {set,ls} ...
-vmdkops_admin.py volume: error: invalid choice: 'hm' (choose from 'set', 'ls')
-```
-
 
 The remainder of this document will describe each admin CLI command and provide examples
 of their usage.
@@ -71,27 +47,24 @@ vmgroups allow placing access control restrictions on all Docker storage request
 
 ### Help
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup -h
-usage: vmdkops_admin.py vmgroup [-h] {create,vm,update,access,ls,rm} ...
+[root@localhost:~] esxcli storage guestvol vmgroup --help
+Usage: esxcli storage guestvol vmgroup {cmd} [cmd options]
 
-positional arguments:
-  {create,vm,update,access,ls,rm}
-    create              Create a new vmgroup
-    vm                  Add, removes and lists VMs in a vmgroup
-    update              Update an existing vmgroup
-    access              Add or remove Datastore access and quotas for a vm-
-                        group
-    ls                  List vmgroups and the VMs they are applied to
-    rm                  Delete a vmgroup
+Available Namespaces:
+  access                Add or remove Datastore access and quotas for a vmgroup
+  vm                    Add, removes, replaces and lists VMs in a vmgroup
 
-optional arguments:
-  -h, --help            show this help message and exit
+Available Commands:
+  create                Create a new vmgroup
+  ls                    List vmgroups and the VMs they are applied to
+  rm                    Delete a vmgroup
+  update                Update a vmgroup
 ```
 
 ### Create
 A vmgroup named "_DEFAULT" will be created automatically post install.
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+[root@localhost:~] esxcli storage guestvol vmgroup ls
 Uuid                                  Name      Description                Default_datastore  VM_list
 ------------------------------------  --------  -------------------------  -----------------  -------
 11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS
@@ -101,11 +74,11 @@ The "Default_datastore" field is set to "_VM_DS" for "_DEFAULT" vmgroup. Any vol
 
 When configuration is initialized with 'config init', the access to _ALL_DS and _VM_DS for all VMs is automatically enabled.
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=_DEFAULT
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=_DEFAULT
 Datastore  Allow_create  Max_volume_size  Total_size
 ---------  ------------  ---------------  ----------
-_ALL_DS   True          Unset            Unset
-_VM_DS    True          Unset            Unset
+_ALL_DS    True          Unset            Unset
+_VM_DS     True          Unset            Unset
 ```
 
 Creates a new named vmgroup and optionally assigns VMs. Valid vmgroup name is only allowed to be "[a-zA-Z0-9_][a-zA-Z0-9_.-]*"
@@ -119,47 +92,40 @@ Users can modify this privilege using `vmgroup access` subcommands.
 
 Sample:
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=vmgroup1 --default-datastore=datastore1
+[root@localhost:~] esxcli storage guestvol vmgroup create --name=vmgroup1 --default-datastore=vsanDatastore
 vmgroup 'vmgroup1' is created. Do not forget to run 'vmgroup vm add' to add vm to vmgroup.
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+[root@localhost:~] esxcli storage guestvol vmgroup ls
 Uuid                                  Name      Description                Default_datastore  VM_list
 ------------------------------------  --------  -------------------------  -----------------  -------
 11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS
-9de84179-6894-44ad-b444-470e8619a5ed  vmgroup1                             datastore1
+5d43cc7b-1e34-4b86-af2e-d595e86a1cfa  vmgroup1                             vsanDatastore
 
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
-Datastore   Allow_create  Max_volume_size  Total_size
-----------  ------------  ---------------  ----------
-datastore1  True          Unset            Unset
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup1
+Datastore      Allow_create  Max_volume_size  Total_size
+-------------  ------------  ---------------  ----------
+vsanDatastore  True          Unset            Unset
 ```
 
 The "default_datastore" can be also set to a special value "_VM_DS" during vmgroup create.
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
-Uuid                                  Name      Description                  Default_datastore  VM_list
-------------------------------------  --------  ---------------------------  -----------------  -------
-11111111-1111-1111-1111-111111111111  _DEFAULT  This is the default vmgroup  _VM_DS
+[root@localhost:~] esxcli storage guestvol vmgroup create --name=vmgroup2 --default-datastore="_VM_DS"
+vmgroup 'vmgroup2' is created. Do not forget to run 'vmgroup vm add' to add vm to vmgroup.
+[root@localhost:~] esxcli storage guestvol vmgroup ls
+Uuid                                  Name      Description                Default_datastore  VM_list
+------------------------------------  --------  -------------------------  -----------------  -------
+11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS
+4aaee5c9-9778-4299-9eb9-4c59f20a519b  vmgroup2                             _VM_DS
 
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=vmgroup1 --default-datastore="_VM_DS"
-vmgroup 'vmgroup1' is created. Do not forget to run 'vmgroup vm add' to add vm to vmgroup.
-[root@localhost:~]
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
-Uuid                                  Name      Description                  Default_datastore  VM_list
-------------------------------------  --------  ---------------------------  -----------------  -------
-11111111-1111-1111-1111-111111111111  _DEFAULT  This is the default vmgroup  _VM_DS
-30545fdc-20e0-409a-8330-6ebe027fcc34  vmgroup1                               _VM_DS
-
-[root@localhost:~]
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup2
 Datastore  Allow_create  Max_volume_size  Total_size
 ---------  ------------  ---------------  ----------
-_VM_DS    True          Unset            Unset
+_VM_DS     True          Unset            Unset
 
 ```
 
 "Default_datastore" cannot be set to "_ALL_DS". An attempt to do so will generate an error"
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=vmgroup2 --default-datastore="_ALL_DS"
+[root@localhost:~] esxcli storage guestvol vmgroup create --name=vmgroup3 --default-datastore="_ALL_DS"
 Cannot use _ALL_DS as default datastore. Please use specific datastore name or _VM_DS special datastore
 ```
 
@@ -167,54 +133,51 @@ The vmgroup to VM association can be done at create time.
 
 Sample:
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=vmgroup1 --default-datastore=datastore1 --vm-list=photon7
+[root@localhost:~] esxcli storage guestvol vmgroup create --name=vmgroup1 --default-datastore=vsanDatastore --vm-list=ubuntu-VM0.0
 vmgroup 'vmgroup1' is created. Do not forget to run 'vmgroup vm add' to add vm to vmgroup.
 
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+[root@localhost:~] esxcli storage guestvol vmgroup ls
 Uuid                                  Name      Description                Default_datastore  VM_list
-------------------------------------  --------  -------------------------  -----------------  -------
+------------------------------------  --------  -------------------------  -----------------  ------------
 11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS
-04423382-efa4-4525-b0a6-16b98ce38f0f  vmgroup1                             datastore1         photon7
+f68c315d-2690-4b63-94c4-f0db09ad458f  vmgroup1                             vsanDatastore      ubuntu-VM0.0
 
 ```
 
 #### Help
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create -h
-usage: vmdkops_admin.py vmgroup create [-h] --name NAME --default-datastore
-                                       DEFAULT_DATASTORE
-                                       [--description DESCRIPTION]
-                                       [--vm-list vm1, vm2, ...]
+[root@localhost:~] esxcli storage guestvol vmgroup create --help
+Usage: esxcli storage guestvol vmgroup create [cmd options]
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --name NAME           The name of the vmgroup
-  --default-datastore DEFAULT_DATASTORE
-                        Datastore to be used by default for volumes placement
-  --description DESCRIPTION
-                        The description of the vmgroup
-  --vm-list vm1, vm2, ...
-                        A list of VM names to place in this vmgroup
+Description:
+  create                Create a new vmgroup
+
+Cmd options:
+  --default-datastore=<str>
+                        Datastore to be used by default for volumes placement (required)
+  --description=<str>   The description of the vmgroup
+  --name=<str>          The name of the vmgroup (required)
+  --vm-list=<str>       A list of VM names to place in this vmgroup
 
 ```
 ### List
 List existing vmgroups, the datastores vmgroups have access to and the VMs assigned.
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+[root@localhost:~] esxcli storage guestvol vmgroup ls
 Uuid                                  Name      Description                Default_datastore  VM_list
-------------------------------------  --------  -------------------------  -----------------  -------
+------------------------------------  --------  -------------------------  -----------------  ------------
 11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS
-04423382-efa4-4525-b0a6-16b98ce38f0f  vmgroup1                             datastore1         photon7
+f68c315d-2690-4b63-94c4-f0db09ad458f  vmgroup1                             vsanDatastore      ubuntu-VM0.0
 
 ```
 
 #### Help
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls -h
-usage: vmdkops_admin.py vmgroup ls [-h]
+[root@localhost:~] esxcli storage guestvol vmgroup ls --help
+Usage: esxcli storage guestvol vmgroup ls [cmd options]
 
-optional arguments:
-  -h, --help  show this help message and exit
+Description:
+  ls                    List vmgroups and the VMs they are applied to
 ```
 
 ### Update
@@ -223,51 +186,48 @@ Update existing vmgroup. This command allows to update "Description" and "Defaul
 After changing the "default_datastore" for a vmgroup, a full access privilege to the new "default_datastore" will be created automatically, and the existing access privilege to old "default_datastore" will remain. User can remove the access privilege to old "default_datastore" if not needed using `vmgroup access rm` subcommands.
 Sample:
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+[root@localhost:~] esxcli storage guestvol vmgroup ls
 Uuid                                  Name      Description                Default_datastore  VM_list
-------------------------------------  --------  -------------------------  -----------------  -------
+------------------------------------  --------  -------------------------  -----------------  ------------
 11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS
-0767f5f8-73de-4382-8c38-1935bb636ef4  vmgroup1                             datastore1         photon7
+f68c315d-2690-4b63-94c4-f0db09ad458f  vmgroup1                             vsanDatastore      ubuntu-VM0.0
 
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
-Datastore   Allow_create  Max_volume_size  Total_size
-----------  ------------  ---------------  ----------
-datastore1  True          Unset            Unset
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup1
+Datastore      Allow_create  Max_volume_size  Total_size
+-------------  ------------  ---------------  ----------
+vsanDatastore  True          Unset            Unset
 
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup update --name=vmgroup1 --description="New description of vmgroup1" --new-name=new-vmgroup1 --default-datastore=datastore2
+[root@localhost:~] esxcli storage guestvol vmgroup update --name=vmgroup1 --description="New description of vmgroup1" --new-name=new-vmgroup1 --defau
+lt-datastore=sharedVmfs-0
 vmgroup modify succeeded
 
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+[root@localhost:~] esxcli storage guestvol vmgroup ls
 Uuid                                  Name          Description                  Default_datastore  VM_list
-------------------------------------  ------------  ---------------------------  -----------------  -------
+------------------------------------  ------------  ---------------------------  -----------------  ------------
 11111111-1111-1111-1111-111111111111  _DEFAULT      This is a default vmgroup    _VM_DS
-0767f5f8-73de-4382-8c38-1935bb636ef4  new-vmgroup1  New description of vmgroup1  datastore2         photon7
-
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=new-vmgroup1
-Datastore   Allow_create  Max_volume_size  Total_size
-----------  ------------  ---------------  ----------
-datastore1  True          Unset            Unset
-datastore2  True          Unset            Unset
+f68c315d-2690-4b63-94c4-f0db09ad458f  new-vmgroup1  New description of vmgroup1  sharedVmfs-0       ubuntu-VM0.0
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=new-vmgroup1
+Datastore      Allow_create  Max_volume_size  Total_size
+-------------  ------------  ---------------  ----------
+sharedVmfs-0   True          Unset            Unset
+vsanDatastore  True          Unset            Unset
 ```
 Please use the test suggested above, for "create".
 
 #### Help
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup  update -h
-usage: vmdkops_admin.py vmgroup update [-h] --name NAME
-                                        [--default-datastore DEFAULT_DATASTORE]
-                                        [--description DESCRIPTION]
-                                        [--new-name NEW_NAME]
+[root@localhost:~] esxcli storage guestvol vmgroup update --help
+Usage: esxcli storage guestvol vmgroup update [cmd options]
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --name NAME           The name of the vmgroup
-  --default-datastore DEFAULT_DATASTORE
-                        The name of the datastore to be used by default for
-                        volumes placement
-  --description DESCRIPTION
-                        The new description of the vmgroup
-  --new-name NEW_NAME   The new name of the vmgroup
+Description:
+  update                Update a vmgroup
+
+Cmd options:
+  --default-datastore=<str>
+                        Datastore to be used by default for volumes placement
+  --description=<str>   The new description of the vmgroup
+  --name=<str>          The name of the vmgroup (required)
+  --new-name=<str>      The new name of the vmgroup
 
 ```
 
@@ -276,14 +236,13 @@ Remove a vmgroup, optionally all volumes for a vmgroup can be removed as well.
 
 Sample:
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup rm --name=vmgroup1 --remove-volumes
-All Volumes will be removed
-vmgroup rm succeeded
+[root@localhost:~] esxcli storage guestvol vmgroup rm --name=new-vmgroup1 --remove-volumes
+All Volumes will be removed. vmgroup rm succeeded
 
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
-Uuid                                  Name      Description                 Default_datastore  VM_list
-------------------------------------  --------  --------------------------  -----------------  -------
-11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup
+[root@localhost:~] esxcli storage guestvol vmgroup ls
+Uuid                                  Name      Description                Default_datastore  VM_list
+------------------------------------  --------  -------------------------  -----------------  -------
+11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS
 ```
 
 In MultiNode mode, VMs from different hosts can be a part of a vmgroup.
@@ -293,15 +252,15 @@ on the same host on which the VM resides.
 Then remove the vmgroup.
 #### Help
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup rm -h
-usage: vmdkops_admin.py vmgroup rm [-h] --name NAME [--remove-volumes]
+[root@localhost:~] esxcli storage guestvol vmgroup rm --help
+Usage: esxcli storage guestvol vmgroup rm [cmd options]
 
-optional arguments:
-  -h, --help        show this help message and exit
-  --name NAME       The name of the vmgroup
-  --remove-volumes  BE CAREFUL: Removes this vmgroup volumes when removing a
-                    vmgroup
+Description:
+  rm                    Delete a vmgroup
 
+Cmd options:
+  --name=<str>          The name of the vmgroup (required)
+  --remove-volumes      BE CAREFUL: Removes this vmgroup volumes when removing a vmgroup
 ```
 
 ### Virtual Machine
@@ -310,53 +269,50 @@ optional arguments:
 Add a VM to a vmgroup. A VM can only access the datastores for the vmgroup it is assigned to.
 VMs can be assigned to only one vmgroup at a time.
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
-Uuid                                  Name       Description                 Default_datastore  VM_list
-------------------------------------  ---------  --------------------------  -----------------  --------
-11111111-1111-1111-1111-111111111111  _DEFAULT   This is a default vmgroup
-6d810c66-ffc7-47c8-8870-72114f86c2cf  vmgroup1                                                 photon6
-
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup vm add --name=vmgroup1 --vm-list=photon7
+[root@localhost:~] esxcli storage guestvol vmgroup vm add --name=vmgroup1 --vm-list=ubuntu-VM1.0
 vmgroup vm add succeeded
+[root@localhost:~] esxcli storage guestvol vmgroup ls
+Uuid                                  Name      Description                Default_datastore  VM_list
+------------------------------------  --------  -------------------------  -----------------  -------------------------
+11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS
+443583f6-afd0-4fa7-bfa7-9116384431f3  vmgroup1                             vsanDatastore      ubuntu-VM0.0,ubuntu-VM1.0
 
 ```
 
 #### List
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup vm ls --name=vmgroup1
+[root@localhost:~] esxcli storage guestvol vmgroup vm ls --name vmgroup1
 Uuid                                  Name
-------------------------------------  --------
-564d5849-b135-1259-cc73-d2d3aa1d9b8c  photon6
-564d99a2-4097-9966-579f-3dc4082b10c9  photon7
+------------------------------------  ------------
+564d9bc4-bfd6-b648-935b-6353fb6dc1e7  ubuntu-VM0.0
+564d171f-2de0-95b7-f9b8-9d9c42841b7a  ubuntu-VM1.0
 ```
 
 #### Remove
 Remove a VM from a vmgroup's list of VMs. VM will no longer be able to access the volumes created for the vmgroup.
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup vm rm --name=vmgroup1 --vm-list=photon7
+[root@localhost:~] esxcli storage guestvol vmgroup vm rm --name=vmgroup1 --vm-list=ubuntu-VM1.0
 vmgroup vm rm succeeded
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup vm ls --name=vmgroup1
+[root@localhost:~] esxcli storage guestvol vmgroup vm ls --name vmgroup1
 Uuid                                  Name
-------------------------------------  --------
-564d5849-b135-1259-cc73-d2d3aa1d9b8c  photon6
+------------------------------------  ------------
+564d9bc4-bfd6-b648-935b-6353fb6dc1e7  ubuntu-VM0.0
 
 ```
 
 ### Replace
 Replace VMs from a vmgroup's list of VMs. VMs which are replaced will no longer be able to access the volumes created for the vmgroup.
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup vm ls --name=vmgroup1
+[root@localhost:~] esxcli storage guestvol vmgroup vm ls --name vmgroup1
 Uuid                                  Name
-------------------------------------  --------
-564d5849-b135-1259-cc73-d2d3aa1d9b8c  photon6
-
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup vm replace --name=vmgroup1 --vm-list=photon7
+------------------------------------  ------------
+564d9bc4-bfd6-b648-935b-6353fb6dc1e7  ubuntu-VM0.0
+[root@localhost:~] esxcli storage guestvol vmgroup vm replace --name=vmgroup1 --vm-list=ubuntu-VM1.0
 vmgroup vm replace succeeded
-
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup vm ls --name=vmgroup1
+[root@localhost:~] esxcli storage guestvol vmgroup vm ls --name vmgroup1
 Uuid                                  Name
-------------------------------------  --------
-564d99a2-4097-9966-579f-3dc4082b10c9  photon7
+------------------------------------  ------------
+564d171f-2de0-95b7-f9b8-9d9c42841b7a  ubuntu-VM1.0
 ```
 
 Note: If the VMs have volumes attached (containers running), their membership change i.e. changing the vmgroup to which
@@ -368,18 +324,14 @@ To do so:
 
 #### Help
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup vm -h
-usage: vmdkops_admin.py vmgroup vm [-h] {rm,add,ls,replace} ...
+[root@localhost:~] esxcli storage guestvol vmgroup vm --help
+Usage: esxcli storage guestvol vmgroup vm {cmd} [cmd options]
 
-positional arguments:
-  {rm,add,ls,replace}
-    rm                 Remove VM(s) from a vmgroup
-    add                Add a VM(s) to a vmgroup
-    ls                 list VMs in a vmgroup
-    replace            Replace VM(s) for a vmgroup
-
-optional arguments:
-  -h, --help           show this help message and exit
+Available Commands:
+  add                   Add VM(s) to a vmgroup
+  ls                    list VMs in a vmgroup
+  replace               Replace VM(s) for a vmgroup
+  rm                    Remove VM(s) from a vmgroup
 
 ```
 
@@ -389,18 +341,14 @@ This includes ability to grant privileges & set resource consumption limits for 
 
 #### Help
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access -h
-usage: vmdkops_admin.py vmgroup access [-h] {rm,add,set,ls} ...
+[root@localhost:~] esxcli storage guestvol vmgroup access --help
+Usage: esxcli storage guestvol vmgroup access {cmd} [cmd options]
 
-positional arguments:
-  {rm,add,set,ls}
-    rm             Remove all access to a datastore for a vmgroup
-    add            Add a datastore access for a vmgroup
-    set            Modify datastore access for a vmgroup
-    ls             List all access info for a vmgroup
-
-optional arguments:
-  -h, --help       show this help message and exit
+Available Commands:
+  add                   Add a datastore access for a vmgroup
+  ls                    List access for a vmgroup
+  rm                    Remove datastore access for a vmgroup
+  set                   Modify datastore access for a vmgroup
 
 ```
 
@@ -412,100 +360,89 @@ When DS is set to _ALL_DS, access to any datastore which has not been granted ac
 Sample:
 
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
-Datastore   Allow_create  Max_volume_size  Total_size
-----------  ------------  ---------------  ----------
-datastore1  True          Unset            Unset
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup1
+Datastore      Allow_create  Max_volume_size  Total_size
+-------------  ------------  ---------------  ----------
+vsanDatastore  True          Unset            Unset
 
-[root@localhost:~]
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=datastore2  --volume-maxsize=500MB --volume-totalsize=1GB
+[root@localhost:~] esxcli storage guestvol vmgroup access add --name=vmgroup1 --datastore=sharedVmfs-0  --volume-maxsize=500MB --volume-totalsize=1GB
 vmgroup access add succeeded
-[root@localhost:~]
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
-Datastore   Allow_create  Max_volume_size  Total_size
-----------  ------------  ---------------  ----------
-datastore1  True          Unset            Unset
-datastore2  False         500.00MB         1.00GB
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup1
+Datastore      Allow_create  Max_volume_size  Total_size
+-------------  ------------  ---------------  ----------
+sharedVmfs-0   False         500.00MB         1.00GB
+vsanDatastore  True          Unset            Unset
 
 ```
 
 By default no "allow_create" right is given
 
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=datastore2  --volume-maxsize=500MB --volume-totalsize=1GB
+[root@localhost:~] esxcli storage guestvol vmgroup access add --name=vmgroup1 --datastore=sharedVmfs-0  --volume-maxsize=500MB --volume-totalsize=1GB
 vmgroup access add succeeded
-[root@localhost:~]
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
-Datastore   Allow_create  Max_volume_size  Total_size
-----------  ------------  ---------------  ----------
-datastore1  True          Unset            Unset
-datastore2  False         500.00MB         1.00GB
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup1
+Datastore      Allow_create  Max_volume_size  Total_size
+-------------  ------------  ---------------  ----------
+sharedVmfs-0   False         500.00MB         1.00GB
+vsanDatastore  True          Unset            Unset
 ```
 
 "allow_create" right is given when you run the command with "--allow-create" flag.
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=datastore2  --volume-maxsize=500MB --volume-totalsize=1GB --allow-create
+[root@localhost:~] esxcli storage guestvol vmgroup access add --name=vmgroup1 --datastore=sharedVmfs-0  --volume-maxsize=500MB --volume-totalsize=1GB
+ --allow-create
 vmgroup access add succeeded
-[root@localhost:~]
-[root@localhost:~]
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
-Datastore   Allow_create  Max_volume_size  Total_size
-----------  ------------  ---------------  ----------
-datastore1  True          Unset            Unset
-datastore2  True          500.00MB         1.00GB
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup1
+Datastore      Allow_create  Max_volume_size  Total_size
+-------------  ------------  ---------------  ----------
+sharedVmfs-0   True          500.00MB         1.00GB
+vsanDatastore  True          Unset            Unset
 ```
 For _VM_DS and _ALL_DS special DS names, "--volume-totalsize" can also be set.
 
 When "--volume-totalsize" is set for "_VM_DS", it means the total volume size on datastore where VM lives cannot exceed the value specified by "--volume-totalsize". For example, if "--volume-totalsize" is set to "1GB" for "_VM_DS" and VM lives in "datastore2", where the total volume size is already 800MB and user tries to create another volume with 500MB will not be allowed. However, if the VM is moved to "datastore3", where the total volume size is 500MB and user tries to create another volume with 500MB will be allowed.
 
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=_VM_DS  --volume-maxsize=500MB --volume-totalsize=1GB --allow-create
+[root@localhost:~] esxcli storage guestvol vmgroup access add --name=vmgroup1 --datastore=_VM_DS  --volume-maxsize=500MB --volume-totalsize=1GB --all
+ow-create
 vmgroup access add succeeded
-
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
-Datastore     Allow_create  Max_volume_size  Total_size
-------------  ------------  ---------------  ----------
-datastore1    True          Unset            Unset
-_VM_DS        True          500.00MB         1.00GB
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup1
+Datastore      Allow_create  Max_volume_size  Total_size
+-------------  ------------  ---------------  ----------
+vsanDatastore  True          Unset            Unset
+_VM_DS         True          500.00MB         1.00GB
 ```
 
 When "--volume-totalsize" is set for "_ALL_DS", it means the total volume size on any datastore which has not been given access to explicitly cannot exceed the value specified by "--volume-totalsize". In the following example, "vmgroup1" has been given access to "datastore1" and "_ALL_DS". The "Total_size" for "datastore1" is "Unset", which means no limit. The "Total_size" for "_ALL_DS" is "1GB". So for "datastore1", there is no limit on the total volume size. However, for any datastore other than "datastore1", the total volume size on that datastore cannot exceed 1GB.
 
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add --name=vmgroup1 --datastore=_ALL_DS  --volume-maxsize=500MB --volume-totalsize=1GB --allow-create
+[root@localhost:~] esxcli storage guestvol vmgroup access add --name=vmgroup1 --datastore=_ALL_DS  --volume-maxsize=500MB --volume-totalsize=1GB --al
+low-create
 vmgroup access add succeeded
-
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
-Datastore     Allow_create  Max_volume_size  Total_size
-------------  ------------  ---------------  ----------
-datastore1    True          Unset            Unset
-_ALL_DS       True          500.00MB         1.00GB
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup1
+Datastore      Allow_create  Max_volume_size  Total_size
+-------------  ------------  ---------------  ----------
+vsanDatastore  True          Unset            Unset
+_ALL_DS        True          500.00MB         1.00GB
 ```
 
 
 ##### Help
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access add -h
-usage: vmdkops_admin.py vmgroup access add [-h]
-                                           [--volume-totalsize Num{MB,GB,TB} - e.g. 2TB]
-                                           --name NAME
-                                           [--volume-maxsize Num{MB,GB,TB} - e.g. 2TB]
-                                           [--allow-create] --datastore
-                                           DATASTORE
+[root@localhost:~] esxcli storage guestvol vmgroup access add --help
+Usage: esxcli storage guestvol vmgroup access add [cmd options]
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --volume-totalsize Num{MB,GB,TB} - e.g. 2TB
-                        Maximum total size of all volume that can be created
-                        on the datastore for this vmgroup
-  --name NAME           The name of the vmgroup
-  --volume-maxsize Num{MB,GB,TB} - e.g. 2TB
-                        Maximum size of the volume that can be created
+Description:
+  add                   Add a datastore access for a vmgroup
+
+Cmd options:
   --allow-create        Allow create and delete on datastore if set
-  --datastore DATASTORE
-                        Datastore which access is controlled
-
-
+  --datastore=<str>     Datastore name (required)
+  --name=<str>          The name of the vmgroup (required)
+  --volume-maxsize=<str>
+                        Maximum size of the volume that can be created
+  --volume-totalsize=<str>
+                        Maximum total size of all volume that can be created on the datastore for this vmgroup
 ```
 
 #### List
@@ -516,65 +453,64 @@ When displaying the result keep in mind:
 - For capacity Unset indicates no limits
 
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
-Datastore   Allow_create  Max_volume_size  Total_size
-----------  ------------  ---------------  ----------
-datastore1  True          Unset            Unset
-datastore2  True          500.00MB         1.00GB
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup1
+Datastore      Allow_create  Max_volume_size  Total_size
+-------------  ------------  ---------------  ----------
+vsanDatastore  True          Unset            Unset
+_ALL_DS        True          500.00MB         1.00GB
 ```
 
 ##### Help
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls -h
-usage: vmdkops_admin.py vmgroup access ls [-h] --name NAME
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --help
+Usage: esxcli storage guestvol vmgroup access ls [cmd options]
 
-optional arguments:
-  -h, --help   show this help message and exit
-  --name NAME  The name of the vmgroup
+Description:
+  ls                    List access for a vmgroup
 
+Cmd options:
+  --name=<str>          Vmgroup name (required)
 ```
 
 #### Remove
 Remove access to a datastore for a vmgroup.
 Removing of access privilege to "default_datastore" is not suported
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+[root@localhost:~] esxcli storage guestvol vmgroup ls
 Uuid                                  Name      Description                Default_datastore  VM_list
-------------------------------------  --------  -------------------------  -----------------  -------
+------------------------------------  --------  -------------------------  -----------------  ------------
 11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup  _VM_DS
-2a97fef4-30cd-4a50-bf31-3dbc7d130be2  vmgroup1                             datastore1         photon7
+443583f6-afd0-4fa7-bfa7-9116384431f3  vmgroup1                             vsanDatastore      ubuntu-VM1.0
 
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
-Datastore   Allow_create  Max_volume_size  Total_size
-----------  ------------  ---------------  ----------
-datastore1  True          Unset            Unset
-datastore2  True          500.00MB         1.00GB
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup1
+Datastore      Allow_create  Max_volume_size  Total_size
+-------------  ------------  ---------------  ----------
+vsanDatastore  True          Unset            Unset
+_ALL_DS        True          500.00MB         1.00GB
 
 [root@localhost:~]
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access rm --name=vmgroup1 --datastore=datastore1
-Removing of access privilege to "default_datastore" is not supported
-[root@localhost:~]
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access rm --name=vmgroup1 --datastore=datastore2
+[root@localhost:~] esxcli storage guestvol vmgroup access rm --name=vmgroup1 --datastore=vsanDatastore
+Removing of access privilege to 'default_datastore' is not supported
+[root@localhost:~] esxcli storage guestvol vmgroup access rm --name=vmgroup1 --datastore=_ALL_DS
 vmgroup access rm succeeded
-[root@localhost:~]
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
-Datastore   Allow_create  Max_volume_size  Total_size
-----------  ------------  ---------------  ----------
-datastore1  True          Unset            Unset
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup1
+Datastore      Allow_create  Max_volume_size  Total_size
+-------------  ------------  ---------------  ----------
+vsanDatastore  True          Unset            Unset
 
 ```
 
 ##### Help
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup  access rm -h
-usage: vmdkops_admin.py vmgroup access rm [-h] --name NAME --datastore
-                                           DATASTORE
+[root@localhost:~] esxcli storage guestvol vmgroup  access rm --help
+Usage: esxcli storage guestvol vmgroup access rm [cmd options]
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --name NAME           The name of the vmgroup
-  --datastore DATASTORE
-                        Datstore which access is controlled
+Description:
+  rm                    Remove datastore access for a vmgroup
+
+Cmd options:
+  --datastore=<str>     Datastore name (required)
+  --name=<str>          The name of the vmgroup (required)
 
 ```
 
@@ -584,26 +520,21 @@ Set command allows to change the existing access control in place for a vmgroup.
 Sample:
 
 ```shell
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
-Datastore   Allow_create  Max_volume_size  Total_size
-----------  ------------  ---------------  ----------
-datastore1  False         Unset            Unset
-_ALL_DS     True          500.00MB         Unset
-
-[root@localhost:~]
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access set --name=vmgroup1 --datastore=datastore1 --allow-create=True  --volume-maxsize=1000MB --volume-totalsize=2GB
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup1
+Datastore      Allow_create  Max_volume_size  Total_size
+-------------  ------------  ---------------  ----------
+vsanDatastore  True          Unset            Unset
+[root@localhost:~] esxcli storage guestvol vmgroup access set --name=vmgroup1 --datastore=vsanDatastore --allow-create=True  --volume-maxsize=1000MB
 vmgroup access set succeeded
-[root@localhost:~]
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
-Datastore   Allow_create  Max_volume_size  Total_size
-----------  ------------  ---------------  ----------
-datastore1  True          1000.00MB        2.00GB
-_ALL_DS     True          500.00MB         Unset
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup1
+Datastore      Allow_create  Max_volume_size  Total_size
+-------------  ------------  ---------------  ----------
+vsanDatastore  True          1000.00MB        Unset
 ```
 
 "--volume-totalsize" can also be set to the value other than unlimit when add privilege for special value "_VM_DS" and "_ALL_DS".
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup1
 Datastore   Allow_create  Max_volume_size  Total_size
 ----------  ------------  ---------------  ----------
 datastore1  True          1000.00MB        2.00GB
@@ -611,46 +542,35 @@ _ALL_DS     True          500.00MB         Unset
 _VM_DS      True          Unset            Unset
 
 
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access set --name=vmgroup1 --datastore=_VM_DS  --volume-maxsize=1GB --volume-totalsize=2GB
+[root@localhost:~] esxcli storage guestvol vmgroup access set --name=vmgroup1 --datastore=_VM_DS  --volume-maxsize=1GB --volume-totalsize=2GB
 vmgroup access set succeeded
-
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access set --name=vmgroup1 --datastore=_ALL_DS  --volume-maxsize=500MB --volume-totalsize=1GB
+[root@localhost:~] esxcli storage guestvol vmgroup access set --name=vmgroup1 --datastore=_ALL_DS  --volume-maxsize=500MB --volume-totalsize=1GB
 vmgroup access set succeeded
-
-
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access ls --name=vmgroup1
-Datastore   Allow_create  Max_volume_size  Total_size
-----------  ------------  ---------------  ----------
-datastore1  True          1000.00MB        2.00GB
-_ALL_DS     True          500.00MB         1.00GB
-_VM_DS      True          1.00GB           2.00GB
+[root@localhost:~] esxcli storage guestvol vmgroup access ls --name=vmgroup1
+Datastore      Allow_create  Max_volume_size  Total_size
+-------------  ------------  ---------------  ----------
+vsanDatastore  True          1000.00MB        Unset
+_ALL_DS        True          500.00MB         1.00GB
+_VM_DS         True          1.00GB           2.00GB
 
 ```
 
 ##### Help
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup access set -h
-usage: vmdkops_admin.py vmgroup access set [-h]
-                                            [--volume-totalsize Num{MB,GB,TB} - e.g. 2TB]
-                                            --name NAME
-                                            [--volume-maxsize Num{MB,GB,TB} - e.g. 2TB]
-                                            [--allow-create Value{True|False} - e.g. True]
-                                            --datastore DATASTORE
+[root@localhost:~] esxcli storage guestvol vmgroup access set --help
+Usage: esxcli storage guestvol vmgroup access set [cmd options]
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --volume-totalsize Num{MB,GB,TB} - e.g. 2TB
-                        Maximum total size of all volume that can be created
-                        on the datastore for this vmgroup
-  --name NAME           The name of the vmgroup
-  --volume-maxsize Num{MB,GB,TB} - e.g. 2TB
+Description:
+  set                   Modify datastore access for a vmgroup
+
+Cmd options:
+  --allow-create        Allow create and delete on datastore if set to True. This value can also be set to False by user.
+  --datastore=<str>     Datastore name (required)
+  --name=<str>          The name of the vmgroup (required)
+  --volume-maxsize=<str>
                         Maximum size of the volume that can be created
-  --allow-create Value{True|False} - e.g. True
-                        Allow create and delete on datastore if set to True;
-                        disallow create and delete on datastore if set to
-                        False
-  --datastore DATASTORE
-                        Datastore name
+  --volume-totalsize=<str>
+                        Maximum total size of all volume that can be created on the datastore for this vmgroup
 
 ```
 
@@ -658,27 +578,25 @@ optional arguments:
 
 #### Help
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py volume ls -h
-usage: vmdkops_admin.py volume ls [-h] [-c Col1,Col2,...]
+[root@localhost:~] esxcli storage guestvol volume ls --help
+Usage: esxcli storage guestvol volume ls [cmd options]
 
-optional arguments:
-  -h, --help        show this help message and exit
-  -c Col1,Col2,...  Display selected columns: Choices = ['volume',
-                    'datastore', 'created-by', 'created', 'attached-to',
-                    'policy', 'capacity', 'used']
+Description:
+  ls                    List volumes
+
+Cmd options:
+  --vmgroup=<str>       Displays volumes for a given vmgroup
 ```
 
 #### List All
 List all properties for all Docker volumes that exist on datastores accessible to the host.
 
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py volume ls
-Volume  Datastore   VMGroup   Capacity  Used  Filesystem  Policy  Disk Format  Attached-to  Access      Attach-as               Created By  Created Date
-------  ----------  ---------  --------  ----  ----------  ------  -----------  -----------  ----------  ----------------------  ----------  ------------------------
-vol1    datastore1  _DEFAULT   100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Sun Sep 11 21:36:13 2016
-vol12   datastore1  _DEFAULT   100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Sun Sep 11 22:29:39 2016
-vol1    datastore1  vmgroup1  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Sun Sep 11 22:48:13 2016
-vol2    datastore1  vmgroup1  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Sun Sep 11 22:48:23 2016
+[root@localhost:~] esxcli storage guestvol volume ls
+Volume  Datastore     VMGroup   Capacity  Used  Filesystem  Policy  Disk Format  Attached-to  Access      Attach-as               Created By    Created Date
+------  ------------  --------  --------  ----  ----------  ------  -----------  -----------  ----------  ----------------------  ------------  ------------------------
+vol1    sharedVmfs-0  _DEFAULT  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  ubuntu-VM0.0  Mon Aug 21 04:36:08 2017
+vol2    sharedVmfs-0  _DEFAULT  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  ubuntu-VM0.0  Mon Aug 21 04:36:12 2017
 ```
 
 Note that the `Policy` column shows the named VSAN storage policy created with the same tool
@@ -688,29 +606,27 @@ policy and show up as `N/A'.
 Note that the `VMGroup` column shows the vmgroup by which the volume was created. If the vmgroup which created the volume has been removed, the `VMGroup` column shows up as 'N/A'. See the following example:
 
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py volume ls
-Volume  Datastore   VMGroup  Capacity  Used  Filesystem  Policy  Disk Format  Attached-to  Access      Attach-as               Created By  Created Date
-------  ----------  --------  --------  ----  ----------  ------  -----------  -----------  ----------  ----------------------  ----------  ------------------------
-vol1    datastore1  _DEFAULT  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Sun Sep 11 21:36:13 2016
-vol12   datastore1  _DEFAULT  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Sun Sep 11 22:29:39 2016
-vol1    datastore1  N/A       100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Sun Sep 11 22:48:13 2016
-vol2    datastore1  N/A       100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Sun Sep 11 22:48:23 2016
+[root@localhost:~] esxcli storage guestvol volume ls
+Volume  Datastore      VMGroup   Capacity  Used  Filesystem  Policy          Disk Format  Attached-to  Access      Attach-as               Created By    Created Date
+------  -------------  --------  --------  ----  ----------  --------------  -----------  -----------  ----------  ----------------------  ------------  ------------------------
+vol1    sharedVmfs-0   _DEFAULT  100MB     13MB  ext4        N/A             thin         detached     read-write  independent_persistent  ubuntu-VM0.0  Mon Aug 21 04:36:08 2017
+vol2    sharedVmfs-0   _DEFAULT  100MB     13MB  ext4        N/A             thin         detached     read-write  independent_persistent  ubuntu-VM0.0  Mon Aug 21 04:36:12 2017
+vol3    vsanDatastore  N/A       100MB     80MB  ext4        [VSAN default]  thin         detached     read-write  independent_persistent  ubuntu-VM1.0  Mon Aug 21 04:38:06 2017
+vol4    vsanDatastore  N/A       100MB     80MB  ext4        [VSAN default]  thin         detached     read-write  independent_persistent  ubuntu-VM1.0  Mon Aug 21 04:38:10 2017
 ```
 
-#### List selected columns
+#### List limited information about volumes
 
-Show only the selected columns.
-
+Only shows Volume, Capacity, Disk Format and Attached-to fields
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py volume ls -c volume,datastore,attached-to
-Volume     Datastore   Attached To VM
----------  ----------  --------------
-large-vol  datastore1  detached
-vol        datastore1  detached
+[root@localhost:~] esxcli storage guestvol volume shortls
+Volume  Capacity  Disk Format  Attached-to
+------  --------  -----------  -----------
+vol1    100MB     thin         detached
+vol2    100MB     thin         detached
+vol3    100MB     thin         detached
+vol4    100MB     thin         detached
 ```
-
-Note that the that the choices are given in a comma separated list with no spaces, and are shown in
-the help given above with `vmdkops_admin ls -h`.
 
 ### Set
 Modify attribute settings on a given volume. The volume is identified by its name, vmgroup_name which the volume belongs to and datastore,
@@ -719,7 +635,7 @@ The attributes to set/modify are specified as a comma separated list as "<attr1>
 a command line would look like this.
 
 ```bash
-$ vmdkops-admin set --volume=<volume@datastore> --vmgroup=<vmgroup_name> --options="<attr1>=<value>, <attr2>=<value>, ..."
+$ esxcli storage guestvol volume set --volume=<volume@datastore> --vmgroup=<vmgroup_name> --options="<attr1>=<value>, <attr2>=<value>, ..."
 ```
 
 The volume attributes are set and take effect only the next time the volume attached to a VM. The changes do not impact any VM
@@ -740,24 +656,22 @@ The container images themselves can be smaller as they share the libs and possib
 
 Example:
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py volume ls
-Volume  Datastore   VMGroup  Capacity  Used  Filesystem  Policy  Disk Format  Attached-to  Access      Attach-as               Created By  Created Date
-------  ----------  --------  --------  ----  ----------  ------  -----------  -----------  ----------  ----------------------  ----------  ------------------------
-vol1    datastore1  _DEFAULT  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Sun Sep 11 21:36:13 2016
-vol12   datastore1  _DEFAULT  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Sun Sep 11 22:29:39 2016
-vol1    datastore1  N/A       100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Sun Sep 11 22:48:13 2016
-vol2    datastore1  N/A       100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Sun Sep 11 22:48:23 2016
-
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py volume set --volume=vol1@datastore1 --vmgroup=_DEFAULT --options="access=read-only"
-Successfully updated settings for : vol1@datastore1
-
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py volume ls
-Volume  Datastore   VMGroup  Capacity  Used  Filesystem  Policy  Disk Format  Attached-to  Access      Attach-as               Created By  Created Date
-------  ----------  --------  --------  ----  ----------  ------  -----------  -----------  ----------  ----------------------  ----------  ------------------------
-vol1    datastore1  _DEFAULT  100MB     13MB  ext4        N/A     thin         detached     read-only   independent_persistent  photon-6    Sun Sep 11 21:36:13 2016
-vol12   datastore1  _DEFAULT  100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Sun Sep 11 22:29:39 2016
-vol1    datastore1  N/A       100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Sun Sep 11 22:48:13 2016
-vol2    datastore1  N/A       100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Sun Sep 11 22:48:23 2016
+[root@localhost:~] esxcli storage guestvol volume ls
+Volume  Datastore      VMGroup   Capacity  Used  Filesystem  Policy          Disk Format  Attached-to  Access      Attach-as               Created By    Created Date
+------  -------------  --------  --------  ----  ----------  --------------  -----------  -----------  ----------  ----------------------  ------------  ------------------------
+vol1    sharedVmfs-0   _DEFAULT  100MB     13MB  ext4        N/A             thin         detached     read-write  independent_persistent  ubuntu-VM0.0  Mon Aug 21 04:36:08 2017
+vol2    sharedVmfs-0   _DEFAULT  100MB     13MB  ext4        N/A             thin         detached     read-write  independent_persistent  ubuntu-VM0.0  Mon Aug 21 04:36:12 2017
+vol3    vsanDatastore  N/A       100MB     80MB  ext4        [VSAN default]  thin         detached     read-write  independent_persistent  ubuntu-VM1.0  Mon Aug 21 04:38:06 2017
+vol4    vsanDatastore  N/A       100MB     80MB  ext4        [VSAN default]  thin         detached     read-write  independent_persistent  ubuntu-VM1.0  Mon Aug 21 04:38:10 2017
+[root@localhost:~] esxcli storage guestvol volume set --volume=vol1@sharedVmfs-0 --vmgroup=_DEFAULT --options="access=read-only"
+Successfully updated settings for vol1@sharedVmfs-0
+[root@localhost:~] esxcli storage guestvol volume ls
+Volume  Datastore      VMGroup   Capacity  Used  Filesystem  Policy          Disk Format  Attached-to  Access      Attach-as               Created By    Created Date
+------  -------------  --------  --------  ----  ----------  --------------  -----------  -----------  ----------  ----------------------  ------------  ------------------------
+vol1    sharedVmfs-0   _DEFAULT  100MB     13MB  ext4        N/A             thin         detached     read-only   independent_persistent  ubuntu-VM0.0  Mon Aug 21 04:36:08 2017
+vol2    sharedVmfs-0   _DEFAULT  100MB     13MB  ext4        N/A             thin         detached     read-write  independent_persistent  ubuntu-VM0.0  Mon Aug 21 04:36:12 2017
+vol3    vsanDatastore  N/A       100MB     80MB  ext4        [VSAN default]  thin         detached     read-write  independent_persistent  ubuntu-VM1.0  Mon Aug 21 04:38:06 2017
+vol4    vsanDatastore  N/A       100MB     80MB  ext4        [VSAN default]  thin         detached     read-write  independent_persistent  ubuntu-VM1.0  Mon Aug 21 04:38:10 2017
 
 ```
 
@@ -768,19 +682,14 @@ Create, configure and show the VSAN policy names and their corresponding VSAN po
 
 #### Help
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py policy -h
-usage: vmdkops_admin.py policy [-h] {rm,create,ls,update} ...
+[root@localhost:~] esxcli storage guestvol policy --help
+Usage: esxcli storage guestvol policy {cmd} [cmd options]
 
-positional arguments:
-  {rm,create,ls,update}
-    rm                  Remove a storage policy
-    create              Create a storage policy
-    ls                  List storage policies and volumes using those policies
-    update              Update the definition of a storage policy and all VSAN
-                        objects using that policy
-
-optional arguments:
-  -h, --help            show this help message and exit
+Available Commands:
+  create                Create a storage policy
+  ls                    List storage policies and volumes using those policies
+  rm                    Remove a storage policy
+  update                Update the definition of a storage policy and all VSAN objects using that policy
 ```
 
 #### Create
@@ -788,7 +697,7 @@ optional arguments:
 Create a VSAN storage policy.
 
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py policy create --name some-policy --content '(("proportionalCapacity" i0)("hostFailuresToTolerate" i0))'
+[root@localhost:~] esxcli storage guestvol policy create --name some-policy --content '(("proportionalCapacity" i0)("hostFailuresToTolerate" i0))'
 Successfully created policy: some-policy
 ```
 
@@ -801,8 +710,8 @@ for storage policy options.
 List all VSAN storage policies.
 
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py policy ls
-Policy Name  Policy Content                                             Active
+[root@localhost:~] esxcli storage guestvol policy ls
+Policy Name  Policy Content                                              Active
 -----------  ----------------------------------------------------------  ------
 some-policy  (("proportionalCapacity" i0)("hostFailuresToTolerate" i0))  Unused
 ```
@@ -821,9 +730,8 @@ failed to update will be shown. The names of the virtual disks that failed to up
 so that manual action can be taken.
 
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py policy update --name some-policy --content '(("proportionalCapacity" i1))'
-This operation may take a while. Please be patient.
-Successfully updated policy: some-policy
+[root@localhost:~] esxcli storage guestvol policy update --name some-policy --content '(("proportionalCapacity" i1))'
+Successfully updated policy some-policy
 ```
 
 #### Remove  (`rm`)
@@ -836,7 +744,7 @@ for a virtual disk, and reset virtual disks to the default storage policy is a n
 enhancement tracked [here](https://github.com/vmware/docker-volume-vsphere/issues/577).
 
 ```bash
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py policy rm --name=some-policy
+[root@localhost:~] esxcli storage guestvol policy rm --name=some-policy
 Successfully removed policy: some-policy
 ```
 
@@ -865,16 +773,16 @@ Initializing the config is optional. If the config is not initialized, there wil
 Before configuring access control or quotas, the config needs to be inited to either SingleNode (`init --local`) or MultiNode (`init --datastore=ds_name`) mode.
 
 ```
-[root@localhost:~] vmdkops_admin config init -h
-usage: vmdkops_admin.py config init [-h] [--local] [--force]
-                                    [--datastore DATASTORE]
+[root@localhost:~] esxcli storage guestvol config init --help
+Usage: esxcli storage guestvol config init [cmd options]
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --local               Allows local (SingleNode) Init
+Description:
+  init                  Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]
+
+Cmd options:
+  --datastore=<str>     Config file will be placed on a datastore
   --force               Force operation, ignore warnings
-  --datastore DATASTORE
-                        Config DB will be placed on a shared datastore
+  --local               Allows local (SingleNode) Init
 ```
 
 Example:
@@ -900,17 +808,20 @@ vmdkops-opsd is not running
 Starting vmdkops-opsd
 vmdkops-opsd is running pid=5979684
 
-[root@localhost:~] vmdkops_admin status
-Version: 0.12.fea683a-0.0.1
+[root@localhost:~] esxcli storage guestvol status
+=== Service:
+Version: 0.14.ff1d8d4-0.0.1
 Status: Running
-DB_LocalPath: /etc/vmware/vmdkops/auth-db
-DB_SharedLocation: /etc/vmware/vmdkops/auth-db
-DB_Mode: SingleNode (local DB exists)    <==== LOCAL configuration
-Pid: 5979684
+Pid: 607737
 Port: 1019
 LogConfigFile: /etc/vmware/vmdkops/log_config.json
 LogFile: /var/log/vmware/vmdk_ops.log
-LogLevel: DEBUG
+LogLevel: INFO
+=== Authorization Config DB:
+DB_LocalPath: /etc/vmware/vmdkops/auth-db
+DB_Mode: SingleNode (local DB exists)     <==== LOCAL configuration
+DB_SharedLocation: N/A
+
 ```
 
 
@@ -918,22 +829,26 @@ LogLevel: DEBUG
 
 Allows to remove local configuration DB. Since this is a destructive operation, admin needs to type both `--local` flag (to confirm it's local only operation and does not impact shared database, if any) , and `--confirm` flag to confirm that she actually wants to delete the local Config DB.
 
-Running `vmdkops_admin config rm` with no flags prints an explanation on how to remove the shared config DB, if any.
+Running `esxcli storage guestvol config rm` with no flags prints an explanation on how to remove the shared config DB, if any.
 
 ```
-usage: vmdkops_admin.py config rm [-h] [--local] [--no-backup] [--confirm]
+[root@localhost:~] esxcli storage guestvol config rm --help
+Usage: esxcli storage guestvol config rm [cmd options]
 
-optional arguments:
-  -h, --help   show this help message and exit
-  --local      Remove only local link or local DB
-  --no-backup  Do not create DB backup before removing
-  --confirm    Explicitly confirm the operation
+Description:
+  rm                    Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]
+
+Cmd options:
+  --confirm             Explicitly confirm the operation
+  --local               Remove only local link or local DB
+  --no-backup           Do not create DB backup before removing
+  --unlink              Remove the local link to shared DB
 ```
 
 
 #### Status
 
-To get config DB  status, use  `/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py status` command.
+To get config DB  status, use  `esxcli storage guestvol status` command.
 
 #### Move (`config mv`)
 
@@ -944,49 +859,53 @@ To get config DB  status, use  `/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py sta
 Show config and run-time information about the service.
 
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py status  -h
-usage: vmdkops_admin.py status [-h] [--fast]
+[root@localhost:~] esxcli storage guestvol status --help
+Usage: esxcli storage guestvol status [cmd options]
 
-optional arguments:
-  -h, --help  show this help message and exit
-  --fast      SKip some of the data collection (port, version)
-  ```
+Description:
+  status                Status of vdvs service
+
+Cmd options:
+  --fast                Skip some of the data collection (port, version)
+```
 
 
 ```bash
-[root@localhost:~] time /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py status
-Version: 0.12.0afa0ec-0.0.1
+[root@localhost:~] time esxcli storage guestvol status
+=== Service:
+Version: 0.14.ff1d8d4-0.0.1
 Status: Running
-DB_LocalPath: /etc/vmware/vmdkops/auth-db
-DB_SharedLocation: N/A
-DB_Mode: SingleNode (local DB exists)
-Pid: 6298936
+Pid: 607737
 Port: 1019
 LogConfigFile: /etc/vmware/vmdkops/log_config.json
 LogFile: /var/log/vmware/vmdk_ops.log
-LogLevel: DEBUG
-
-real	0m 2.01s
-user	0m 0.59s
+LogLevel: INFO
+=== Authorization Config DB:
+DB_Mode: SingleNode (local DB exists)
+DB_SharedLocation: N/A
+DB_LocalPath: /etc/vmware/vmdkops/auth-db
+real	0m 2.67s
+user	0m 0.31s
 sys	0m 0.00s
 ```
 
  Some of the information retrieval may be slow (e.g. VIB version (`Version` field) # or VMCI port number (`Port` field). `--fast` flag skips slow data collection and prints `?` for fields with no information.
 
 ```bash
-[root@localhost:~] time /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py status --fast
+[root@localhost:~] time esxcli storage guestvol status --fast
+=== Service:
 Version: ?
 Status: Running
-DB_LocalPath: /etc/vmware/vmdkops/auth-db
-DB_SharedLocation: N/A
-DB_Mode: SingleNode (local DB exists)
-Pid: 6298936
+Pid: 607737
 Port: ?
 LogConfigFile: /etc/vmware/vmdkops/log_config.json
 LogFile: /var/log/vmware/vmdk_ops.log
-LogLevel: DEBUG
-
-real	0m 0.72s
-user	0m 0.51s
+LogLevel: INFO
+=== Authorization Config DB:
+DB_LocalPath: /etc/vmware/vmdkops/auth-db
+DB_SharedLocation: N/A
+DB_Mode: SingleNode (local DB exists)
+real	0m 0.95s
+user	0m 0.34s
 sys	0m 0.00s
 ```

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -64,7 +64,7 @@ After installing the new build, type command “vmgroup ls”
 Check for failure to connect to auth DB.
 
 ```
-/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+esxcli storage guestvol vmgroup ls
 Failed to connect auth DB(DB connection error /etc/vmware/vmdkops/auth-db)
 ```
 
@@ -91,7 +91,7 @@ Step 1: Remove  auth-db file at /etc/vmware/vmdkops/auth-db
 
 Step 2: Verify “vmgroup ls” command
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+[root@localhost:~] esxcli storage guestvol vmgroup ls
 Uuid                                  Name       Description                 Default_datastore  VM_list
 ------------------------------------  ---------  --------------------------  -----------------  -------
 11111111-1111-1111-1111-111111111111  _DEFAULT   This is a default vmgroup
@@ -122,7 +122,7 @@ Step 2: Move the auth-db file at /etc/vmware/vmdkops/auth-db
 Step 3: Verify “vmgroup ls” command, now only  ```_DEFAULT``` should be listed.
 
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+[root@localhost:~] esxcli storage guestvol vmgroup ls
 Uuid                                  Name      Description                 Default_datastore  VM_list
 ------------------------------------  --------  --------------------------  -----------------  -------
 11111111-1111-1111-1111-111111111111  _DEFAULT  This is a default vmgroup
@@ -135,10 +135,10 @@ Step 4: Recreate the vmgroup configuration with new name “new-vmgroup1” (ass
 ***Note: Please DO NOT create the vmgroup with the old name “vmgroup1”!!!***
 
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup create --name=new-vmgroup1  --vm-list=photon-6 --default-datastore=datastore1
+[root@localhost:~] esxcli storage guestvol vmgroup create --name=new-vmgroup1  --vm-list=photon-6 --default-datastore=datastore1
 vmgroup 'new-vmgroup1' is created.  Do not forget to run 'vmgroup vm add' to add vm to vmgroup.
 
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py vmgroup ls
+[root@localhost:~] esxcli storage guestvol vmgroup ls
 Uuid                                  Name           Description                 Default_datastore  VM_list
 ------------------------------------  -------------  --------------------------  -----------------  --------
 11111111-1111-1111-1111-111111111111  _DEFAULT       This is a default vmgroup
@@ -163,8 +163,7 @@ vsphere             new-vol1@datastore1
 Volume “vol1” which was created before still exists, and can be seen from the following AdminCLI command
 
 ```
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py volume ls
-[root@localhost:~] /usr/lib/vmware/vmdkops/bin/vmdkops_admin.py volume ls
+[root@localhost:~] esxcli storage guestvol volume ls
 Volume    Datastore   VMGroup       Capacity  Used  Filesystem  Policy  Disk Format  Attached-to  Access      Attach-as               Created By  Created Date
 --------  ----------  ------------  --------  ----  ----------  ------  -----------  -----------  ----------  ----------------------  ----------  ------------------------
 vol1      datastore1  N/A           100MB     13MB  ext4        N/A     thin         detached     read-write  independent_persistent  photon-6    Wed Sep 14 16:20:30 2016

--- a/docs/user-guide/install.md
+++ b/docs/user-guide/install.md
@@ -37,6 +37,11 @@ Installation Result
    VIBs Skipped:
 ```
 
+**Note**: To make admin commandset available on ESX host, please restart hostd after vib installation.
+```
+/etc/init.d/hostd restart
+```
+
 ## Installation on Docker Hosts
 
 vDVS plugin can be installed on Docker hosts like any docker plugin installation. You will need docker version **1.13/17.03 or above** on the VM. In a large pool of nodes, you can push the plugin installation to multiple VM through a configuration management tool such as Ansible/Salt or using a remote shell session. The installation of plugin is really simple and we will walk through the steps to install/uninstall, enable and verify the plugin installation.

--- a/esx_service/README.md
+++ b/esx_service/README.md
@@ -12,5 +12,10 @@ Install with with something like this:
   > esxcli software vib install --no-sig-check -v `pwd`/<vib_name>
 ```
 
+To make admin commandset available on ESX host, please restart hostd after vib installation.
+This needs to be because hostd reads available extensions for esxcli only during startup.
+```
+/etc/init.d/hostd restart
+```
 On client side, ../client_plugin/vmdkops is a Go client module
 

--- a/esx_service/cli/vmdkops_admin.xml
+++ b/esx_service/cli/vmdkops_admin.xml
@@ -4,31 +4,31 @@
     <!-- esxcli extension syntax version -->
     <version>1.0.0</version>
     <namespaces>
-        <namespace path="storage.vdvs">
-            <description>Admin commands to manage volumes consumed by vdvs</description>
+        <namespace path="storage.guestvol">
+            <description>Admin commands to manage volumes consumed by containers running on guest VM </description>
         </namespace>
-        <namespace path="storage.vdvs.volume">
+        <namespace path="storage.guestvol.volume">
             <description>Manage vDVS volumes</description>
         </namespace>
-        <namespace path="storage.vdvs.policy">
+        <namespace path="storage.guestvol.policy">
             <description>Configure and display storage policy information</description>
         </namespace>
-        <namespace path="storage.vdvs.vmgroup">
+        <namespace path="storage.guestvol.vmgroup">
             <description>Administer and monitor volume access control</description>
         </namespace>
-        <namespace path="storage.vdvs.vmgroup.vm">
+        <namespace path="storage.guestvol.vmgroup.vm">
             <description>Add, removes, replaces and lists VMs in a vmgroup</description>
         </namespace>
-        <namespace path="storage.vdvs.vmgroup.access">
+        <namespace path="storage.guestvol.vmgroup.access">
             <description>Add or remove Datastore access and quotas for a vmgroup</description>
         </namespace>
-        <namespace path="storage.vdvs.config">
+        <namespace path="storage.guestvol.config">
             <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>
         </namespace>
     </namespaces>
     <commands>
         <!-- Volume commands -->
-        <command path="storage.vdvs.volume.ls">
+        <command path="storage.guestvol.volume.ls">
             <description>List volumes</description>
             <input-spec>
                 <parameter name="vmgroup" type="string" required="false">
@@ -85,9 +85,68 @@
                 <formatter>table</formatter>
                 <format-parameter name="fields:vdvs">Volume,Datastore,VMGroup,Capacity,Used,Filesystem,Policy,Disk Format,Attached-to,Access,Attach-as,Created By,Created Date</format-parameter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume ls $if{vmgroup, --vmgroup $val{vmgroup}}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume ls $if{vmgroup, --vmgroup '$val{vmgroup}'}</execute>
         </command>
-        <command path="storage.vdvs.volume.set">
+        <command path="storage.guestvol.volume.shortls">
+            <description>List volumes with limited information</description>
+            <input-spec>
+                <parameter name="vmgroup" type="string" required="false">
+                    <description>Displays volumes for a given vmgroup</description>
+                </parameter>
+            </input-spec>
+            <output-spec>
+                <list type="structure">
+                    <structure typeName="vdvs">
+                        <field name="Volume">
+                            <string/>
+                        </field>
+                        <field name="Datastore">
+                            <string/>
+                        </field>
+                        <field name="VMGroup">
+                            <string/>
+                        </field>
+                        <field name="Capacity">
+                            <string/>
+                        </field>
+                        <field name="Used">
+                            <string/>
+                        </field>
+                        <field name="Filesystem">
+                            <string/>
+                        </field>
+                        <field name="Policy">
+                            <string/>
+                        </field>
+                        <field name="Disk Format">
+                            <string/>
+                        </field>
+                        <field name="Attached-to">
+                            <string/>
+                        </field>
+                        <field name="Access">
+                            <string/>
+                        </field>
+                        <field name="Attach-as">
+                            <string/>
+                        </field>
+                        <field name="Created By">
+                            <string/>
+                        </field>
+                        <field name="Created Date">
+                            <string/>
+                        </field>
+                    </structure>
+                </list>
+            </output-spec>
+            <has-updates value="true"/>
+            <format-parameters>
+                <formatter>table</formatter>
+                <format-parameter name="fields:vdvs">Volume,Capacity,Disk Format,Attached-to</format-parameter>
+            </format-parameters>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume ls $if{vmgroup, --vmgroup '$val{vmgroup}'}</execute>
+        </command>
+        <command path="storage.guestvol.volume.set">
             <description>Edit settings for a given volume</description>
             <input-spec>
                 <parameter name="volume" type="string" required="true">
@@ -106,10 +165,10 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume set --vmgroup=$val{vmgroup} --volume=$val{volume} --options=$val{options}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml volume set --vmgroup='$val{vmgroup}' --volume='$val{volume}' --options=$val{options}</execute>
         </command>
         <!-- Policy commands -->
-        <command path="storage.vdvs.policy.create">
+        <command path="storage.guestvol.policy.create">
             <description>Create a storage policy</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -125,9 +184,9 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy create --name=$val{name} --content='$val{content}'</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy create --name='$val{name}' --content='$val{content}'</execute>
         </command>
-        <command path="storage.vdvs.policy.rm">
+        <command path="storage.guestvol.policy.rm">
             <description>Remove a storage policy</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -140,9 +199,9 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy rm --name=$val{name}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy rm --name='$val{name}'</execute>
         </command>
-        <command path="storage.vdvs.policy.ls">
+        <command path="storage.guestvol.policy.ls">
             <description>List storage policies and volumes using those policies</description>
             <input-spec></input-spec>
             <output-spec>
@@ -167,7 +226,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy ls</execute>
         </command>
-        <command path="storage.vdvs.policy.update">
+        <command path="storage.guestvol.policy.update">
             <description>Update the definition of a storage policy and all VSAN objects using that policy</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -183,10 +242,10 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy update --name=$val{name} --content='$val{content}'</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml policy update --name='$val{name}' --content='$val{content}'</execute>
         </command>
         <!-- vmgroup commands -->
-        <command path="storage.vdvs.vmgroup.create">
+        <command path="storage.guestvol.vmgroup.create">
             <description>Create a new vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -209,9 +268,9 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup create --name=$val{name} --default-datastore=$val{default-datastore} $if{description, --description='$val{description}}' $if{vm-list, --vm-list=$val{vm-list}} </execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup create --name='$val{name}' --default-datastore='$val{default-datastore}' $if{description, --description='$val{description}'} $if{vm-list, --vm-list=$val{vm-list}} </execute>
         </command>
-        <command path="storage.vdvs.vmgroup.update">
+        <command path="storage.guestvol.vmgroup.update">
             <description>Update a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -234,15 +293,15 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml  vmgroup update --name=$val{name} $if{new-name, --new-name=$val{new-name}} $if{description, --description='$val{description}}' $if{vm-list, --vm-list=$val{vm-list}}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml  vmgroup update --name='$val{name}' $if{new-name, --new-name='$val{new-name}'} $if{description, --description='$val{description}'} $if{vm-list, --vm-list=$val{vm-list}}  $if{default-datastore, --default-datastore='$val{default-datastore}'}</execute>
         </command>
-        <command path="storage.vdvs.vmgroup.rm">
+        <command path="storage.guestvol.vmgroup.rm">
             <description>Delete a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
                     <description>The name of the vmgroup</description>
                 </parameter>
-                <parameter name="remove-volumes" type="bool" required="false">
+                <parameter name="remove-volumes" type="flag" required="false">
                     <description>BE CAREFUL: Removes this vmgroup volumes when removing a vmgroup</description>
                 </parameter>
             </input-spec>
@@ -253,9 +312,9 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup rm --name=$val{name} $if{remove-volumes, --remove-volumes=$val{remove-volumes}}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup rm --name=$val{name} $if{remove-volumes, --remove-volumes}</execute>
         </command>
-        <command path="storage.vdvs.vmgroup.ls">
+        <command path="storage.guestvol.vmgroup.ls">
             <description>List vmgroups and the VMs they are applied to</description>
             <input-spec></input-spec>
             <output-spec>
@@ -287,7 +346,7 @@
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup ls</execute>
         </command>
         <!-- vmgroup vm commands -->
-        <command path="storage.vdvs.vmgroup.vm.add">
+        <command path="storage.guestvol.vmgroup.vm.add">
             <description>Add VM(s) to a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -304,9 +363,9 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm add --name=$val{name} --vm-list=$val{vm-list}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm add --name='$val{name}' --vm-list=$val{vm-list}</execute>
         </command>
-        <command path="storage.vdvs.vmgroup.vm.rm">
+        <command path="storage.guestvol.vmgroup.vm.rm">
             <description>Remove VM(s) from a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -323,9 +382,9 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm rm --name=$val{name} --vm-list=$val{vm-list}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm rm --name='$val{name}' --vm-list=$val{vm-list}</execute>
         </command>
-        <command path="storage.vdvs.vmgroup.vm.replace">
+        <command path="storage.guestvol.vmgroup.vm.replace">
             <description>Replace VM(s) for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -342,9 +401,9 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm replace --name=$val{name} --vm-list=$val{vm-list}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm replace --name='$val{name}' --vm-list=$val{vm-list}</execute>
         </command>
-        <command path="storage.vdvs.vmgroup.vm.ls">
+        <command path="storage.guestvol.vmgroup.vm.ls">
             <description>list VMs in a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -368,10 +427,10 @@
                 <formatter>table</formatter>
                 <format-parameter name="fields:vdvs">Uuid, Name</format-parameter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm ls --name=$val{name}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup vm ls --name='$val{name}'</execute>
         </command>
         <!-- vmgroup access commands -->
-        <command path="storage.vdvs.vmgroup.access.add">
+        <command path="storage.guestvol.vmgroup.access.add">
             <description>Add a datastore access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -396,9 +455,9 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access add --name=$val{name} --datastore=$val{datastore} $if{allow-create, --allow-create} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access add --name='$val{name}' --datastore='$val{datastore}' $if{allow-create, --allow-create} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
         </command>
-        <command path="storage.vdvs.vmgroup.access.set">
+        <command path="storage.guestvol.vmgroup.access.set">
             <description>Modify datastore access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -424,9 +483,9 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access set --name=$val{name} --datastore=$val{datastore} $if{allow-create, --allow-create=$val{allow-create}} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access set --name=$val{name} --datastore='$val{datastore}' $if{allow-create, --allow-create=$val{allow-create}} $if{volume-maxsize, --volume-maxsize=$val{volume-maxsize}} $if{volume-totalsize, --volume-totalsize=$val{volume-totalsize}} </execute>
         </command>
-        <command path="storage.vdvs.vmgroup.access.rm">
+        <command path="storage.guestvol.vmgroup.access.rm">
             <description>Remove datastore access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -443,9 +502,9 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access rm --name=$val{name} --datastore=$val{datastore}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access rm --name='$val{name}' --datastore='$val{datastore}'</execute>
         </command>
-        <command path="storage.vdvs.vmgroup.access.ls">
+        <command path="storage.guestvol.vmgroup.access.ls">
             <description>List access for a vmgroup</description>
             <input-spec>
                 <parameter name="name" type="string" required="true">
@@ -475,10 +534,10 @@
                 <formatter>table</formatter>
                 <format-parameter name="fields:vdvs">Datastore, Allow_create, Max_volume_size, Total_size</format-parameter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access ls --name=$val{name}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml vmgroup access ls --name='$val{name}'</execute>
         </command>
         <!-- vmgroup config commands -->
-        <command path="storage.vdvs.status">
+        <command path="storage.guestvol.status">
             <description>Status of vdvs service</description>
             <input-spec>
                 <parameter name="fast" type="flag" required="false">
@@ -493,7 +552,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml status $if{fast, --fast}</execute>
         </command>
-        <command path="storage.vdvs.config.init">
+        <command path="storage.guestvol.config.init">
             <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>
             <input-spec>
                 <parameter name="datastore" type="string" required="false">
@@ -512,9 +571,9 @@
             <format-parameters>
                 <formatter>simple</formatter>
             </format-parameters>
-            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config init $if{datastore, --datastore=$val{datastore}} $if{local, --local} $if{force, --force}</execute>
+            <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config init $if{datastore, --datastore='$val{datastore}'} $if{local, --local} $if{force, --force}</execute>
         </command>
-        <command path="storage.vdvs.config.rm">
+        <command path="storage.guestvol.config.rm">
             <description>Init and manage Config DB to enable quotas and access control [EXPERIMENTAL]</description>
             <input-spec>
                 <parameter name="unlink" type="flag" required="false">
@@ -538,7 +597,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config rm $if{local, --local} $if{unlink, --unlink} $if{no-backup, --no-backup} $if{confirm, --confirm}</execute>
         </command>
-        <command path="storage.vdvs.config.mv">
+        <command path="storage.guestvol.config.mv">
             <description>Relocate config file from its current location [NOT SUPPORTED YET]</description>
             <input-spec>
                 <parameter name="to" type="string" required="true">
@@ -556,7 +615,7 @@
             </format-parameters>
             <execute>/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py --output-format=xml config mv --to=$val{to} $if{force, --force}</execute>
         </command>
-        <command path="storage.vdvs.config.status">
+        <command path="storage.guestvol.config.status">
             <description>Show the status of the Config DB</description>
             <input-spec></input-spec>
             <output-spec>


### PR DESCRIPTION
1. Updates documentation in admin-cli.md to reflect usage of esxcli
2. Update readme installation instruction to restart hostd after vib installation
3. Minor fixes to handle values with spaces for flags like name, vmgroup, datastore, description etc.
4. Introducing volume shortls command to display limited info about volumes.

Fixes #1757 