### PR TITLE
Populate client list on mount and depopulate on unmount

### DIFF
--- a/client_plugin/drivers/vfile/kvstore/etcdops/etcdops.go
+++ b/client_plugin/drivers/vfile/kvstore/etcdops/etcdops.go
@@ -76,8 +76,8 @@ type EtcdKVS struct {
 	nodeAddr  string
 }
 
-// vFileVolConnectivityData - Contains metadata of vFile volumes
-type vFileVolConnectivityData struct {
+// VFileVolConnectivityData - Contains metadata of vFile volumes
+type VFileVolConnectivityData struct {
 	Port        int      `json:"port,omitempty"`
 	ServiceName string   `json:"serviceName,omitempty"`
 	Username    string   `json:"username,omitempty"`
@@ -415,7 +415,7 @@ func (e *EtcdKVS) etcdEventHandler(ev *etcdClient.Event) {
 			// port number and file service name.
 			var entries []kvstore.KvPair
 			var writeEntries []kvstore.KvPair
-			var volRecord vFileVolConnectivityData
+			var volRecord VFileVolConnectivityData
 
 			// Port, Server name, Client list, Samba
 			// username/password are in the same key.

--- a/client_plugin/drivers/vfile/kvstore/etcdops/etcdops.go
+++ b/client_plugin/drivers/vfile/kvstore/etcdops/etcdops.go
@@ -78,11 +78,10 @@ type EtcdKVS struct {
 
 // VFileVolConnectivityData - Contains metadata of vFile volumes
 type VFileVolConnectivityData struct {
-	Port        int      `json:"port,omitempty"`
-	ServiceName string   `json:"serviceName,omitempty"`
-	Username    string   `json:"username,omitempty"`
-	Password    string   `json:"password,omitempty"`
-	ClientList  []string `json:"clientList,omitempty"`
+	Port        int    `json:"port,omitempty"`
+	ServiceName string `json:"serviceName,omitempty"`
+	Username    string `json:"username,omitempty"`
+	Password    string `json:"password,omitempty"`
 }
 
 // NewKvStore function: start or join ETCD cluster depending on the role of the node
@@ -370,7 +369,7 @@ func (e *EtcdKVS) serviceAndVolumeGC(cli *etcdClient.Client) {
 
 // cleanOrphanService: stop orphan services
 func (e *EtcdKVS) cleanOrphanService(volumesToVerify []string) {
-	volStates, err := e.kvMapFromPrefix(string(kvstore.VolPrefixState))
+	volStates, err := e.KvMapFromPrefix(string(kvstore.VolPrefixState))
 	if err != nil {
 		// if ETCD is not functionaing correctly, stop and return
 		log.Warningf("Failed to get volume states from ETCD due to error %v.", err)

--- a/client_plugin/drivers/vfile/kvstore/kvstore.go
+++ b/client_plugin/drivers/vfile/kvstore/kvstore.go
@@ -56,6 +56,7 @@ const (
 	VolPrefixState                    = "SVOLS_stat_"
 	VolPrefixGRef                     = "SVOLS_gref_"
 	VolPrefixInfo                     = "SVOLS_info_"
+	VolPrefixClient                   = "SVOLS_client_"
 	VolumeDoesNotExistError           = "No such volume"
 )
 
@@ -96,4 +97,10 @@ type KvStore interface {
 	// BlockingWaitAndGet - Blocking wait until a key value becomes equal to a specific value
 	// then read the value of another key
 	BlockingWaitAndGet(key string, value string, newKey string) (string, error)
+
+	// KvMapFromPrefix -  Create key-value pairs according to a given prefix
+	KvMapFromPrefix(prefix string) (map[string]string, error)
+
+	// DeleteClientMetaData - Delete volume client metadata in KV store
+	DeleteClientMetaData(name string, nodeID string) error
 }

--- a/client_plugin/drivers/vfile/vfile_driver.go
+++ b/client_plugin/drivers/vfile/vfile_driver.go
@@ -772,7 +772,6 @@ func (d *VolumeDriver) UnmountVolume(name string) error {
 			}).Error("Failed to remove VM IP from ClientList")
 		return err
 	}
-
 	return nil
 }
 

--- a/client_plugin/drivers/vfile/vfile_driver.go
+++ b/client_plugin/drivers/vfile/vfile_driver.go
@@ -674,25 +674,6 @@ func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isRead
 		return "", errors.New(msg)
 	}
 
-	// mount is successful, update the clientList
-	_, addr, _, err := d.dockerOps.GetSwarmInfo()
-	if err != nil {
-		log.WithFields(
-			log.Fields{"volume name": name,
-				"error": err,
-			}).Error("Failed to get IP address from docker swarm ")
-		return "", err
-	}
-
-	err = d.addVMToClientList(name, addr)
-	if err != nil {
-		log.WithFields(
-			log.Fields{"volume name": name,
-				"error": err,
-			}).Error("Failed to add VM IP to ClientList")
-		return "", err
-	}
-
 	return mountpoint, nil
 }
 
@@ -735,6 +716,15 @@ func (d *VolumeDriver) mountVFileVolume(volName string, mountpoint string, volRe
 				"output": string(output),
 				"error":  err,
 			}).Error("Mount failed: ")
+		return err
+	}
+
+	err = d.addVMToClientList(volName, addr)
+	if err != nil {
+		log.WithFields(
+			log.Fields{"volume name": volName,
+				"error": err,
+			}).Error("Failed to add VM IP to ClientList")
 		return err
 	}
 


