### PR TITLE
Implement the new locking and notification system for vFile

### DIFF
--- a/client_plugin/drivers/vfile/kvstore/etcdops/etcdops.go
+++ b/client_plugin/drivers/vfile/kvstore/etcdops/etcdops.go
@@ -30,6 +30,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	etcdClient "github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/vmware/docker-volume-vsphere/client_plugin/drivers/vfile/dockerops"
 	"github.com/vmware/docker-volume-vsphere/client_plugin/drivers/vfile/kvstore"
 )
@@ -52,8 +53,10 @@ import (
    gcTicker:                   ticker for garbage collector to run a collection
    etcdClientCreateError:      Error indicating failure to create etcd client
    swarmUnhealthyErrorMsg:     Message indicating swarm cluster is unhealthy
-   etcdSingleRef:              if global refcount 0 -> 1, start SMB server
-   etcdNoRef:                  if global refcount 1 -> 0, shut down SMB server
+   etcdNoRef:                  global refcount = 0, no dependency on this volume
+   etcdLockTicker:             ticker for blocking wait a ETCD lock
+   etcdLockTimer:              timeout for blocking wait a ETCD lock
+   etcdLockTimeoutErrMsg:      Message indicating the failure to block wait a ETCD lock
 */
 const (
 	etcdDataDir              = "/etcd-data"
@@ -70,8 +73,10 @@ const (
 	gcTicker                 = 15 * time.Second
 	etcdClientCreateError    = "Failed to create etcd client"
 	swarmUnhealthyErrorMsg   = "Swarm cluster maybe unhealthy"
-	etcdSingleRef            = "1"
 	etcdNoRef                = "0"
+	etcdLockTicker           = 1 * time.Second
+	etcdLockTimer            = 20 * time.Second
+	etcdLockTimeoutErrMsg    = "ETCD Lock blocking wait timeout"
 )
 
 type EtcdKVS struct {
@@ -89,6 +94,17 @@ type EtcdKVS struct {
 	etcdClientPort string
 	// etcdPeerPort is port for etcd peers talk to each other
 	etcdPeerPort string
+}
+
+type EtcdLock struct {
+	// Key for this lock
+	Key string
+	// lockCli to hold the client for the lock
+	lockCli *etcdClient.Client
+	// lockSession to hold the session for the lock
+	lockSession *concurrency.Session
+	// lockMutex to hold the mutex for the lock
+	lockMutex *concurrency.Mutex
 }
 
 // VFileVolConnectivityData - Contains metadata of vFile volumes
@@ -539,7 +555,8 @@ func (e *EtcdKVS) checkLocalEtcd() error {
 			} else {
 				log.Infof("Local ETCD client is up successfully, start watcher")
 				e.watcher = cli
-				go e.etcdWatcher(cli)
+				go e.etcdStartWatcher(cli)
+				go e.etcdStopWatcher(cli)
 				return nil
 			}
 		case <-timer.C:
@@ -548,13 +565,24 @@ func (e *EtcdKVS) checkLocalEtcd() error {
 	}
 }
 
-// etcdWatcher function sets up a watcher to monitor all the changes to global refcounts in the KV store
-func (e *EtcdKVS) etcdWatcher(cli *etcdClient.Client) {
-	watchCh := cli.Watch(context.Background(), kvstore.VolPrefixGRef,
+// etcdStartWatcher function sets up a watcher to monitor the change to StartTrigger in the KV store
+func (e *EtcdKVS) etcdStartWatcher(cli *etcdClient.Client) {
+	watchCh := cli.Watch(context.Background(), kvstore.VolPrefixStartTrigger,
 		etcdClient.WithPrefix(), etcdClient.WithPrevKV())
 	for wresp := range watchCh {
 		for _, ev := range wresp.Events {
-			e.etcdEventHandler(ev)
+			e.etcdStartEventHandler(ev)
+		}
+	}
+}
+
+// etcdStopWatcher function sets up a watcher to monitor the change to StopTrigger in the KV store
+func (e *EtcdKVS) etcdStopWatcher(cli *etcdClient.Client) {
+	watchCh := cli.Watch(context.Background(), kvstore.VolPrefixStopTrigger,
+		etcdClient.WithPrefix(), etcdClient.WithPrevKV())
+	for wresp := range watchCh {
+		for _, ev := range wresp.Events {
+			e.etcdStopEventHandler(ev)
 		}
 	}
 }
@@ -650,140 +678,311 @@ func (e *EtcdKVS) cleanOrphanService(volumesToVerify []string) {
 	}
 }
 
-// etcdEventHandler function handles the returned event from etcd watcher of global refcount changes
-func (e *EtcdKVS) etcdEventHandler(ev *etcdClient.Event) {
+// etcdStartEventHandler function handles the returned event from etcd watcher of the start trigger changes
+func (e *EtcdKVS) etcdStartEventHandler(ev *etcdClient.Event) {
 	log.WithFields(
 		log.Fields{"type": ev.Type},
-	).Infof("Watcher on global refcount returns event ")
+	).Debug("Watcher on start trigger returns event ")
 
-	nested := func(key string, fromState kvstore.VolStatus,
-		toState kvstore.VolStatus, interimState kvstore.VolStatus,
-		fn func(string) (int, string, bool)) {
+	// monitor PUT requests on start triggers, excluding the PUT for creation
+	if ev.Type == etcdClient.EventTypePut && ev.PrevKv != nil {
+		log.Debugf("Watcher got a increase event on watcher, new value is %s", string(ev.Kv.Value))
+		volName := strings.TrimPrefix(string(ev.Kv.Key), kvstore.VolPrefixStartTrigger)
 
-		// watcher observes global refcount critical change
-		// transactional edit state first
-		volName := strings.TrimPrefix(key, kvstore.VolPrefixGRef)
-		succeeded := e.CompareAndPutStateOrBusywait(kvstore.VolPrefixState+volName,
-			string(fromState), string(interimState))
-		if !succeeded {
-			// this handler doesn't get the right to start/stop server
+		// Compare the value of start marker, only one watcher will be able to successfully update the value to
+		// the new value of start trigger
+		success, err := e.CompareAndPutIfNotEqual(kvstore.VolPrefixStartMarker+volName, string(ev.Kv.Value))
+		if err != nil || success == false {
 			return
 		}
 
-		port, servName, succeeded := fn(volName)
+		log.Infof("Successfully update the start marker to the value of start trigger, proceed to next step")
+
+		// Get the lock for changing the state and server
+		lock, err := e.CreateLock(kvstore.VolPrefixState + volName)
+		if err != nil {
+			log.Errorf("Failed to create lock for state changing of %s", volName)
+			return
+		}
+
+		err = lock.BlockingLockWithLease()
+		if err != nil {
+			log.Errorf("Failed to blocking wait lock for state changing of %s", volName)
+			lock.ClearLock()
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), etcdRequestTimeout)
+		resp, err := e.watcher.Get(ctx, kvstore.VolPrefixState+volName)
+		cancel()
+		if err != nil {
+			log.WithFields(
+				log.Fields{"volName": volName,
+					"error": err},
+			).Error("Failed to Get state of volume from ETCD ")
+			lock.ReleaseLock()
+			return
+		}
+
+		if string(resp.Kvs[0].Value) == string(kvstore.VolStateMounted) {
+			log.Infof("Volume is already in desired state %s", kvstore.VolStateMounted)
+			lock.ReleaseLock()
+			return
+		}
+
+		// start the SMB server
+		port, servName, succeeded := e.dockerOps.StartSMBServer(volName)
 		if succeeded {
-			// Either starting or stopping SMB
-			// server succeeded.
-			// Update volume metadata to reflect
-			// port number and file service name.
-			var entries []kvstore.KvPair
-			var writeEntries []kvstore.KvPair
-			var volRecord VFileVolConnectivityData
-
-			// Port, Server name, Client list, Samba
-			// username/password are in the same key.
-			// Must fetch this key to know the value
-			// of other fields before rewriting them.
-			keys := []string{
-				kvstore.VolPrefixInfo + volName,
-			}
-			entries, err := e.ReadMetaData(keys)
+			err = e.updateServerInfo(kvstore.VolPrefixInfo+volName, port, servName)
 			if err != nil {
-				// Failed to fetch existing metadata on the volume
-				// Set volume state to error as we cannot
-				// proceed
-				log.Warningf("Failed to read volume metadata before updating port information: %v",
-					err)
-				e.CompareAndPut(kvstore.VolPrefixState+volName,
-					string(interimState),
-					string(kvstore.VolStateError))
-				return
-			}
-			err = json.Unmarshal([]byte(entries[0].Value), &volRecord)
-			if err != nil {
-				// Failed to unmarshal record from JSON
-				// Set volume state to error as we cannot
-				// proceed
-				log.Warningf("Failed to unmarshal JSON for reading existing metadata: %v",
-					err)
-				e.CompareAndPut(kvstore.VolPrefixState+volName,
-					string(interimState),
-					string(kvstore.VolStateError))
-				return
-			}
-			// Rewrite the port number and service name
-			// then marshal the data structure to JSON again.
-			volRecord.Port = port
-			volRecord.ServiceName = servName
-			byteRecord, err := json.Marshal(volRecord)
-			if err != nil {
-				// Failed to marshal record as JSON
-				// Set volume state to error as we cannot
-				// proceed
-				log.Warningf("Failed to marshal JSON for writing metadata: %v",
-					err)
-				e.CompareAndPut(kvstore.VolPrefixState+volName,
-					string(interimState),
-					string(kvstore.VolStateError))
-				return
-			}
-			writeEntries = append(writeEntries, kvstore.KvPair{
-				Key:   kvstore.VolPrefixInfo + volName,
-				Value: string(byteRecord)})
-
-			log.Infof("Updating port and file service name for %s", volName)
-			err = e.WriteMetaData(writeEntries)
-			if err != nil {
-				// Failed to write metadata.
-				// Set volume state to error as we cannot
-				// proceed
-				log.Warningf("Failed to write metadata for volume %s",
-					volName)
-				e.CompareAndPut(kvstore.VolPrefixState+volName,
-					string(interimState),
-					string(kvstore.VolStateError))
+				// Leave the SMB server running but don't update the state
+				log.Errorf("Failed to update metadata for %s", volName)
+				lock.ReleaseLock()
 				return
 			}
 
-			// server start/stop succeed. Set desired state on volume.
+			// server start succeed. Set desired state on volume.
 			stateUpdateResult := e.CompareAndPut(kvstore.VolPrefixState+volName,
-				string(interimState),
-				string(toState))
+				string(kvstore.VolStateReady),
+				string(kvstore.VolStateMounted))
 			if stateUpdateResult == false {
-				// Could not set desired state on volume
-				// set to state Error
-				e.CompareAndPut(kvstore.VolPrefixState+volName,
-					string(interimState),
-					string(kvstore.VolStateError))
+				log.Errorf("Failed to update state of %s from Ready to Mounted", volName)
 			}
 		} else {
-			// failed to start/stop server, set to state Error
-			e.CompareAndPut(kvstore.VolPrefixState+volName,
-				string(interimState),
-				string(kvstore.VolStateError))
+			// failed to start server
+			log.Errorf("Failed to start SMB server for %s", volName)
 		}
-		return
+		lock.ReleaseLock()
 	}
 
-	// What we want to monitor are PUT requests on global refcount
-	// Not delete, not get, not anything else
-	if ev.Type == etcdClient.EventTypePut {
-		if string(ev.Kv.Value) == etcdSingleRef &&
-			ev.PrevKv != nil &&
-			string(ev.PrevKv.Value) == etcdNoRef {
-			// Refcount went 0 -> 1
-			nested(string(ev.Kv.Key), kvstore.VolStateReady,
-				kvstore.VolStateMounted, kvstore.VolStateMounting,
-				e.dockerOps.StartSMBServer)
-		} else if string(ev.Kv.Value) == etcdNoRef &&
-			ev.PrevKv != nil &&
-			string(ev.PrevKv.Value) == etcdSingleRef {
-			// Refcount went 1 -> 0
-			nested(string(ev.Kv.Key), kvstore.VolStateMounted,
-				kvstore.VolStateReady, kvstore.VolStateUnmounting,
-				e.dockerOps.StopSMBServer)
+	return
+}
+
+// etcdStopEventHandler function handles the returned event from etcd watcher of the stop trigger changes
+func (e *EtcdKVS) etcdStopEventHandler(ev *etcdClient.Event) {
+	log.WithFields(
+		log.Fields{"type": ev.Type},
+	).Debug("Watcher on stop trigger returns event ")
+
+	// monitor PUT requests on stop triggers, excluding the PUT for creation
+	if ev.Type == etcdClient.EventTypePut && ev.PrevKv != nil {
+		log.Debugf("Watcher got a increase event on stop watcher, new value is %s", string(ev.Kv.Value))
+		volName := strings.TrimPrefix(string(ev.Kv.Key), kvstore.VolPrefixStopTrigger)
+
+		// Compare the value of stop marker, only one watcher will be able to successfully update the value to
+		// the new value of stop trigger
+		success, err := e.CompareAndPutIfNotEqual(kvstore.VolPrefixStopMarker+volName, string(ev.Kv.Value))
+		if err != nil || success == false {
+			return
+		}
+
+		log.Infof("Successfully update the stop marker to the value of stop trigger, proceed to next step")
+
+		// Get the lock for changing the state and server
+		lock, err := e.CreateLock(kvstore.VolPrefixState + volName)
+		if err != nil {
+			log.Errorf("Failed to create lock for state changing of %s", volName)
+			return
+		}
+
+		err = lock.BlockingLockWithLease()
+		if err != nil {
+			log.Errorf("Failed to blocking wait lock for state changing of %s", volName)
+			lock.ClearLock()
+			return
+		}
+
+		// stop event should check global refcount instead of state
+		ctx, cancel := context.WithTimeout(context.Background(), etcdRequestTimeout)
+		resp, err := e.watcher.Get(ctx, kvstore.VolPrefixGRef+volName)
+		cancel()
+		if err != nil {
+			log.WithFields(
+				log.Fields{"volName": volName,
+					"error": err},
+			).Error("Failed to Get global refcount of volume from ETCD ")
+			lock.ReleaseLock()
+			return
+		}
+
+		if string(resp.Kvs[0].Value) != etcdNoRef {
+			log.Infof("Volume %s still has global users, cannot stop the server", volName)
+			lock.ReleaseLock()
+			return
+		}
+
+		// Change state back to Ready before stop the server
+		_, err = e.CompareAndPutIfNotEqual(kvstore.VolPrefixState+volName, string(kvstore.VolStateReady))
+		if err != nil {
+			log.Errorf("Failed to update state of %s to Ready during server stop event", err)
+			lock.ReleaseLock()
+			return
+		}
+
+		// stop the SMB server
+		port, servName, succeeded := e.dockerOps.StopSMBServer(volName)
+		if succeeded {
+			err = e.updateServerInfo(kvstore.VolPrefixInfo+volName, port, servName)
+			if err != nil {
+				log.Warningf("Failed to update metadata for %s after stopping the server", volName)
+			}
+		} else {
+			log.Errorf("Failed to stop SMB server for %s", volName)
+		}
+		lock.ReleaseLock()
+		return
+	}
+}
+
+func (e *EtcdKVS) updateServerInfo(key string, port int, servName string) error {
+	// Update volume metadata to reflect port number and file service name.
+	var entries []kvstore.KvPair
+	var writeEntries []kvstore.KvPair
+	var volRecord VFileVolConnectivityData
+
+	// Port, Server name, Samba username/password are in the same key.
+	// Must fetch this key to know the value of other fields before rewriting them.
+	keys := []string{key}
+	entries, err := e.ReadMetaData(keys)
+	if err != nil {
+		// Failed to fetch existing metadata on the volume
+		log.Warningf("Failed to read volume metadata before updating: %v", err)
+		return err
+	}
+	err = json.Unmarshal([]byte(entries[0].Value), &volRecord)
+	if err != nil {
+		// Failed to unmarshal record from JSON
+		log.Warningf("Failed to unmarshal JSON for reading existing metadata: %v", err)
+		return err
+	}
+
+	// Check if current port number is already recorded in the meta data
+	if volRecord.Port != port {
+		// Rewrite the port number and service name
+		// then marshal the data structure to JSON again.
+		volRecord.Port = port
+		volRecord.ServiceName = servName
+		byteRecord, err := json.Marshal(volRecord)
+		if err != nil {
+			// Failed to marshal record as JSON
+			log.Warningf("Failed to marshal JSON for writing metadata: %v", err)
+			return err
+		}
+		writeEntries = append(writeEntries, kvstore.KvPair{
+			Key:   key,
+			Value: string(byteRecord)})
+
+		log.Infof("Updating port and file service name for %s", key)
+		err = e.WriteMetaData(writeEntries)
+		if err != nil {
+			// Failed to write metadata.
+			log.Warningf("Failed to write metadata for volume %s", key)
+			return err
+		}
+	} else {
+		log.Warningf("Volume metadata already contains the correct port number, skip updating metadata")
+	}
+	return nil
+}
+
+// CreateLock: create a ETCD lock for a given key, only setup the client
+// session and mutex should be create when start to use the lock
+func (e *EtcdKVS) CreateLock(name string) (kvstore.KvLock, error) {
+	// Create a client to talk to etcd
+	etcdAPI := e.createEtcdClient()
+	if etcdAPI == nil {
+		log.Warningf(etcdClientCreateError)
+		return nil, errors.New(etcdClientCreateError)
+	}
+
+	var kvlock kvstore.KvLock
+	elock := &EtcdLock{
+		Key:     name + "-lock",
+		lockCli: etcdAPI,
+	}
+	kvlock = elock
+	return kvlock, nil
+}
+
+// TryLock: try to get a ETCD mutex lock
+func (e *EtcdLock) TryLock() error {
+	session, err := concurrency.NewSession(e.lockCli, concurrency.WithTTL(20))
+	if err != nil {
+		log.Errorf("Failed to create session before blocking wait lock of %s", e.Key)
+		return err
+	}
+	mutex := concurrency.NewMutex(session, e.Key)
+	err = mutex.Lock(context.TODO())
+	if err != nil {
+		log.Errorf("Failed to get TryLock for key %s", e.Key)
+		session.Close()
+		return err
+	} else {
+		log.Infof("TryLock %s successfully", e.Key)
+		e.lockSession = session
+		e.lockMutex = mutex
+		return nil
+	}
+}
+
+// BlockingLockWithLease: blocking wait to get a ETCD mutex on the given name until timeout
+func (e *EtcdLock) BlockingLockWithLease() error {
+	log.Debugf("BlockingLockWithLease: key=%s", e.Key)
+
+	session, err := concurrency.NewSession(e.lockCli, concurrency.WithTTL(20))
+	if err != nil {
+		log.Errorf("Failed to create session before blocking wait lock of %s", e.Key)
+		return err
+	}
+
+	ticker := time.NewTicker(etcdLockTicker)
+	defer ticker.Stop()
+	timer := time.NewTimer(dockerops.GetServiceStartTimeout() + etcdLockTimer)
+	defer timer.Stop()
+
+	mutex := concurrency.NewMutex(session, e.Key)
+
+	for {
+		select {
+		case <-ticker.C:
+			err := mutex.Lock(context.TODO())
+			if err != nil {
+				log.Warningf("Failed to get lock for key %s", e.Key)
+			} else {
+				log.Infof("Locked %s successfully", e.Key)
+				e.lockSession = session
+				e.lockMutex = mutex
+				return nil
+			}
+		case <-timer.C:
+			msg := fmt.Sprintf(etcdLockTimeoutErrMsg)
+			log.Warningf(msg)
+			session.Close()
+			return errors.New(msg)
 		}
 	}
+}
+
+// ClearLock: stop the client/session with the lock
+func (e *EtcdLock) ClearLock() {
+	e.lockMutex = nil
+	if e.lockSession != nil {
+		e.lockSession.Close()
+		e.lockSession = nil
+	}
+	if e.lockCli != nil {
+		e.lockCli.Close()
+		e.lockCli = nil
+	}
+}
+
+// ReleaseLock: try to release a lock
+func (e *EtcdLock) ReleaseLock() {
+	err := e.lockMutex.Unlock(context.TODO())
+	if err != nil {
+		log.Warningf("Failed to release lock for %s, but will continue to clear the lock session", e.Key)
+	}
+	e.ClearLock()
 	return
 }
 
@@ -820,7 +1019,36 @@ func (e *EtcdKVS) CompareAndPut(key string, oldVal string, newVal string) bool {
 	return txresp.Succeeded
 }
 
-//CompareAndPutOrFetch - Compare and put of get the current value of the key
+// CompareAndPutIfNotEqual - Compare and put a new value of the key if the current value is not equal to the new value
+func (e *EtcdKVS) CompareAndPutIfNotEqual(key string, newVal string) (bool, error) {
+	log.Debugf("CompareAndPutIfNotEqual: key=%s, newVal=%s", key, newVal)
+	var txresp *etcdClient.TxnResponse
+	// Create a client to talk to etcd
+	etcdAPI := e.createEtcdClient()
+	if etcdAPI == nil {
+		return false, errors.New(etcdClientCreateError)
+	}
+	defer etcdAPI.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), etcdRequestTimeout)
+	txresp, err := etcdAPI.Txn(ctx).If(
+		etcdClient.Compare(etcdClient.Value(key), "!=", newVal),
+	).Then(
+		etcdClient.OpPut(key, newVal),
+	).Commit()
+	cancel()
+
+	if err != nil {
+		log.WithFields(
+			log.Fields{"Key": key,
+				"Value to compare": newVal,
+				"Error":            err},
+		).Errorf("Failed to compare and put if not equal")
+	}
+	return txresp.Succeeded, err
+}
+
+//CompareAndPutOrFetch - Compare and put or get the current value of the key
 func (e *EtcdKVS) CompareAndPutOrFetch(key string,
 	oldVal string,
 	newVal string) (*etcdClient.TxnResponse, error) {
@@ -1043,6 +1271,69 @@ func (e *EtcdKVS) WriteMetaData(entries []kvstore.KvPair) error {
 	return nil
 }
 
+// UpdateMetaData - Read/Write/Delete metadata according to given key-value pairs
+func (e *EtcdKVS) UpdateMetaData(entries []kvstore.KvPair) ([]kvstore.KvPair, error) {
+	var ops []etcdClient.Op
+	//var result_entries []kvstore.KvPair
+	log.WithFields(
+		log.Fields{"KvPair": entries},
+	).Debug("UpdateMetaData")
+
+	// Create a client to talk to etcd
+	client := e.createEtcdClient()
+	if client == nil {
+		return nil, errors.New(etcdClientCreateError)
+	}
+	defer client.Close()
+
+	// Lets build the request which will be executed
+	// in a single transaction
+	// ops contain multiple operations
+	for _, elem := range entries {
+		if elem.OpType == kvstore.OpPut {
+			ops = append(ops, etcdClient.OpPut(elem.Key, elem.Value))
+		} else if elem.OpType == kvstore.OpGet {
+			ops = append(ops, etcdClient.OpGet(elem.Key))
+		} else if elem.OpType == kvstore.OpDelete {
+			ops = append(ops, etcdClient.OpDelete(elem.Key))
+		} else {
+			msg := fmt.Sprintf("Unknown OpType for UpdateMetaData: %s", elem.OpType)
+			log.Errorf(msg)
+			return nil, errors.New(msg)
+		}
+	}
+
+	// Post all requested operations in one transaction
+	ctx, cancel := context.WithTimeout(context.Background(), etcdRequestTimeout)
+	resp, err := client.Txn(ctx).Then(ops...).Commit()
+	cancel()
+	if err != nil {
+		msg := fmt.Sprintf("Transactional metadata update failed: %v.", err)
+		if err == context.DeadlineExceeded {
+			msg += fmt.Sprintf(swarmUnhealthyErrorMsg)
+		}
+		log.Warningf(msg)
+		return nil, errors.New(msg)
+	}
+
+	for i, elem := range entries {
+		resp := resp.Responses[i].GetResponseRange()
+		if elem.OpType == kvstore.OpGet {
+			// If any Get() didnt find a key, there wont be
+			// an error returned. It will just return an empty resp
+			if resp.Count == 0 {
+				continue
+			}
+			entries[i].Value = string(resp.Kvs[0].Value)
+		}
+	}
+
+	log.WithFields(
+		log.Fields{"KvPair": entries},
+	).Debug("UpdateMetaData succeeded")
+	return entries, nil
+}
+
 // ReadMetaData - Read metadata in KV store
 func (e *EtcdKVS) ReadMetaData(keys []string) ([]kvstore.KvPair, error) {
 	var entries []kvstore.KvPair
@@ -1128,6 +1419,10 @@ func (e *EtcdKVS) DeleteMetaData(name string) error {
 	ops := []etcdClient.Op{
 		etcdClient.OpDelete(kvstore.VolPrefixState + name),
 		etcdClient.OpDelete(kvstore.VolPrefixGRef + name),
+		etcdClient.OpDelete(kvstore.VolPrefixStartTrigger + name),
+		etcdClient.OpDelete(kvstore.VolPrefixStopTrigger + name),
+		etcdClient.OpDelete(kvstore.VolPrefixStartMarker + name),
+		etcdClient.OpDelete(kvstore.VolPrefixStopMarker + name),
 		etcdClient.OpDelete(kvstore.VolPrefixInfo + name),
 	}
 

--- a/client_plugin/drivers/vfile/kvstore/kvstore.go
+++ b/client_plugin/drivers/vfile/kvstore/kvstore.go
@@ -57,13 +57,36 @@ const (
 	VolPrefixGRef                     = "SVOLS_gref_"
 	VolPrefixInfo                     = "SVOLS_info_"
 	VolPrefixClient                   = "SVOLS_client_"
+	VolPrefixStartTrigger             = "SVOLS_start_trigger_"
+	VolPrefixStopTrigger              = "SVOLS_stop_trigger_"
+	VolPrefixStartMarker              = "SVOLS_start_marker_"
+	VolPrefixStopMarker               = "SVOLS_stop_marker_"
 	VolumeDoesNotExistError           = "No such volume"
+	OpGet                             = "Get"
+	OpPut                             = "Put"
+	OpDelete                          = "Delete"
 )
 
 // KvPair : Key Value pair holder
 type KvPair struct {
-	Key   string
-	Value string
+	Key    string
+	Value  string
+	OpType string
+}
+
+// KvLoc: generic lock for a key
+type KvLock interface {
+	// BlockingLockWithLease - Try to blocking wait to get a lock on a key
+	BlockingLockWithLease() error
+
+	// TryLock - try a lock
+	TryLock() error
+
+	// ReleaseLock - releasing a lock
+	ReleaseLock()
+
+	// ClearLock - clean a lock
+	ClearLock()
 }
 
 // KvStore is the interface for VolumeDriver to access a plugin-level KV store
@@ -73,6 +96,9 @@ type KvStore interface {
 
 	// ReadMetaData - Read volume metadata in KV store
 	ReadMetaData(keys []string) ([]KvPair, error)
+
+	// UpdateMetaData - Read/Write/Delete metadata according to given key-value pairs
+	UpdateMetaData(entries []KvPair) ([]KvPair, error)
 
 	// DeleteMetaData - Delete volume metadata in KV store
 	DeleteMetaData(name string) error
@@ -103,4 +129,7 @@ type KvStore interface {
 
 	// DeleteClientMetaData - Delete volume client metadata in KV store
 	DeleteClientMetaData(name string, nodeID string) error
+
+	// CreateLock - Create a new lock based on a given key
+	CreateLock(key string) (KvLock, error)
 }

--- a/client_plugin/drivers/vfile/vfile_driver.go
+++ b/client_plugin/drivers/vfile/vfile_driver.go
@@ -81,6 +81,10 @@ type VolumeDriver struct {
 
    status:          What state is the vFile volume currently in?
    globalRefcount:  How many host VMs are accessing this volume?
+   StartTrigger:    trigger for watchers of server start event on swarm managers
+   StopTrigger:     trigger for watchers of server stop event on swarm managers
+   StartMarker:     marker to filter a single watcher for server start event
+   StopMarker:      marker to filter a single watcher for server stop event
    port:            On which port is the Samba service listening?
    serviceName:     What is the name of the Samba service for this volume?
    username:
@@ -93,6 +97,10 @@ type VolumeDriver struct {
 type VolumeMetadata struct {
 	Status         kvstore.VolStatus `json:"-"` // Field won't be marshalled
 	GlobalRefcount int               `json:"-"` // Field won't be marshalled
+	StartTrigger   int               `json:"starttrigger,omitempty"`
+	StopTrigger    int               `json:"stoptrigger,omitempty"`
+	StartMarker    int               `json:"startmarker,omitempty"`
+	StopMarker     int               `json:"stopmarker,omitempty"`
 	Port           int               `json:"port,omitempty"`
 	ServiceName    string            `json:"serviceName,omitempty"`
 	Username       string            `json:"username,omitempty"`
@@ -268,6 +276,10 @@ func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 	volRecord := VolumeMetadata{
 		Status:         kvstore.VolStateCreating,
 		GlobalRefcount: 0,
+		StartTrigger:   0,
+		StopTrigger:    0,
+		StartMarker:    0,
+		StopMarker:     0,
 		Port:           0,
 		Username:       dockerops.SambaUsername,
 		Password:       dockerops.SambaPassword,
@@ -276,6 +288,10 @@ func (d *VolumeDriver) Create(r volume.Request) volume.Response {
 	// Append global refcount and status to kv pairs that will be written
 	entries = append(entries, kvstore.KvPair{Key: kvstore.VolPrefixGRef + r.Name, Value: strconv.Itoa(volRecord.GlobalRefcount)})
 	entries = append(entries, kvstore.KvPair{Key: kvstore.VolPrefixState + r.Name, Value: string(volRecord.Status)})
+	entries = append(entries, kvstore.KvPair{Key: kvstore.VolPrefixStartTrigger + r.Name, Value: strconv.Itoa(volRecord.StartTrigger)})
+	entries = append(entries, kvstore.KvPair{Key: kvstore.VolPrefixStopTrigger + r.Name, Value: strconv.Itoa(volRecord.StopTrigger)})
+	entries = append(entries, kvstore.KvPair{Key: kvstore.VolPrefixStartMarker + r.Name, Value: strconv.Itoa(volRecord.StartMarker)})
+	entries = append(entries, kvstore.KvPair{Key: kvstore.VolPrefixStopMarker + r.Name, Value: strconv.Itoa(volRecord.StopMarker)})
 	// Append the rest of the metadata as one KV pair where the data is jsonified
 	byteRecord, err := json.Marshal(volRecord)
 	if err != nil {
@@ -351,7 +367,6 @@ func (d *VolumeDriver) Remove(r volume.Request) volume.Response {
 	}
 
 	var msg string
-	var volRecord VolumeMetadata
 
 	// Cannot remove volumes till plugin completely initializes
 	// because we don't know if it is being used or not
@@ -371,61 +386,69 @@ func (d *VolumeDriver) Remove(r volume.Request) volume.Response {
 		return volume.Response{Err: msg}
 	}
 
-	// Test and set status to Deleting
-	if !d.kvStore.CompareAndPutStateOrBusywait(kvstore.VolPrefixState+r.Name,
-		string(kvstore.VolStateReady),
-		string(kvstore.VolStateDeleting)) {
-		// Failed to change state from Ready to Deleting
-		// 1. Volume is in Mounted state -> get clients and return error
-		// 2. Volume is already in Deleting/Error/Creating/Unmounting and timeout -> continue delete
-		// 3. Volume is in other states -> return error
+	// Get the lock for changing the global refcount
+	grefLock, err := d.kvStore.CreateLock(kvstore.VolPrefixGRef + r.Name)
+	if err != nil {
+		msg = fmt.Sprintf("Failed to create lock for removing volume %s. Error: %v",
+			kvstore.VolPrefixGRef+r.Name, err)
+		log.Error(msg)
+		return volume.Response{Err: msg}
+	}
 
-		// Get a list of host VMs using this volume, if any
-		keys := []string{
-			kvstore.VolPrefixState + r.Name,
-			kvstore.VolPrefixInfo + r.Name,
-		}
-		entries, err := d.kvStore.ReadMetaData(keys)
-		if err != nil {
-			msg = fmt.Sprintf("Remove failed: cannot read metadata of volume %s", r.Name)
-			log.Errorf(msg)
-			return volume.Response{Err: msg}
-		}
+	err = grefLock.BlockingLockWithLease()
+	if err != nil {
+		msg = fmt.Sprintf("Failed to blocking wait lock for removing volume %s. Error: %v",
+			kvstore.VolPrefixGRef+r.Name, err)
+		log.Error(msg)
+		grefLock.ClearLock()
+		return volume.Response{Err: msg}
+	}
 
-		state := entries[0].Value
-		switch state {
-		case string(kvstore.VolStateDeleting):
-			log.Warningf("Remove: volume in Deleting state after timeout. Continue deleting.")
-		case string(kvstore.VolStateError):
-		case string(kvstore.VolStateCreating):
-		case string(kvstore.VolStateUnmounting):
-			log.Warningf("Remove: volume in %s state after timeout. Continue deleting", state)
-			if !d.kvStore.CompareAndPut(kvstore.VolPrefixState+r.Name,
-				state, string(kvstore.VolStateDeleting)) {
-				msg = fmt.Sprintf("Remove: Volume state changed unexpected. Please retry later")
-				log.Errorf(msg)
-				return volume.Response{Err: msg}
+	// Try to lock for changing state. At this point, there should be no lock on the state
+	stateLock, err := d.kvStore.CreateLock(kvstore.VolPrefixState + r.Name)
+	if err != nil {
+		msg = fmt.Sprintf("Failed to create lock for removing volume %s. Error: %v",
+			kvstore.VolPrefixState+r.Name, err)
+		log.Error(msg)
+		grefLock.ReleaseLock()
+		return volume.Response{Err: msg}
+	}
 
-			}
-		case string(kvstore.VolStateMounted):
-			// Unmarshal Info key
-			err = json.Unmarshal([]byte(entries[1].Value), &volRecord)
-			if err != nil {
-				msg = fmt.Sprintf("Remove failed: cannot unmarshal info data. %v", err)
-				log.Errorf(msg)
-				return volume.Response{Err: msg}
-			}
+	err = stateLock.TryLock()
+	if err != nil {
+		msg = fmt.Sprintf("Failed to try lock for removing volume %s. Error: %v",
+			kvstore.VolPrefixState+r.Name, err)
+		log.Error(msg)
+		stateLock.ClearLock()
+		grefLock.ReleaseLock()
+		return volume.Response{Err: msg}
+	}
 
-			msg = fmt.Sprintf("Remove failed: volume state is Mounted.")
-			msg += fmt.Sprintf(" Host VMs using this volume: %s",
-				strings.Join(d.GetClientList(r.Name), ","))
-			log.Errorf(msg)
-			return volume.Response{Err: msg}
-		default:
-			msg = fmt.Sprintf("Remove failed: cannot delete from current state %s.", state)
-			log.Errorf(msg)
-			return volume.Response{Err: msg}
-		}
+	// Set global refcount to 0, set state to Ready, before removing the volume
+	var entries []kvstore.KvPair
+	entries = append(entries, kvstore.KvPair{Key: kvstore.VolPrefixGRef + r.Name, Value: strconv.Itoa(0)})
+	entries = append(entries, kvstore.KvPair{Key: kvstore.VolPrefixState + r.Name, Value: string(kvstore.VolStateReady)})
+	err = d.kvStore.WriteMetaData(entries)
+	if err != nil {
+		msg = fmt.Sprintf("Failed to reset global refcount and state before removing volume %s. Error: %v",
+			r.Name, err)
+		log.Error(msg)
+		stateLock.ReleaseLock()
+		grefLock.ReleaseLock()
+		return volume.Response{Err: msg}
+	}
+
+	// release the lock for volume state
+	stateLock.ReleaseLock()
+
+	// increase stop trigger again in case server is still running
+	err = d.kvStore.AtomicIncr(kvstore.VolPrefixStopTrigger + r.Name)
+	if err != nil {
+		msg = fmt.Sprintf("Failed to increase stop trigger when removing volume %s. Error: %v",
+			r.Name, err)
+		log.Error(msg)
+		grefLock.ReleaseLock()
+		return volume.Response{Err: msg}
 	}
 
 	// Delete internal volume
@@ -434,12 +457,15 @@ func (d *VolumeDriver) Remove(r volume.Request) volume.Response {
 
 	// Delete metadata associated with this volume
 	log.Infof("Attempting to delete volume metadata for %s", r.Name)
-	err := d.kvStore.DeleteMetaData(r.Name)
+	err = d.kvStore.DeleteMetaData(r.Name)
 	if err != nil {
 		msg = fmt.Sprintf("Failed to delete volume metadata for %s. Reason: %v", r.Name, err)
+		log.Error(msg)
+		grefLock.ReleaseLock()
 		return volume.Response{Err: msg}
 	}
 
+	grefLock.ReleaseLock()
 	return volume.Response{Err: ""}
 }
 
@@ -511,37 +537,10 @@ func (d *VolumeDriver) processMount(r volume.MountRequest) volume.Response {
 	return volume.Response{Mountpoint: mountpoint}
 }
 
-func (d *VolumeDriver) addVMToClientList(volName string, nodeID string, vmIP string) error {
-	log.Infof("Add VM[%s] with ID[%s] to ClientList for volume[%s]", vmIP, nodeID, volName)
-	var entries []kvstore.KvPair
-	clientKey := kvstore.VolPrefixClient + volName + "_" + nodeID
-	entries = append(entries, kvstore.KvPair{Key: clientKey, Value: vmIP})
-	err := d.kvStore.WriteMetaData(entries)
-	if err != nil {
-		// Failed to write metadata.
-		log.Warningf("Failed to add ClientList[%] on node[%s] for volume %s",
-			vmIP, nodeID, volName)
-		return err
-	}
-	return nil
-}
-
-func (d *VolumeDriver) removeVMFromClientList(volName string, nodeID string, vmIP string) error {
-	log.Infof("Remove VM[%s] with ID[%s] from ClientList for volume[%s]", vmIP, nodeID, volName)
-	err := d.kvStore.DeleteClientMetaData(volName, nodeID)
-	if err != nil {
-		// Failed to delete metadata.
-		log.Warningf("Failed to remove ClientList[%] on node[%s] for volume %s",
-			vmIP, nodeID, volName)
-		return err
-	}
-	return nil
-}
-
 // MountVolume - Request attach and then mounts the volume.
 func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isReadOnly bool, skipAttach bool) (string, error) {
 	mountpoint := d.GetMountPoint(name)
-	// First, make sure  that mountpoint exists.
+	// First, make sure that mountpoint exists.
 	err := fs.Mkdir(mountpoint)
 	if err != nil {
 		log.WithFields(
@@ -551,14 +550,29 @@ func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isRead
 		return mountpoint, err
 	}
 
-	// Increase GRef
-	log.Infof("Before AtomicIncr")
-	err = d.kvStore.AtomicIncr(kvstore.VolPrefixGRef + name)
+	log.Debugf("MountVolume: before get lock for global refcount of %s", name)
+	// Get the lock for changing the global refcount
+	lock, err := d.kvStore.CreateLock(kvstore.VolPrefixGRef + name)
+	if err != nil {
+		log.Errorf("Failed to create lock for mounting volume %s", kvstore.VolPrefixGRef+name)
+		return "", err
+	}
+
+	err = lock.BlockingLockWithLease()
+	if err != nil {
+		log.Errorf("Failed to blocking wait lock for mounting volume %s", kvstore.VolPrefixGRef+name)
+		lock.ClearLock()
+		return "", err
+	}
+
+	log.Debugf("Before AtomicIncr for StartServerTrigger")
+	err = d.kvStore.AtomicIncr(kvstore.VolPrefixStartTrigger + name)
 	if err != nil {
 		log.WithFields(
 			log.Fields{"name": name,
 				"error": err},
-		).Error("Failed to increase global refcount when processMount ")
+		).Error("Failed to increase start server trigger when processMount ")
+		lock.ReleaseLock()
 		return "", err
 	}
 
@@ -568,25 +582,10 @@ func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isRead
 	info, err := d.kvStore.BlockingWaitAndGet(kvstore.VolPrefixState+name,
 		string(kvstore.VolStateMounted), kvstore.VolPrefixInfo+name)
 	if err != nil {
-		msg := fmt.Sprintf("Failed to blocking wait for Mounted state. Error: %v.", err)
-		err = d.kvStore.AtomicDecr(kvstore.VolPrefixGRef + name)
-		if err != nil {
-			msg += fmt.Sprintf(" Also failed to decrease global refcount. Error: %v.", err)
-		}
 		log.WithFields(
 			log.Fields{"name": name,
-				"error": msg}).Error("")
-		return "", errors.New(msg)
-	}
-
-	// add VM to ClientList
-	nodeID, addr, _, err := d.dockerOps.GetSwarmInfo()
-	err = d.addVMToClientList(name, nodeID, addr)
-	if err != nil {
-		log.WithFields(
-			log.Fields{"volume name": name,
-				"error": err,
-			}).Error("Failed to add VM IP to ClientList")
+				"error": err}).Error("Failed to blocking wait for Mounted state ")
+		lock.ReleaseLock()
 		return "", err
 	}
 
@@ -600,6 +599,7 @@ func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isRead
 			log.Fields{"name": name,
 				"error": err},
 		).Error("Failed to unmarshal info data ")
+		lock.ReleaseLock()
 		return "", err
 	}
 
@@ -610,24 +610,37 @@ func (d *VolumeDriver) MountVolume(name string, fstype string, id string, isRead
 		}).Info("Get info for mounting ")
 	err = d.mountVFileVolume(name, mountpoint, &volRecord)
 	if err != nil {
-		msg := fmt.Sprintf("Failed to mount vFile volume. Error: %v.", err)
-		// AtomicDecr decreases global refcount by one
-		// if global refcount reduces from 1 to 0, a watcher event is triggered on manager nodes
-		err = d.kvStore.AtomicDecr(kvstore.VolPrefixGRef + name)
-		if err != nil {
-			msg += fmt.Sprintf(" Also failed to decrease global refcount. Error: %v.", err)
-		}
-		// remmove VM IP from ClientList
-		err = d.removeVMFromClientList(name, nodeID, addr)
-		if err != nil {
-			msg += fmt.Sprintf(" Also failed to remove VM from ClientList. Error: %v.", err)
-		}
 		log.WithFields(
 			log.Fields{"name": name,
-				"error": msg}).Error("")
-		return "", errors.New(msg)
+				"error": err}).Error("Failed to mount vFile volume ")
+
+		lock.ReleaseLock()
+		return "", err
 	}
 
+	nodeID, addr, _, err := d.dockerOps.GetSwarmInfo()
+	if err != nil {
+		log.WithFields(
+			log.Fields{"volume name": name,
+				"error": err,
+			}).Error("Failed to get swarm info ")
+		lock.ReleaseLock()
+		return "", err
+	}
+
+	var entries []kvstore.KvPair
+	entries = append(entries, kvstore.KvPair{Key: kvstore.VolPrefixGRef + name, Value: strconv.Itoa(volRecord.GlobalRefcount + 1)})
+	entries = append(entries, kvstore.KvPair{Key: kvstore.VolPrefixClient + name + "_" + nodeID, Value: addr})
+	err = d.kvStore.WriteMetaData(entries)
+	if err != nil {
+		// Failed to write metadata.
+		log.Warningf("Failed to update GRef and ClientList[%] on node[%s] for volume %s",
+			addr, nodeID, name)
+		lock.ReleaseLock()
+		return "", err
+	}
+
+	lock.ReleaseLock()
 	return mountpoint, nil
 }
 
@@ -758,35 +771,79 @@ func (d *VolumeDriver) UnmountVolume(name string) error {
 		return err
 	}
 
-	// Decrease GRef
-	log.Infof("Before AtomicDecr")
-	err = d.kvStore.AtomicDecr(kvstore.VolPrefixGRef + name)
-	if err != nil {
-		log.WithFields(
-			log.Fields{"name": name,
-				"error": err},
-		).Error("Failed to derease global refcount when processUnmount ")
-		return err
-	}
-
-	// remove VM from ClientList
 	nodeID, addr, _, err := d.dockerOps.GetSwarmInfo()
 	if err != nil {
 		log.WithFields(
 			log.Fields{"volume name": name,
 				"error": err,
-			}).Error("Failed to get IP address from docker swarm ")
+			}).Error("Failed to get IP address from docker swarm for UnmountVolume ")
 		return err
 	}
 
-	err = d.removeVMFromClientList(name, nodeID, addr)
+	// Get the lock for changing the global refcount
+	lock, err := d.kvStore.CreateLock(kvstore.VolPrefixGRef + name)
 	if err != nil {
-		log.WithFields(
-			log.Fields{"volume name": name,
-				"error": err,
-			}).Error("Failed to remove VM IP from ClientList")
+		log.Errorf("Failed to create lock for mounting volume %s", kvstore.VolPrefixGRef+name)
 		return err
 	}
+
+	err = lock.BlockingLockWithLease()
+	if err != nil {
+		log.Errorf("Failed to blocking wait lock for unmounting volume %s", kvstore.VolPrefixGRef+name)
+		lock.ClearLock()
+		return err
+	}
+
+	keys := []string{
+		kvstore.VolPrefixGRef + name,
+	}
+
+	// Read the current global refcount
+	entries, err := d.kvStore.ReadMetaData(keys)
+	if err != nil {
+		log.Errorf("Failed to read metadata for volume %s from KV store. %v", name, err)
+		lock.ReleaseLock()
+		return err
+	}
+
+	gref, _ := strconv.Atoi(entries[0].Value)
+	if gref > 0 {
+		gref--
+	} else {
+		log.Warningf("Global refcount is 0 before unmounting, possible errors in previous operations to this volume")
+	}
+
+	var updateEntries []kvstore.KvPair
+	updateEntries = append(updateEntries,
+		kvstore.KvPair{
+			Key:    kvstore.VolPrefixGRef + name,
+			Value:  strconv.Itoa(gref),
+			OpType: kvstore.OpPut})
+	updateEntries = append(updateEntries,
+		kvstore.KvPair{
+			Key:    kvstore.VolPrefixClient + name + "_" + nodeID,
+			OpType: kvstore.OpDelete})
+	_, err = d.kvStore.UpdateMetaData(updateEntries)
+	if err != nil {
+		log.Warningf("Failed to update GRef and delete ClientList[%] on node[%s] for volume %s",
+			addr, nodeID, name)
+		lock.ReleaseLock()
+		return err
+	}
+
+	err = d.kvStore.AtomicIncr(kvstore.VolPrefixStopTrigger + name)
+	if err != nil {
+		// if failed, release the lock
+		log.WithFields(
+			log.Fields{"name": name,
+				"error": err},
+		).Error("Failed to increase stop trigger when processUnmount ")
+		lock.ReleaseLock()
+		return err
+	}
+
+	// release the GRef lock
+	lock.ReleaseLock()
 	return nil
 }
 

--- a/tests/e2e/advanced_vfile_test.go
+++ b/tests/e2e/advanced_vfile_test.go
@@ -90,6 +90,7 @@ func (s *AdvancedVFileTestSuite) TestVFileVolumeLifecycle(c *C) {
 
 	// Mount the volume on worker
 	out, err = dockercli.AttachVFileVolume(s.worker1, s.volName1, s.container1Name)
+	c.Assert(err, IsNil, Commentf(out))
 
 	// Expect global refcount for this volume to be 2
 	out = verification.GetVFileVolumeGlobalRefcount(s.volName1, s.master)


### PR DESCRIPTION
The PR is to solve issue https://github.com/vmware/docker-volume-vsphere/issues/1943

The new design has the following changes:

1. The start and stop of file server is not triggered by global refcount change now. Instead, every global mount/umount request will increase the value of StartTrigger/StopTrigger in the KV store. Two separate watchers (on each master node) will generate events according to the PUT operations to these two triggers.
2. The states of volumes are reduced to Ready and Mounted only. No intermediate states are needed. As a result, locks are required when the states need to be updated.
3. To avoid overlapping operations, locks are also required for updating global refcounts. The locks for global refcount are different from the locks for volume states. Usually, the workers are the ones who grab global refcount locks, and the managers (watchers) are the ones who need state locks.
4. Two fields StartMarker and StopMarker are used to guarantee only one manager's watcher is able to proceed to do the start/stop server operations. And thus other watchers will be able to return and handle events for different volumes in parallel.
5. To make sure when an error happens, the volumes won't be left in an error state, the order for updating metadata in KV store has been changed too. First of all, global refcount will only be increased after the state of the volume is Mounted; Second, the state of volume can be changed to Mounted only after the file server is up and running. On the other side, during unmount, global refcount and client list will be updated first in the same transaction; then stop trigger is increased to trigger the event to stop the file server.
6. During the volume deletion, both global refcount and state locks are required. The plugin is responsible to reset the global refcount to 0 and reset state to Ready, and then should increase the StopTrigger to shut down the file server service, if for some reason it's still running.