### PR TITLE
Fix test cleanup for test-esx target

### DIFF
--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -840,6 +840,7 @@ class VmdkTenantTestCase(unittest.TestCase):
             self.assertEqual(self.default_tenant_vol1_name + "@" + self.datastore_name, result[0]['Name'])
             self.assertEqual(self.default_tenant_vol2_name + "@" + self.datastore1_name, result[1]['Name'])
             
+            # deleting the volume "default_tenant_vol2"
             default_tenant_path = os.path.join(self.datastore1_path, auth_data_const.DEFAULT_TENANT_UUID)
             vmdk_path = vmdk_utils.get_vmdk_path(default_tenant_path, self.default_tenant_vol2_name)
             vmdk_ops.removeVMDK(vmdk_path)

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -675,7 +675,7 @@ class VmdkTenantTestCase(unittest.TestCase):
                 if len(datastores) > 1:
                     datastore1 = datastores[1]
                     self.datastore1_name = datastore1[0]
-                    self.datastoer1_path = datastore[2]
+                    self.datastore1_path = datastore1[2]
                     logging.debug("Found second datastore: datastore_name=%s datastore_path=%s",
                                   self.datastore1_name, self.datastore1_path)
             else:
@@ -839,6 +839,10 @@ class VmdkTenantTestCase(unittest.TestCase):
             self.assertEqual(len(result), 2)
             self.assertEqual(self.default_tenant_vol1_name + "@" + self.datastore_name, result[0]['Name'])
             self.assertEqual(self.default_tenant_vol2_name + "@" + self.datastore1_name, result[1]['Name'])
+            
+            default_tenant_path = os.path.join(self.datastore1_path, auth_data_const.DEFAULT_TENANT_UUID)
+            vmdk_path = vmdk_utils.get_vmdk_path(default_tenant_path, self.default_tenant_vol2_name)
+            vmdk_ops.removeVMDK(vmdk_path)
 
             # remove privilege to datastore "self.datastore1_name"
             error_info = auth_api._tenant_access_rm(name=auth_data_const.DEFAULT_TENANT,

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -777,14 +777,14 @@ class VmdkTenantTestCase(unittest.TestCase):
 
     def test_vmdkops_on_default_tenant_vm(self):
         """ Test vmdk life cycle on a VM which belongs to DEFAULT tenant """
-        # This test test the following cases:
-        # 1. DEFAULT tenant, privilege to datastore "_ALL_DS", and privilege to datastore "_VM_DS""
+        # This test tests the following cases:
+        # 1. For DEFAULT tenant, privilege to datastore "_ALL_DS", and privilege to datastore "_VM_DS""
         # are present, vmdk_ops from VM which is not owned by any tenant, vmdk_ops should succeed, and the volumes
         # will be created in the _VM_DS
-        # 2. change the default_datastore for DEFAULT tenant,  volume create with short name should be created in the
+        # 2. Change the default_datastore for DEFAULT tenant,  volume create with short name should be created in the
         # default datastore instead of VM datastore
-        # 3. Only privilege to  "_VM_DS" present, "create volume" should succed
-        # 4. REMOVE DEFAULT tenant, "create volume" should fail
+        # 3. With privilege set only to  "_VM_DS", "create volume" should succeed
+        # 4. After removing DEFAULT tenant, "create volume" should fail
 
         # run create, attach, detach, remove command when DEFAULT tenant and  privileges to "_ALL_DS" and "_VM_DS" are present
         # This is the case after user fresh install


### PR DESCRIPTION
This PR addresses the issue #1479 

Performed local testing. All tests passed successfully and there were no leftover volumes
```
=> Running target test-esx Mon Oct 9 11:28:37 PDT 2017

Esx cli volume ls:

[root@sc2-rdops-vm03-dhcp-106-33:~] esxcli storage guestvol volume ls
Volume  Datastore  VMGroup  Capacity  Used  Filesystem  Policy  Disk Format  Attached-to  Access  Attach-as  Created By  Created Date
------  ---------  -------  --------  ----  ----------  ------  -----------  -----------  ------  ---------  ----------  ------------

[root@sc2-rdops-vm03-dhcp-106-33:~]
```