### PR TITLE
[SKIP CI] Update Edit me link on customer facing documents to point to vmware:master

### DIFF
--- a/jekyll-docs/_config.yml
+++ b/jekyll-docs/_config.yml
@@ -12,7 +12,7 @@ site_title: vSphere Docker Volume Service
 company_name: VMWare
 # this appears in the footer
 
-github_editme_path: vmware/docker-volume-vsphere/edit/gh-pages/jekyll-docs
+github_editme_path: vmware/docker-volume-vsphere/edit/master/docs/external
 # if you're using Github, provide the basepath to the branch you've created for reviews, following the sample here. if not, leave this value blank.
 
 disqus_shortname: idrbwjekyll


### PR DESCRIPTION
This PR addresses issue #1847.

This change ensures that "Edit me" on vmware.github.io points to vmware:master/docs folder