### PR TITLE
vFile: adjust garbage collector interval and server timeout

### DIFF
--- a/client_plugin/drivers/vfile/dockerops/dockerops.go
+++ b/client_plugin/drivers/vfile/dockerops/dockerops.go
@@ -67,7 +67,7 @@ const (
 	// Time between successive checks for deleting a volume
 	checkSleepDuration = time.Second
 	// default Timeout to mark Samba service launch as unsuccessful
-	defaultSvcStartTimeoutSec = 30
+	defaultSvcStartTimeoutSec = 45
 	// Prefix for internal volume names
 	internalVolumePrefix = "InternalVol"
 	// Error returned when no Samba service for that volume exists

--- a/client_plugin/drivers/vfile/kvstore/etcdops/etcdops.go
+++ b/client_plugin/drivers/vfile/kvstore/etcdops/etcdops.go
@@ -60,7 +60,7 @@ const (
 	etcdClusterStateExisting = "existing"
 	requestTimeout           = 5 * time.Second
 	checkSleepDuration       = time.Second
-	gcTicker                 = 30 * time.Second
+	gcTicker                 = 5 * time.Second
 	etcdClientCreateError    = "Failed to create etcd client"
 	etcdSingleRef            = "1"
 	etcdNoRef                = "0"


### PR DESCRIPTION
After users deleted the vFile volume, due to the long interval, users can notice
the left-over file sharing service before the garbage collector is able to clean
it. Thus reducing the interval to make sure the orphan services can be cleaned up
on time.

Adjust the timeout for waiting file sharing server to start/stop from 30 secs to
45 secs, to handle VMs with limited resource.

Partially fixes #1815