### PR TITLE
Report usage if no args/commands provided on the command line

### DIFF
--- a/esx_service/cli/vmdkops_admin.py
+++ b/esx_service/cli/vmdkops_admin.py
@@ -582,7 +582,8 @@ def build_argparse_opts(opts):
 def parse_args():
     parser = create_parser()
     args = parser.parse_args()
-    if args != argparse.Namespace():
+    opts = vars(args)
+    if args != argparse.Namespace() and 'func' in opts.keys():
        return args
     else:
        parser.print_help()


### PR DESCRIPTION
Check that there is a function to run after parsing args, else report usage.

Before:
/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py
Traceback (most recent call last):
  File "/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py", line 1477, in <module>
    main()
  File "/usr/lib/vmware/vmdkops/bin/vmdkops_admin.py", line 72, in main
    if args.func(args) != None:

After:
[root@sc-rdops-vm16-dhcp-232-194:/vmfs/volumes/59474fd1-55672410-d21e-02001e5a2f6d/dockvols/vmdkops/bin] python ./vmdkops_admin.py volume
Namespace(output_format=None)
{'output_format': None}
usage: vmdkops_admin.py [-h] [--output-format OUTPUT_FORMAT]
                        {config,vmgroup,volume,policy,status} ...

vSphere Docker Volume Service admin CLI

optional arguments:
  -h, --help            show this help message and exit
  --output-format OUTPUT_FORMAT
                        Specify output format. Supported format : xml. Default
                        one is plaintext

Manage VMDK-based Volumes for Docker:

  {config,vmgroup,volume,policy,status}
                        action
    config              Init and manage Config DB to enable quotas and access
                        control [EXPERIMENTAL]
    vmgroup             Administer and monitor volume access control
    volume              Manipulate volumes
    policy              Configure and display storage policy information
