### PR TITLE
Do not log error for GetVolume with volume for empty names

### DIFF
--- a/client_plugin/drivers/vmdk/vmdk_driver.go
+++ b/client_plugin/drivers/vmdk/vmdk_driver.go
@@ -124,9 +124,15 @@ func (d *VolumeDriver) List(r volume.Request) volume.Response {
 
 // GetVolume - return volume meta-data.
 func (d *VolumeDriver) GetVolume(name string) (map[string]interface{}, error) {
+	// Get for empty volume name is issued by docker when it is coming up.
+	// Just return the error in such case.
+	if name == "" {
+		return nil, fmt.Errorf(" No volume with name as empty string exists")
+	}
+
 	mdata, err := d.ops.Get(name)
-	// Get for empty volume name is issued by docker when it is coming up. Do not log error for this case.
-	if err != nil && name != "" {
+
+	if err != nil {
 		log.WithFields(log.Fields{"name": name, "error": err}).Error("Failed to get volume meta-data ")
 	}
 	return mdata, err

--- a/client_plugin/drivers/vmdk/vmdk_driver.go
+++ b/client_plugin/drivers/vmdk/vmdk_driver.go
@@ -124,7 +124,7 @@ func (d *VolumeDriver) List(r volume.Request) volume.Response {
 
 // GetVolume - return volume meta-data.
 func (d *VolumeDriver) GetVolume(name string) (map[string]interface{}, error) {
-	// Get for empty volume name is issued by docker when it is coming up.
+	// Get for empty volume name is issued by docker when it is coming up. Issue #1833
 	// Just return the error in such case.
 	if name == "" {
 		return nil, fmt.Errorf(" No volume with name as empty string exists")

--- a/client_plugin/drivers/vmdk/vmdk_driver.go
+++ b/client_plugin/drivers/vmdk/vmdk_driver.go
@@ -125,7 +125,7 @@ func (d *VolumeDriver) List(r volume.Request) volume.Response {
 // GetVolume - return volume meta-data.
 func (d *VolumeDriver) GetVolume(name string) (map[string]interface{}, error) {
 	mdata, err := d.ops.Get(name)
-	if err != nil {
+	if err != nil && name != "" {
 		log.WithFields(log.Fields{"name": name, "error": err}).Error("Failed to get volume meta-data ")
 	}
 	return mdata, err

--- a/client_plugin/drivers/vmdk/vmdk_driver.go
+++ b/client_plugin/drivers/vmdk/vmdk_driver.go
@@ -125,6 +125,7 @@ func (d *VolumeDriver) List(r volume.Request) volume.Response {
 // GetVolume - return volume meta-data.
 func (d *VolumeDriver) GetVolume(name string) (map[string]interface{}, error) {
 	mdata, err := d.ops.Get(name)
+	// Get for empty volume name is issued by docker when it is coming up. Do not log error for this case.
 	if err != nil && name != "" {
 		log.WithFields(log.Fields{"name": name, "error": err}).Error("Failed to get volume meta-data ")
 	}


### PR DESCRIPTION
Docker issues get volume for empty name when docker is coming up.
Such a volume is always bound to not be present. Do not log such an error to avoid confusion during debugging.

Before fix:
```
2017-08-27 00:18:05.532271346 +0000 UTC [INFO] No config file found. Using defaults.
2017-08-27 00:18:05.53236616 +0000 UTC [INFO] Starting plugin driver=vsphere log_level=info config="/etc/docker-volume-vsphere.conf" 
2017-08-27 00:18:05.53246005 +0000 UTC [INFO] Getting volume data from unix:///var/run/docker.sock
2017-08-27 00:18:07.532759667 +0000 UTC [INFO] Can't connect to unix:///var/run/docker.sock due to (An error occurred trying to connect: context deadline exceeded), skipping discovery
2017-08-27 00:18:07.532818301 +0000 UTC [INFO] Refcounting failed: (An error occurred trying to connect: context deadline exceeded).
2017-08-27 00:18:07.532836898 +0000 UTC [INFO] Docker VMDK plugin started version="vSphere Volume Driver v0.5" port=1019 mock_esx=false 
2017-08-27 00:18:07.533401439 +0000 UTC [INFO] Going into ServeUnix - Listening on Unix socket address="/run/docker/plugins/vsphere.sock" 
2017-08-27 00:18:07.533778242 +0000 UTC [INFO] Scheduling again after 2 seconds
2017-08-27 00:18:08.972390847 +0000 UTC [ERROR] Failed to get volume meta-data name= error="Volume  not found (file: /vmfs/volumes/Datastore1/dockvols/11111111-1111-1111-1111-111111111111/.vmdk)" 
2017-08-27 00:18:09.068758549 +0000 UTC [ERROR] Failed to get volume meta-data name="BasicTestSuite.TestVmGroupVolumeIsolation_volume_351821" error="Volume BasicTestSuite.TestVmGroupVolumeIsolation_volume_351821 not found (file: /vmfs/volumes/Datastore1/dockvols/11111111-1111-1111-1111-111111111111/BasicTestSuite.TestVmGroupVolumeIsolation_volume_351821.vmdk)" 
2017-08-27 00:18:09.1657383 +0000 UTC [ERROR] Failed to get volume meta-data name= error="Volume  not found (file: /vmfs/volumes/Datastore1/dockvols/11111111-1111-1111-1111-111111111111/.vmdk)" 
2017-08-27 00:18:09.477024551 +0000 UTC [ERROR] Failed to get volume meta-data error="Volume  not found (file: /vmfs/volumes/Datastore1/dockvols/11111111-1111-1111-1111-111111111111/.vmdk)" name= 
2017-08-27 00:18:09.53432175 +0000 UTC [INFO] Getting volume data from unix:///var/run/docker.sock
```

After fix
```
2017-08-27 10:21:29.006832045 -0700 PDT [INFO] No config file found. Using defaults.
2017-08-27 10:21:29.007068707 -0700 PDT [INFO] Starting plugin log_level=info config="/etc/docker-volume-vsphere.conf" driver=vsphere
2017-08-27 10:21:29.007174231 -0700 PDT [INFO] Getting volume data from unix:///var/run/docker.sock
2017-08-27 10:21:31.007518737 -0700 PDT [INFO] Can't connect to unix:///var/run/docker.sock due to (An error occurred trying to connect: context deadline exceeded), skipping discovery
2017-08-27 10:21:31.00758671 -0700 PDT [INFO] Refcounting failed: (An error occurred trying to connect: context deadline exceeded).
2017-08-27 10:21:31.007606272 -0700 PDT [INFO] Docker VMDK plugin started version="vSphere Volume Driver v0.5" port=1019 mock_esx=false
2017-08-27 10:21:31.008031087 -0700 PDT [INFO] Scheduling again after 2 seconds
2017-08-27 10:21:31.008052156 -0700 PDT [INFO] Going into ServeUnix - Listening on Unix socket address="/run/docker/plugins/vsphere.sock"
2017-08-27 10:21:33.008567576 -0700 PDT [INFO] Getting volume data from unix:///var/run/docker.sock
2017-08-27 10:21:33.169100628 -0700 PDT [INFO] Found 0 running or paused containers
2017-08-27 10:21:33.322833901 -0700 PDT [INFO] Discovered 0 volumes that may be in use.
2017-08-27 10:21:33.322895272 -0700 PDT [INFO] Refcounting successfully completed
2017-08-27 10:23:22.328250909 -0700 PDT [INFO] Mounting volume name="vol2@sharedVmfs-0"
2017-08-27 10:23:22.430850149 -0700 PDT [INFO] Directory doesn't exist, creating it path="/mnt/vmdk/vol2@sharedVmfs-0/"
2017-08-27 10:23:22.8750164 -0700 PDT [INFO] Device file found. device="/dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:0:0"
2017-08-27 10:23:57.259633121 -0700 PDT [INFO] Unmounting Volume name="vol2@sharedVmfs-0"
2017-08-27 10:23:57.81125639 -0700 PDT [WARNING] Received signal signal=terminated
2017-08-27 10:24:00.052876895 -0700 PDT [INFO] No config file found. Using defaults.
2017-08-27 10:24:00.05295672 -0700 PDT [INFO] Starting plugin driver=vsphere log_level=info config="/etc/docker-volume-vsphere.conf"
2017-08-27 10:24:00.05304409 -0700 PDT [INFO] Getting volume data from unix:///var/run/docker.sock
2017-08-27 10:24:02.053950639 -0700 PDT [INFO] Can't connect to unix:///var/run/docker.sock due to (An error occurred trying to connect: context deadline exceeded), skipping discovery
2017-08-27 10:24:02.054047027 -0700 PDT [INFO] Refcounting failed: (An error occurred trying to connect: context deadline exceeded).
2017-08-27 10:24:02.054111493 -0700 PDT [INFO] Docker VMDK plugin started mock_esx=false version="vSphere Volume Driver v0.5" port=1019
2017-08-27 10:24:02.054320053 -0700 PDT [INFO] Scheduling again after 2 seconds
2017-08-27 10:24:02.054509698 -0700 PDT [INFO] Going into ServeUnix - Listening on Unix socket address="/run/docker/plugins/vsphere.sock"
2017-08-27 10:24:04.054694535 -0700 PDT [INFO] Getting volume data from unix:///var/run/docker.sock
2017-08-27 10:24:04.375632396 -0700 PDT [INFO] Mounting volume name="vol2@sharedVmfs-0"
2017-08-27 10:24:04.938929733 -0700 PDT [INFO] Device file found. device="/dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:0:0"
2017-08-27 10:24:05.346756077 -0700 PDT [INFO] Found 1 running or paused containers
2017-08-27 10:24:05.348235995 -0700 PDT [INFO] Discovered 1 volumes that may be in use.
2017-08-27 10:24:05.348253996 -0700 PDT [INFO] Volume name=vol2@sharedVmfs-0 count=1 mounted=true device='/dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:0:0'
2017-08-27 10:24:05.348259525 -0700 PDT [INFO] Refcounting successfully completed
```