### PR TITLE
Allow create calls to be idempotent in the VDVS plugin

### DIFF
--- a/client_plugin/drivers/vmdk/vmdk_driver.go
+++ b/client_plugin/drivers/vmdk/vmdk_driver.go
@@ -28,6 +28,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
@@ -369,6 +370,9 @@ func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 	errCreate := d.ops.Create(r.Name, r.Options)
 	if errCreate != nil {
 		log.WithFields(log.Fields{"name": r.Name, "error": errCreate}).Error("Create volume failed ")
+		if strings.Contains(errCreate.Error(), "already exists") {
+			return volume.Response{Err: ""}
+		}
 		return volume.Response{Err: errCreate.Error()}
 	}
 

--- a/client_plugin/drivers/vmdk/vmdk_driver.go
+++ b/client_plugin/drivers/vmdk/vmdk_driver.go
@@ -369,10 +369,10 @@ func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 
 	errCreate := d.ops.Create(r.Name, r.Options)
 	if errCreate != nil {
-		log.WithFields(log.Fields{"name": r.Name, "error": errCreate}).Error("Create volume failed ")
 		if strings.Contains(errCreate.Error(), "already exists") {
 			return volume.Response{Err: ""}
 		}
+		log.WithFields(log.Fields{"name": r.Name, "error": errCreate}).Error("Create volume failed ")
 		return volume.Response{Err: errCreate.Error()}
 	}
 

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -189,8 +189,9 @@ def createVMDK(vmdk_path, vm_name, vol_name,
 
     if os.path.isfile(vmdk_path):
         # We are mostly here due to race or Plugin VMCI retry #1076
-        logging.warning("File %s already exists", vmdk_path)
-        return None
+        msg = "File {0} already exists".format(vmdk_path) 
+        logging.warning(msg)
+        return err(msg)
 
     try:
         validate_opts(opts, vmdk_path)

--- a/tests/e2e/basic_test.go
+++ b/tests/e2e/basic_test.go
@@ -68,7 +68,7 @@ var _ = Suite(&BasicTestSuite{})
 // VM3 - created on shared VSAN datastore (TODO: currently not available)
 //
 // Test steps:
-// 1. Create a volume, re-create the volume and verify the create is idempotent
+// 1. Create a volume, re-create the volume, verify the create is idempotent
 // 2. Verify the volume is available
 // 3. Attach the volume
 // 4. Verify volume status is attached

--- a/tests/e2e/basic_test.go
+++ b/tests/e2e/basic_test.go
@@ -68,7 +68,7 @@ var _ = Suite(&BasicTestSuite{})
 // VM3 - created on shared VSAN datastore (TODO: currently not available)
 //
 // Test steps:
-// 1. Create a volume
+// 1. Create a volume, re-create the volume and verify the create is idempotent
 // 2. Verify the volume is available
 // 3. Attach the volume
 // 4. Verify volume status is attached
@@ -82,6 +82,9 @@ func (s *BasicTestSuite) TestVolumeLifecycle(c *C) {
 
 	for _, host := range s.config.DockerHosts {
 		out, err := dockercli.CreateVolume(host, s.volName1)
+		c.Assert(err, IsNil, Commentf(out))
+
+		out, err = dockercli.CreateVolume(host, s.volName1)
 		c.Assert(err, IsNil, Commentf(out))
 
 		accessible := verification.CheckVolumeAvailability(host, s.volName1)


### PR DESCRIPTION
Updated the ESX service and plugin to allow create to succeed if the volume already exists. Tested with UCP 2.2.4. Remove of volume is not working owing to a docker side issue where the labels of the nodes in the swarm are different and hence the remove doesn't work. All discussion of the docker side issue is in https://github.com/moby/moby/issues/35334.

Volume inspect is at present not supported in UCP.

Extended a basic test to check for idempotency of create.