### PR DESCRIPTION
Fixed #1761 .
I have done the following test manually.
Configuration: 3 VMs in a swarm cluster, 1 master and 2 workers
VM1: 10.160.112.117 (master)
VM2: 10.160.120.245 (worker)
VM3: 10.160.122.147(worker)
1. create a volume "vol1" using vFile plugin
```
vmware@ubuntu16:~$ docker volume ls
DRIVER              VOLUME NAME
vmware@ubuntu16:~$ docker volume create --driver=vfile --name=vol1
vol1
vmware@ubuntu16:~$ 
vmware@ubuntu16:~$ docker volume ls
DRIVER              VOLUME NAME
vsphere:latest      _vF_vol1@vsanDatastore
vfile:latest        vol1
vmware@ubuntu16:~$ docker volume inspect vol1
[
    {
        "Driver": "vfile:latest",
        "Labels": {},
        "Mountpoint": "/mnt/vfile/vol1/",
        "Name": "vol1",
        "Options": {},
        "Scope": "global",
        "Status": {
            "Clients": null,
            "File server Port": 0,
            "Global Refcount": 0,
            "Service name": "",
            "Volume Status": "Ready"
        }
    }
]
```
2. mount volume from VM1, then check the "docker volume inspect" result, we can see the IP of VM1 has been added to the "Clients" section.
```
vmware@ubuntu16:~$ docker run -it -v vol1:/vol busybox /bin/sh
/ # vmware@ubuntu16:~$ 
vmware@ubuntu16:~$ docker volume inspect vol1
[
    {
        "Driver": "vfile:latest",
        "Labels": {},
        "Mountpoint": "/mnt/vfile/vol1/",
        "Name": "vol1",
        "Options": {},
        "Scope": "global",
        "Status": {
            "Clients": [
                "10.160.112.117"
            ],
            "File server Port": 30000,
            "Global Refcount": 1,
            "Service name": "vFileServervol1",
            "Volume Status": "Mounted"
        }
    }
]
```

3. Try to mount "vol1" from VM2, then check the "docker volume inspect" result, we can see the IP of VM2 has been added to the "Clients" section.
```
vmware@ubuntu16:~$ docker run -it -v vol1:/vol busybox /bin/sh
/ # vmware@ubuntu16:~$ 

vmware@ubuntu16:~$ docker volume inspect vol1
[
    {
        "Driver": "vfile:latest",
        "Labels": {},
        "Mountpoint": "/mnt/vfile/vol1/",
        "Name": "vol1",
        "Options": {},
        "Scope": "global",
        "Status": {
            "Clients": [
                "10.160.112.117",
                "10.160.120.245"
            ],
            "File server Port": 30000,
            "Global Refcount": 2,
            "Service name": "vFileServervol1",
            "Volume Status": "Mounted"
        }
    }
]
```

