### PR TITLE
Handling mount during recovery for an already attached volume

### DIFF
--- a/client_plugin/utils/fs/fs_linux.go
+++ b/client_plugin/utils/fs/fs_linux.go
@@ -81,6 +81,18 @@ func DevAttachWait(watcher *inotify.Watcher, volDev *VolumeDevSpec) error {
 		log.WithFields(log.Fields{"volDev": *volDev, "err": err}).Error("Failed to get device path ")
 		return err
 	}
+
+	// This file is created after a device is attached to VM
+	// and removed when device is detached.
+	// If file already present, do not wait for attach
+	_, err = os.Stat(device)
+	if err == nil {
+		log.WithFields(
+			log.Fields{"device": device},
+		).Info("Device file found. ")
+		return nil
+	}
+
 	devAttachWait(watcher, device)
 	return nil
 }

--- a/client_plugin/utils/refcount/refcnt.go
+++ b/client_plugin/utils/refcount/refcnt.go
@@ -483,6 +483,9 @@ func (r *RefCountsMap) syncMountsWithRefCounters(d drivers.VolumeDriver) {
 							isReadOnly = true
 						}
 					}
+					// It could be possible that volume (device) is just namespace mounted for the container and not
+					// under plugin rootfs. We trigger a mount, and if the device is already attached, vmdkops service on esx host
+					// returns proper device ids and we just mount it under plugin rootfs
 					_, err = d.MountVolume(vol, status["fstype"].(string), id, isReadOnly, false)
 					if err != nil {
 						log.Warning("Failed to mount - manual recovery may be needed")


### PR DESCRIPTION
## Description
When the plugin is disabled with active containers with mounted volumes, plugin rootfs is gone but volume is still attached and namespace mounted to the container. In such a case the device path is present on the host.

When the plugin comes up, this case needs to be handled and volume mounted in plugin rootfs

This PR makes mount during plugin recovery resilient. An already attached but not mounted in rootfs volume is mounted during plugin recovery.

Do not wait for dev attach if the device is already attached. This ensures plugin doesn't endup in timeout.

The recovery mount takes advantage of facts:
1. if a volume is attached to a VM, the esx service returns the correct device ids to the plugin
2. When such a volume is attached but not mounted in plugin rootfs, we mount it and use that as mount point for next .

## Testing
Done manually with docker 17.06 while containers are running with --restart flag.
See the detailed steps below for a combination of upgrade and data loss testing.

```
root@sc-rdops-vm02-dhcp-52-237:~# docker volume ls
DRIVER              VOLUME NAME
root@sc-rdops-vm02-dhcp-52-237:~# docker plugin ls
ID                  NAME                DESCRIPTION         ENABLED


root@sc-rdops-vm02-dhcp-52-237:~# docker plugin install --grant-all-permissions --alias vsphere vmware/docker-volume-vsphere:latest VDVS_LOG_LEVEL=debug
latest: Pulling from vmware/docker-volume-vsphere
ad10a6bbce92: Download complete
Digest: sha256:feaa90e4234880fbf1669015e88cd485b2077270219ff84a730b35207bb622d4
Status: Downloaded newer image for vmware/docker-volume-vsphere:latest
Installed plugin vmware/docker-volume-vsphere:latest
root@sc-rdops-vm02-dhcp-52-237:~# docker volume create -d vsphere --name vol1
vol1

root@sc-rdops-vm02-dhcp-52-237:~# docker volume ls
DRIVER              VOLUME NAME
vsphere:latest      vol1@sharedvmfs-0


root@sc-rdops-vm02-dhcp-52-237:~# docker run -d --name con_1 -v vol1@sharedvmfs-0:/data alpine ping 8.8.8.8
50150ed538e6e14e8033acdc2325715ee3939e9ba342bb39cae3a43b3c7e0f6e



root@sc-rdops-vm02-dhcp-52-237:~#
root@sc-rdops-vm02-dhcp-52-237:~#
root@sc-rdops-vm02-dhcp-52-237:~#
root@sc-rdops-vm02-dhcp-52-237:~# docker exec -it con_1 /bin/sh
/ # echo "Stage 1 " > /data/text
/ # cat /data/text
Stage 1
/ # df -h /data
Filesystem                Size      Used Available Use% Mounted on
/dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:0:0
                         92.8M      1.5M     84.3M   2% /data
/ # exit


root@sc-rdops-vm02-dhcp-52-237:~# docker plugin disable -f vsphere
vsphere
root@sc-rdops-vm02-dhcp-52-237:~# docker plugin ls
ID                  NAME                DESCRIPTION                           ENABLED
097eea81301d        vsphere:latest      VMWare vSphere Docker Volume plugin   false
root@sc-rdops-vm02-dhcp-52-237:~# cat /proc/mounts | grep vol1
root@sc-rdops-vm02-dhcp-52-237:~#
root@sc-rdops-vm02-dhcp-52-237:~#
root@sc-rdops-vm02-dhcp-52-237:~#

root@sc-rdops-vm02-dhcp-52-237:~# docker exec -it con_1 /bin/sh
/ # cat /data/text
Stage 1
/ # echo "Stage 1, Stage 2 " > /data/text
/ # cat /data/text
Stage 1, Stage 2
/ # exit
root@sc-rdops-vm02-dhcp-52-237:~#


root@sc-rdops-vm02-dhcp-52-237:~# docker plugin upgrade vsphere:latest pshahzeb/docker-volume-vsphere:0.16-dev
Upgrading plugin vsphere:latest from vmware/docker-volume-vsphere:latest to pshahzeb/docker-volume-vsphere:0.16-dev
Plugin images do not match, are you sure? [y/N] y
Plugin "pshahzeb/docker-volume-vsphere:0.16-dev" is requesting the following privileges:
 - mount: [/dev]
 - mount: [/var/run]
 - mount: [/etc]
 - mount: [/var/log]
 - allow-all-devices: [true]
 - capabilities: [CAP_SYS_ADMIN]
Do you grant the above permissions? [y/N] y
0.16-dev: Pulling from pshahzeb/docker-volume-vsphere
b4282b72a544: Download complete
Digest: sha256:aa2ebde6d348786893a186415bf68722b0c4234a8775f0939331ba25ac2c74b6
Status: Downloaded newer image for pshahzeb/docker-volume-vsphere:0.16-dev
Upgraded plugin vsphere:latest to pshahzeb/docker-volume-vsphere:0.16-dev
root@sc-rdops-vm02-dhcp-52-237:~# docker plugin ls
ID                  NAME                DESCRIPTION                           ENABLED
097eea81301d        vsphere:latest      VMWare vSphere Docker Volume plugin   false
root@sc-rdops-vm02-dhcp-52-237:~# cat /proc/mounts | grep vol1


root@sc-rdops-vm02-dhcp-52-237:~# docker exec -it con_1 /bin/sh
/ # cat /data/text
Stage 1, Stage 2
/ # echo "Stage 1, Stage 2, Stage 3 " > /data/text
/ # cat /data/text
Stage 1, Stage 2, Stage 3
/ # exit
root@sc-rdops-vm02-dhcp-52-237:~#


vsphere
root@sc-rdops-vm02-dhcp-52-237:~# cat /proc/mounts | grep vol1
/dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:0:0 /var/lib/docker/plugins/097eea81301d776a15c2025edf3601f8078b5b292625446cb7b178719f37ae3d/rootfs/mnt/vmdk/vol1@sharedvmfs-0 ext4 rw,relatime,data=ordered 0 0
/dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:0:0 /var/lib/docker/plugins/097eea81301d776a15c2025edf3601f8078b5b292625446cb7b178719f37ae3d/propagated-mount/vol1@sharedvmfs-0 ext4 rw,relatime,data=ordered 0 0


root@sc-rdops-vm02-dhcp-52-237:~# docker exec -it con_1 /bin/sh
/ # cat /data/text
Stage 1, Stage 2, Stage 3
/ # echo "Stage 1, Stage 2, Stage 3, Stage 4 " > /data/text
/ # cat /data/text
Stage 1, Stage 2, Stage 3, Stage 4
/ # exit
root@sc-rdops-vm02-dhcp-52-237:~#

root@sc-rdops-vm02-dhcp-52-237:~# docker run -d --name con_2 -v vol1@sharedvmfs-0:/data alpine ping 8.8.8.8
68e64b4d168855634d35b6c4407a176da73055cc4721ab221855025f359cf32c
root@sc-rdops-vm02-dhcp-52-237:~# docker exec -it con_2 /bin/sh
/ # cat /data/text
Stage 1, Stage 2, Stage 3, Stage 4
/ # echo "Stage 1, Stage 2, Stage 3, Stage 4, Stage 5 " > /data/text
/ # cat /data/text
Stage 1, Stage 2, Stage 3, Stage 4, Stage 5
/ # exit


root@sc-rdops-vm02-dhcp-52-237:~# docker exec -it con_1 /bin/sh
/ # cat /data/text
Stage 1, Stage 2, Stage 3, Stage 4, Stage 5
/ # echo "Stage 1, Stage 2, Stage 3, Stage 4, Stage 5, Stage 6 " > /data/text
/ # cat /data/text
Stage 1, Stage 2, Stage 3, Stage 4, Stage 5, Stage 6
/ # exit
```

Fixes #1779 