### PR TITLE
Create dockvols only when required on specific datastores.

### DIFF
--- a/esx_service/utils/vmdk_utils.py
+++ b/esx_service/utils/vmdk_utils.py
@@ -90,7 +90,7 @@ def init_datastoreCache(force=False):
         tmp_ds = []
 
         for datastore in ds_objects:
-            dockvols_path, err = vmdk_ops.get_vol_path(datastore.info.name)
+            dockvols_path, err = vmdk_ops.get_vol_path(datastore=datastore.info.name, create=False)
             if err:
                 logging.error(" datastore %s is being ignored as the dockvol path can't be created on it", datastore.info.name)
                 continue

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -737,7 +737,7 @@ def apply_action_VMDK(action, vmdk_path, vm_name, bios_uuid, vc_uuid):
     return action(vmdk_path, vm)
 
 
-def get_vol_path(datastore, tenant_name=None):
+def get_vol_path(datastore, tenant_name=None, create=True):
     """
     Check existence (and create if needed) the path for docker volume VMDKs
     Returns either path to tenant-specific folder (if tenant name is passed)
@@ -773,6 +773,11 @@ def get_vol_path(datastore, tenant_name=None):
             logging.warning("Internal: Tenant name symlink not found for path %s", readable_path)
             logging.debug("Found %s, returning", path)
             return path, None
+
+    if not create:
+        # Return the readable path to caller without creating it.
+        logging.debug("Returning %s, path isn't created yet.", readable_path)
+        return readable_path, None
 
     if not os.path.isdir(dock_vol_path):
         # The osfs tools are usable for DOCK_VOLS_DIR on all datastores.


### PR DESCRIPTION
Added a new optional arg to get_vol_path to allow caller to decide whether the dockvols dir is created or not.  In the init_datastoreCache() path the dockvols dir isn't created anymore and instead created only as needed. Didn't remove the call to get_vol_path() in init_datastoreCache as we need the path to the dockvols  dir to be stored in the cache and the call to get_vol_path() is the only place that decides how to create that path.