### PR TITLE
Enable mount/unmount in e2e testing for vFile

### DIFF
--- a/tests/e2e/advanced_vfile_test.go
+++ b/tests/e2e/advanced_vfile_test.go
@@ -118,7 +118,6 @@ func (s *AdvancedVFileTestSuite) TestVFileVolumeLifecycle(c *C) {
 	grefc, _ = strconv.Atoi(out)
 	c.Assert(grefc, Equals, 0, Commentf("Expected volume global refcount to be 0, found %s", out))
 
-	// delete the volume // Will uncomment after unmount() code is done
 	out, err = dockercli.DeleteVolume(s.worker1, s.volName1)
 	c.Assert(err, IsNil, Commentf(out))
 

--- a/tests/e2e/advanced_vfile_test.go
+++ b/tests/e2e/advanced_vfile_test.go
@@ -20,12 +20,13 @@
 package e2e
 
 import (
+	"strconv"
+
 	"github.com/vmware/docker-volume-vsphere/tests/utils/dockercli"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/inputparams"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/misc"
 	"github.com/vmware/docker-volume-vsphere/tests/utils/verification"
 	. "gopkg.in/check.v1"
-	"strconv"
 )
 
 const (

--- a/tests/e2e/basic_vfile_test.go
+++ b/tests/e2e/basic_vfile_test.go
@@ -75,7 +75,6 @@ var _ = Suite(&BasicVFileTestSuite{})
 // 7. Verify volume status is detached
 // 8. Remove the volume
 // 9. Verify the volume is unavailable
-// TODO: step 3-7 currently is not available since volume mount/unmount is not available yet
 func (s *BasicVFileTestSuite) TestVolumeLifecycle(c *C) {
 	misc.LogTestStart(c.TestName())
 
@@ -86,20 +85,21 @@ func (s *BasicVFileTestSuite) TestVolumeLifecycle(c *C) {
 		accessible := verification.CheckVolumeAvailability(host, s.volName1)
 		c.Assert(accessible, Equals, true, Commentf("Volume %s is not available", s.volName1))
 
-		// out, err = dockercli.AttachVolume(host, s.volName1, s.containerName)
-		// c.Assert(err, IsNil, Commentf(out))
+		out, err = dockercli.AttachVolume(host, s.volName1, s.containerName)
+		c.Assert(err, IsNil, Commentf(out))
 
-		// status := verification.VerifyAttachedStatus(s.volName1, host, s.esx)
-		// c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volName1))
+		status := verification.VerifyAttachedStatus(s.volName1, host, s.esx)
+		c.Assert(status, Equals, true, Commentf("Volume %s is not attached", s.volName1))
 
-		// out, err = dockercli.DeleteVolume(host, s.volName1)
-		// c.Assert(err, Not(IsNil), Commentf(out))
+		out, err = dockercli.DeleteVolume(host, s.volName1)
+		c.Assert(err, Not(IsNil), Commentf(out))
 
-		// out, err = dockercli.RemoveContainer(host, s.containerName)
-		// c.Assert(err, IsNil, Commentf(out))
+		out, err = dockercli.RemoveContainer(host, s.containerName)
+		c.Assert(err, IsNil, Commentf(out))
 
-		// status = verification.VerifyDetachedStatus(s.volName1, host, s.esx)
-		// c.Assert(status, Equals, true, Commentf("Volume %s is still attached", s.volName1))
+		status = verification.VerifyDetachedStatus(s.volName1, host, s.esx)
+		c.Assert(status, Equals, true, Commentf("Volume %s is still attached", s.volName1))
+
 		out = verification.GetVFileVolumeStatusHost(s.volName1, host)
 		log.Println("GetVFileVolumeStatusHost return out[%s] for volume %s", out, s.volName1)
 		c.Assert(out, Equals, "Ready", Commentf("Volume %s status is expected to be [Ready], actual status is [%s]",

--- a/tests/utils/dockercli/volumelifecycle.go
+++ b/tests/utils/dockercli/volumelifecycle.go
@@ -50,7 +50,7 @@ func CreateVolumeWithOptions(ip, name, options string) (string, error) {
 // CreateVFileVolume is going to create docker volume with given name using vfile driver.
 func CreateVFileVolume(ip, name string) (string, error) {
 	log.Printf("Creating vFile volume [%s] on VM [%s]\n", name, ip)
-	return ssh.InvokeCommand(ip, dockercli.CreateVFileVolume+" --name= "+name)
+	return ssh.InvokeCommand(ip, dockercli.CreateVFileVolume+" --name="+name)
 }
 
 // CreateVFileVolumeWithOptions is going to create docker volume with given name using vfile driver.


### PR DESCRIPTION
e2e test passed locally.
```
lipingx-m01:docker-volume-vsphere lipingx$ make test-e2e-vfile
/Library/Developer/CommandLineTools/usr/bin/make --directory=client_plugin test-e2e-vfile

=> Running target test-e2e-vfile Tue Sep 12 15:04:51 PDT 2017

../misc/scripts/build.sh test-e2e-runonce-vfile
make: Entering directory `/go/src/github.com/vmware/docker-volume-vsphere/client_plugin'

=> Running target test-e2e-runonce-vfile Tue Sep 12 22:04:52 UTC 2017

go test -v -timeout 50m -tags "runoncevfile" github.com/vmware/docker-volume-vsphere/tests/e2e
=== RUN   Test
2017/09/12 22:04:54 VM name is: vm3
2017/09/12 22:04:55 VM name is: vm2
2017/09/12 22:04:56 START: AdvancedVFileTestSuite.TestVFileVolumeLifecycle
2017/09/12 22:04:56 Creating vFile volume [vfilevolume559360] on VM [10.160.116.6]
2017/09/12 22:04:58 Checking volume [vfilevolume559360] availability from VM [10.160.116.6]
2017/09/12 22:04:59 Attaching vFile volume [vfilevolume559360] on VM [10.160.100.35]
2017/09/12 22:05:07 GetVFileVolumeGlobalRefcount: cmd[]%!(EXTRA string=docker volume inspect  --format "{{index .Status \"Global Refcount\"}}" vfilevolume559360)
2017/09/12 22:05:07 Attaching vFile volume [vfilevolume559360] on VM [10.160.116.6]
2017/09/12 22:05:10 GetVFileVolumeGlobalRefcount: cmd[]%!(EXTRA string=docker volume inspect  --format "{{index .Status \"Global Refcount\"}}" vfilevolume559360)
2017/09/12 22:05:10 Writing QWERTYUIOP000000000000 to file test.txt on volume [vfilevolume559360] from VM[10.160.100.35]
2017/09/12 22:05:11 Reading from file test.txt on volume [vfilevolume559360] from VM[10.160.116.6]
2017/09/12 22:05:12 Writing ASDFGHJKLL111111111111 to file test.txt on volume [vfilevolume559360] from VM[10.160.116.6]
2017/09/12 22:05:13 Reading from file test.txt on volume [vfilevolume559360] from VM[10.160.100.35]
2017/09/12 22:05:14 Removing container [AdvancedVFileTestSuite.TestVFileVolumeLifecycle_container_337659] on VM [10.160.100.35]
2017/09/12 22:05:15 GetVFileVolumeGlobalRefcount: cmd[]%!(EXTRA string=docker volume inspect  --format "{{index .Status \"Global Refcount\"}}" vfilevolume559360)
2017/09/12 22:05:15 Removing container [AdvancedVFileTestSuite.TestVFileVolumeLifecycle_container_337659] on VM [10.160.116.6]
2017/09/12 22:05:17 GetVFileVolumeGlobalRefcount: cmd[]%!(EXTRA string=docker volume inspect  --format "{{index .Status \"Global Refcount\"}}" vfilevolume559360)
2017/09/12 22:05:17 Destroying volume [vfilevolume559360]
2017/09/12 22:05:23 END: AdvancedVFileTestSuite.TestVFileVolumeLifecycle
2017/09/12 22:05:23 START: BasicVFileTestSuite.TestVolumeLifecycle
2017/09/12 22:05:23 Creating vFile volume [vfilevolume186750] on VM [10.160.100.35]
2017/09/12 22:05:25 Checking volume [vfilevolume186750] availability from VM [10.160.100.35]
2017/09/12 22:05:26 Attaching vFile volume [vfilevolume186750] on VM [10.160.100.35]
2017/09/12 22:05:33 GetVFileVolumeGlobalRefcount: cmd[]%!(EXTRA string=docker volume inspect  --format "{{index .Status \"Global Refcount\"}}" vfilevolume186750)
2017/09/12 22:05:34 Destroying volume [vfilevolume186750]
2017/09/12 22:05:34 Removing container [BasicVFileTestSuite.TestVolumeLifecycle_container_583076] on VM [10.160.100.35]
2017/09/12 22:05:36 GetVFileVolumeGlobalRefcount: cmd[]%!(EXTRA string=docker volume inspect  --format "{{index .Status \"Global Refcount\"}}" vfilevolume186750)
2017/09/12 22:05:41 GetVFileVolumeStatusHost: cmd[]%!(EXTRA string=docker volume inspect  --format "{{index .Status \"Volume Status\"}}" vfilevolume186750)
2017/09/12 22:05:41 GetVFileVolumeStatusHost return out[%s] for volume %s Ready vfilevolume186750
2017/09/12 22:05:41 Checking volume [vfilevolume186750] availability from VM [10.160.100.35]
2017/09/12 22:05:42 Destroying volume [vfilevolume186750]
2017/09/12 22:05:45 Creating vFile volume [vfilevolume186750] on VM [10.160.116.6]
2017/09/12 22:05:48 Checking volume [vfilevolume186750] availability from VM [10.160.116.6]
2017/09/12 22:05:48 Attaching vFile volume [vfilevolume186750] on VM [10.160.116.6]
2017/09/12 22:05:56 GetVFileVolumeGlobalRefcount: cmd[]%!(EXTRA string=docker volume inspect  --format "{{index .Status \"Global Refcount\"}}" vfilevolume186750)
2017/09/12 22:05:56 Destroying volume [vfilevolume186750]
2017/09/12 22:05:57 Removing container [BasicVFileTestSuite.TestVolumeLifecycle_container_583076] on VM [10.160.116.6]
2017/09/12 22:05:58 GetVFileVolumeGlobalRefcount: cmd[]%!(EXTRA string=docker volume inspect  --format "{{index .Status \"Global Refcount\"}}" vfilevolume186750)
2017/09/12 22:06:03 GetVFileVolumeStatusHost: cmd[]%!(EXTRA string=docker volume inspect  --format "{{index .Status \"Volume Status\"}}" vfilevolume186750)
2017/09/12 22:06:04 GetVFileVolumeStatusHost return out[%s] for volume %s Ready vfilevolume186750
2017/09/12 22:06:04 Checking volume [vfilevolume186750] availability from VM [10.160.116.6]
2017/09/12 22:06:04 Destroying volume [vfilevolume186750]
2017/09/12 22:06:08 END: BasicVFileTestSuite.TestVolumeLifecycle
2017/09/12 22:06:08 START: VolumeCreateVFileTestSuite.TestInvalidName
2017/09/12 22:06:08 Creating vFile volume [volume/abc] on VM [10.160.100.35]
2017/09/12 22:06:08 Creating vFile volume [Volume-000000] on VM [10.160.100.35]
2017/09/12 22:06:08 Creating vFile volume [Volume_volume_988543@invalidDatastore] on VM [10.160.100.35]
2017/09/12 22:06:08 Creating vFile volume [BpLnfgDsc2WD8F2qNfHK5a84jjJkwzDkh9h2fhfUVuS9jZ8uVbhV3vC5AWX39IVUWSP2NcHciWvqZTa2N95RxRTZHWUsaD6HEdz0T] on VM [10.160.100.35]
2017/09/12 22:06:09 END: VolumeCreateVFileTestSuite.TestInvalidName
2017/09/12 22:06:09 START: VolumeCreateVFileTestSuite.TestInvalidOptions
2017/09/12 22:06:09 Creating vFile volume [option_volume_489988] with options [ -o sizes=100mb] on VM [10.160.100.35]
2017/09/12 22:06:09 Creating vFile volume [option_volume_388418] with options [ -o size=100mbb] on VM [10.160.100.35]
2017/09/12 22:06:09 Creating vFile volume [option_volume_729877] with options [ -o size=100gbEE] on VM [10.160.100.35]
2017/09/12 22:06:10 END: VolumeCreateVFileTestSuite.TestInvalidOptions
2017/09/12 22:06:10 START: VolumeCreateVFileTestSuite.TestValidName
2017/09/12 22:06:10 Creating vFile volume ["Volume Space"] on VM [10.160.100.35]
2017/09/12 22:06:10 Creating vFile volume [Volume-0000000] on VM [10.160.100.35]
2017/09/12 22:06:10 Creating vFile volume [Volume-0000000-****-###] on VM [10.160.100.35]
2017/09/12 22:06:10 Creating vFile volume [Volume-00000] on VM [10.160.100.35]
2017/09/12 22:06:10 Creating vFile volume [abc_volume_303473@'vsanDatastore'] on VM [10.160.100.35]
2017/09/12 22:06:10 Creating vFile volume [eO3YdmZ24gorjSUuXhaCC7WfAe9CLf0sVue2KegTHrTWawWaS5tjqp3h6PuHFJx6twUzGeNrLZP6gI2pWUWeflQBK] on VM [10.160.100.35]
2017/09/12 22:06:10 Creating vFile volume [abc_volume_844682@@@@'vsanDatastore'] on VM [10.160.100.35]
2017/09/12 22:06:10 Creating vFile volume [Volume-你_volume_567508] on VM [10.160.100.35]
2017/09/12 22:06:29 Checking volume ["Volume Space" abc_volume_303473@'vsanDatastore' Volume-你_volume_567508 eO3YdmZ24gorjSUuXhaCC7WfAe9CLf0sVue2KegTHrTWawWaS5tjqp3h6PuHFJx6twUzGeNrLZP6gI2pWUWeflQBK Volume-00000 Volume-0000000 Volume-0000000-****-### abc_volume_844682@@@@'vsanDatastore'] availability from VM [10.160.100.35]
2017/09/12 22:06:29 END: VolumeCreateVFileTestSuite.TestValidName
2017/09/12 22:06:29 Destroying volume ["Volume Space" abc_volume_303473@'vsanDatastore' Volume-你_volume_567508 eO3YdmZ24gorjSUuXhaCC7WfAe9CLf0sVue2KegTHrTWawWaS5tjqp3h6PuHFJx6twUzGeNrLZP6gI2pWUWeflQBK Volume-00000 Volume-0000000 Volume-0000000-****-### abc_volume_844682@@@@'vsanDatastore']
2017/09/12 22:06:55 START: VolumeCreateVFileTestSuite.TestValidOptions
2017/09/12 22:06:55 Creating vFile volume [option_volume_256084] with options [ -o size=10gb] on VM [10.160.100.35]
2017/09/12 22:06:59 Checking volume [option_volume_256084] availability from VM [10.160.100.35]
2017/09/12 22:06:59 END: VolumeCreateVFileTestSuite.TestValidOptions
2017/09/12 22:06:59 Destroying volume [option_volume_256084]
OK: 6 passed
--- PASS: Test (130.10s)
PASS
ok  	github.com/vmware/docker-volume-vsphere/tests/e2e	130.108s
make: Leaving directory `/go/src/github.com/vmware/docker-volume-vsphere/client_plugin'

```