### PR TITLE
Increase the timeout value for service start/stop

### DIFF
--- a/client_plugin/drivers/shared/dockerops/dockerops.go
+++ b/client_plugin/drivers/shared/dockerops/dockerops.go
@@ -66,7 +66,7 @@ const (
 	// Time between successive checks for deleting a volume
 	checkSleepDuration = time.Second
 	// Timeout to mark Samba service launch as unsuccessful
-	sambaRequestTimeout = 30 * time.Second
+	sambaRequestTimeout = 150 * time.Second
 	// Prefix for internal volume names
 	internalVolumePrefix = "InternalVol"
 	// Error returned when no Samba service for that volume exists

--- a/client_plugin/drivers/shared/dockerops/dockerops.go
+++ b/client_plugin/drivers/shared/dockerops/dockerops.go
@@ -67,7 +67,7 @@ const (
 	// Time between successive checks for deleting a volume
 	checkSleepDuration = time.Second
 	// default Timeout to mark Samba service launch as unsuccessful
-	defaultServiceStartTimeOutInSecond = 30
+	defaultSvcStartTimeoutSec = 30
 	// Prefix for internal volume names
 	internalVolumePrefix = "InternalVol"
 	// Error returned when no Samba service for that volume exists
@@ -78,7 +78,7 @@ const (
 func GetServiceStartTimeout() time.Duration {
 	timeOutSec, err := strconv.Atoi(os.Getenv("VFILE_TIMEOUT_IN_SECOND"))
 	if err != nil {
-		timeOutSec = defaultServiceStartTimeOutInSecond
+		timeOutSec = defaultSvcStartTimeoutSec
 	}
 	log.WithFields(log.Fields{"value": timeOutSec}).Info("Service start timeout")
 	return time.Duration(timeOutSec) * time.Second

--- a/client_plugin/drivers/shared/dockerops/dockerops.go
+++ b/client_plugin/drivers/shared/dockerops/dockerops.go
@@ -27,11 +27,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-<<<<<<< HEAD
-	"strings"
-=======
 	"strconv"
->>>>>>> Address comments from Mark to make the sambaRequest timeout value as a config option.
+	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -67,15 +64,10 @@ const (
 	// Time between successive checks for Samba service
 	// status to see if service container was launched
 	checkDuration = 5 * time.Second
-<<<<<<< HEAD
 	// Time between successive checks for deleting a volume
 	checkSleepDuration = time.Second
-	// Timeout to mark Samba service launch as unsuccessful
-	sambaRequestTimeout = 150 * time.Second
-=======
 	// default Timeout to mark Samba service launch as unsuccessful
 	defaultSambaRequestTimeOutInSecond = 30
->>>>>>> Address comments from Mark to make the sambaRequest timeout value as a config option.
 	// Prefix for internal volume names
 	internalVolumePrefix = "InternalVol"
 	// Error returned when no Samba service for that volume exists

--- a/client_plugin/drivers/shared/kvstore/etcdops/etcdops.go
+++ b/client_plugin/drivers/shared/kvstore/etcdops/etcdops.go
@@ -963,7 +963,7 @@ func (e *EtcdKVS) BlockingWaitAndGet(key string, value string, newKey string) (s
 	defer ticker.Stop()
 	// This call is used to block and wait for long
 	// running functions. Larger timeout is justified.
-	timer := time.NewTimer(dockerops.GetSambaRequestTimeout() + 2*requestTimeout)
+	timer := time.NewTimer(dockerops.GetServiceStartTimeout() + 2*requestTimeout)
 	defer timer.Stop()
 
 	for {

--- a/client_plugin/drivers/shared/kvstore/etcdops/etcdops.go
+++ b/client_plugin/drivers/shared/kvstore/etcdops/etcdops.go
@@ -963,7 +963,7 @@ func (e *EtcdKVS) BlockingWaitAndGet(key string, value string, newKey string) (s
 	defer ticker.Stop()
 	// This call is used to block and wait for long
 	// running functions. Larger timeout is justified.
-	timer := time.NewTimer(8 * requestTimeout)
+	timer := time.NewTimer(24 * requestTimeout)
 	defer timer.Stop()
 
 	for {

--- a/client_plugin/drivers/shared/kvstore/etcdops/etcdops.go
+++ b/client_plugin/drivers/shared/kvstore/etcdops/etcdops.go
@@ -963,7 +963,7 @@ func (e *EtcdKVS) BlockingWaitAndGet(key string, value string, newKey string) (s
 	defer ticker.Stop()
 	// This call is used to block and wait for long
 	// running functions. Larger timeout is justified.
-	timer := time.NewTimer(24 * requestTimeout)
+	timer := time.NewTimer(dockerops.GetSambaRequestTimeout() + 2*requestTimeout)
 	defer timer.Stop()
 
 	for {

--- a/docs/user-guide/vfile-plugin.md
+++ b/docs/user-guide/vfile-plugin.md
@@ -3,7 +3,7 @@ title: vFile volume plugin for Docker
 
 ---
 ## Overview
-Depending on the underlying block storage device system, it might not be possible to access the same
+Depending on the underlying block storage system, it might not be possible to access the same
 persistent volume across different hosts/nodes simultanously.
 For example, currently users cannot mount the same persistent volume which is created through
 vSphere Docker Volume Service (vDVS) on containers running on two different hosts at the same time.
@@ -138,9 +138,9 @@ When you see somthing like the following in the log
 Please make sure the volume you used is a valid volume name. A valid volume name consists of ```[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]```.
 
 ### I got " VolumeDriver.Mount: Failed to blocking wait for Mounted state. Error: Timeout reached; BlockingWait is not complete.." when mounting a volume.
-We see this issue only on platforms which the availble disk space are low. On those platforms, docker swarm service takes longer time to up and running. We recommend to run this driver on platforms with enough available disk space. You can also try to increase the service start timeout value by specifing ```VFILE_TIMEOUT_IN_SECOND``` value when installing the plugin:
+We see this issue only on platform where the space is low. When available disk space are low, Docker Swarm service may take longer to start a service. Generally it's better free up some disk space. You can also try to increase the service start timeout value, controlled by ```VFILE_TIMEOUT_IN_SECOND``` env variable:
 ```
 docker plugin install --grant-all-permissions --alias vfile cnastorage/vfile:latest VFILE_TIMEOUT_IN_SECOND=90
 ```
-The above command increases the service start timeout value to 90 seconds and the default value is 30 seconds.
+This will increase timeout to 90 sec, from default of 30 sec.
 

--- a/docs/user-guide/vfile-plugin.md
+++ b/docs/user-guide/vfile-plugin.md
@@ -144,3 +144,4 @@ docker plugin install --grant-all-permissions --alias vfile cnastorage/vfile:lat
 ```
 This will increase timeout to 90 sec, from default of 30 sec.
 
+

--- a/docs/user-guide/vfile-plugin.md
+++ b/docs/user-guide/vfile-plugin.md
@@ -144,4 +144,3 @@ docker plugin install --grant-all-permissions --alias vfile cnastorage/vfile:lat
 ```
 This will increase timeout to 90 sec, from default of 30 sec.
 
-

--- a/docs/user-guide/vfile-plugin.md
+++ b/docs/user-guide/vfile-plugin.md
@@ -9,7 +9,11 @@ For example, currently users cannot mount the same persistent volume which is cr
 vSphere Docker Volume Service (vDVS) on containers running on two different hosts at the same time.
 
 This can be solved through distributed file systems, such as NFS, Ceph, Gluster, etc.
+<<<<<<< HEAD
 However, setting up and maintaining enterprise storage offerings for Cloud Native usecases is not a trivial work.
+=======
+However, setting up and maintaining those distributed file systems for docker persistent data usage is not a trivial work.
+>>>>>>> Update user guide.
 Furthermore, users can face more challenges in order to achieve high availability, scalability, and load balancing.
 
 __vFile volume plugin for Docker__ provides simultanous persistent volume access between hosts in the
@@ -132,3 +136,11 @@ When you see somthing like the following in the log
 2017-08-24 11:57:16.436786459 -0700 PDT [WARNING] Failed to create file server for volume space vol7. Reason: Error response from daemon: {"message":"rpc error: code = 3 desc = name must be valid as a DNS name component"}
 ```
 Please make sure the volume you used is a valid volume name. A valid volume name consists of ```[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]```.
+
+### I got " VolumeDriver.Mount: Failed to blocking wait for Mounted state. Error: Timeout reached; BlockingWait is not complete.." when mounting a volume.
+We see this issue only on platforms which the availble disk space are low. On those platforms, docker swarm service takes longer time to up and running. We recommend to run this driver on platforms with enough available disk space. You can also try to increase the service start timeout value by specifing ```VFILE_TIMEOUT_IN_SECOND``` value when installing the plugin:
+```
+docker plugin install --grant-all-permissions --alias vfile cnastorage/vfile:latest VFILE_TIMEOUT_IN_SECOND=90
+```
+The above command increases the service start timeout value to 90 seconds and the default value is 30 seconds.
+

--- a/plugin_dockerbuild/config.json-template
+++ b/plugin_dockerbuild/config.json-template
@@ -58,6 +58,12 @@
 		"description": "Client protocol version used in test",
 		"value": "",
 		"Settable": [ "value"]
+	},
+	{
+		"name": "VFILE_TIMEOUT_IN_SECOND",
+		"description": "Timeout value in second used by vFILE plugin",
+		"value": "",
+		"Settable": [ "value"]
 	}
 	]
 }


### PR DESCRIPTION
Fixes #1766 
This PR includes: 
Increase the timeout value when waiting for Samba service to start/stop and also the timeout value for block waiting.

The Swarm samba service can take up to 1.5 minutes to come up on setup with less resource, so set the timeout value for waiting for Samba service to start/stop to 90 seconds, and set the timeout value for block waiting for 120 seconds.