4. Try to mount "vol1" from VM3, then check the "docker volume inspect" result, we can see the IP of VM3 has been added to the "Clients" section.
```
vmware@ubuntu16:~$ docker run -it -v vol1:/vol busybox /bin/sh

vmware@ubuntu16:~$ docker volume inspect vol1
[
    {
        "Driver": "vfile:latest",
        "Labels": {},
        "Mountpoint": "/mnt/vfile/vol1/",
        "Name": "vol1",
        "Options": {},
        "Scope": "global",
        "Status": {
            "Clients": [
                "10.160.112.117",
                "10.160.120.245",
                "10.160.122.147"
            ],
            "File server Port": 30000,
            "Global Refcount": 3,
            "Service name": "vFileServervol1",
            "Volume Status": "Mounted"
        }
    }
]
```

5. unmount "vol1" from VM3,  then check the "docker volume inspect" result, we can see the IP of VM3 has been removed from the "Clients" section.
```
vmware@ubuntu16:~$ docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS               NAMES
ae31c3b8768b        busybox             "/bin/sh"                22 seconds ago      Up 18 seconds                           keen_bartik
55e8d79a426f        nginx:latest        "nginx -g 'daemon ..."   8 minutes ago       Up 8 minutes        80/tcp              nginx_serivce.1.q2t8o15bwcsi6lmplx2ud7s9q

vmware@ubuntu16:~$ docker rm ae31c3b8768b -f
ae31c3b8768b

vmware@ubuntu16:~$ docker volume inspect vol1
[
    {
        "Driver": "vfile:latest",
        "Labels": {},
        "Mountpoint": "/mnt/vfile/vol1/",
        "Name": "vol1",
        "Options": {},
        "Scope": "global",
        "Status": {
            "Clients": [
                "10.160.112.117",
                "10.160.120.245"
            ],
            "File server Port": 30000,
            "Global Refcount": 2,
            "Service name": "vFileServervol1",
            "Volume Status": "Mounted"
        }
    }
]
```

6. unmount "vol1" from VM2,  then check the "docker volume inspect" result, we can see the IP of VM2 has been removed from the "Clients" section.
```
vmware@ubuntu16:~$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
1d841ae5b9ba        busybox             "/bin/sh"           About a minute ago   Up About a minute                       musing_bardeen

vmware@ubuntu16:~$ docker rm 1d841ae5b9ba   -f
1d841ae5b9ba

vmware@ubuntu16:~$ docker volume inspect vol1
[
    {
        "Driver": "vfile:latest",
        "Labels": {},
        "Mountpoint": "/mnt/vfile/vol1/",
        "Name": "vol1",
        "Options": {},
        "Scope": "global",
        "Status": {
            "Clients": [
                "10.160.112.117"
            ],
            "File server Port": 30000,
            "Global Refcount": 1,
            "Service name": "vFileServervol1",
            "Volume Status": "Mounted"
        }
    }
]
```

7. unmount "vol1" from VM1,  then check the "docker volume inspect" result, we can see the IP of VM1 has been removed from the "Clients" section.
```
vmware@ubuntu16:~$ docker ps
CONTAINER ID        IMAGE                  COMMAND                  CREATED             STATUS              PORTS                           NAMES
8e12fa40c92a        dperson/samba:latest   "samba.sh -s share..."   3 minutes ago       Up 3 minutes        139/tcp, 137-138/udp, 445/tcp   vFileServervol1.1.e78e71txfldl3caoaabyadjhh
144d7f74f58b        busybox                "/bin/sh"                3 minutes ago       Up 3 minutes                                        hardcore_benz

vmware@ubuntu16:~$ docker rm 144d7f74f58b  -f
144d7f74f58b
vmware@ubuntu16:~$ 
vmware@ubuntu16:~$ 
vmware@ubuntu16:~$ docker volume inspect vol1
[
    {
        "Driver": "vfile:latest",
        "Labels": {},
        "Mountpoint": "/mnt/vfile/vol1/",
        "Name": "vol1",
        "Options": {},
        "Scope": "global",
        "Status": {
            "Clients": null,
            "File server Port": 0,
            "Global Refcount": 0,
            "Service name": "",
            "Volume Status": "Ready"
        }
    }
]
```
```