### PR TITLE
Fix VSAN test to not use hard-coded value for vsan datatstore name

### DIFF
--- a/esx_service/utils/vsan_info_test.py
+++ b/esx_service/utils/vsan_info_test.py
@@ -32,7 +32,7 @@ class TestVsanInfo(unittest.TestCase):
     """ Test VSAN Info API """
 
     VM_NAME = "test-vm"
-    VSAN_DS = "/vmfs/volumes/vsandatastore"
+    VSAN_DS = "/vmfs/volumes/"+vsan_info.get_vsan_datastore().info.name
     TEST_DIR = os.path.join(VSAN_DS, "vsan_info_test")
     TEST_VOL = "test_policy_vol"
     VMDK_PATH = os.path.join(TEST_DIR, TEST_VOL + ".vmdk")
@@ -48,6 +48,7 @@ class TestVsanInfo(unittest.TestCase):
     def setUp(self):
         """create a vmdk before each test (method) in this class"""
         si = vmdk_ops.get_si()
+
         # create VMDK
         err = vmdk_ops.createVMDK(vmdk_path=self.VMDK_PATH,
                                   vm_name=self.VM_NAME,


### PR DESCRIPTION
This PR fixes the issue #1696 

Tested locally. All test-esx tests passed.

```
Running unit tests in /tmp/vmdk_ops_unittest18912/vsan_info_test.py...
..
----------------------------------------------------------------------
Ran 2 tests in 2.358s

OK
```