### PR TITLE
Fix docker version check bug for vFile

### DIFF
--- a/client_plugin/drivers/vfile/dockerops/dockerops.go
+++ b/client_plugin/drivers/vfile/dockerops/dockerops.go
@@ -577,7 +577,14 @@ func (d *DockerOps) CheckDockerVersion(requiredVersion string) (bool, error) {
 		log.Errorf("Failed to get docker server version. Error: %v", err)
 		return false, err
 	}
-	v1, err := version.NewVersion(serverVersion.Version)
+	// serverVersion.Version read from docker has the format like this
+	// 17.06.0-ce
+	// need to extract the numeric part to compare
+	versionStr := strings.Split(serverVersion.Version, "-")
+	// dockerServersion only has the numeric part "17.06.0"
+	dockerServerVersion := versionStr[0]
+	log.Infof("dockerServerVersion: %s", dockerServerVersion)
+	v1, err := version.NewVersion(dockerServerVersion)
 	if err != nil {
 		log.Errorf("Failed to create version comparison for %s. Error: %v", serverVersion.Version, err)
 		return false, err

--- a/client_plugin/drivers/vfile/dockerops/dockerops.go
+++ b/client_plugin/drivers/vfile/dockerops/dockerops.go
@@ -583,7 +583,7 @@ func (d *DockerOps) CheckDockerVersion(requiredVersion string) (bool, error) {
 	versionStr := strings.Split(serverVersion.Version, "-")
 	// dockerServersion only has the numeric part "17.06.0"
 	dockerServerVersion := versionStr[0]
-	log.Infof("dockerServerVersion: %s", dockerServerVersion)
+	log.Debugf("dockerServerVersion: %s", dockerServerVersion)
 	v1, err := version.NewVersion(dockerServerVersion)
 	if err != nil {
 		log.Errorf("Failed to create version comparison for %s. Error: %v", serverVersion.Version, err)

--- a/client_plugin/drivers/vfile/vfile_driver.go
+++ b/client_plugin/drivers/vfile/vfile_driver.go
@@ -58,7 +58,7 @@ const (
 	initError            = "vFile volume driver is not fully initialized yet."
 	mountError           = "exit status 255"
 	checkTicker          = time.Second
-	requiredVersion      = "17.06"
+	requiredVersion      = "17.06.0"
 )
 
 /* VolumeDriver - vFile plugin volume driver struct


### PR DESCRIPTION
Fixed #2024 .
Test:
With this fix, can install vFile successfully with docker 17.06.0-ce.

```
root@sc-rdops-vm18-dhcp-57-89:~# docker version
Client:
 Version:      17.06.0-ce
 API version:  1.30
 Go version:   go1.8.3
 Git commit:   02c1d87
 Built:        Fri Jun 23 21:23:31 2017
 OS/Arch:      linux/amd64

Server:
 Version:      17.06.0-ce
 API version:  1.30 (minimum version 1.12)
 Go version:   go1.8.3
 Git commit:   02c1d87
 Built:        Fri Jun 23 21:19:04 2017
 OS/Arch:      linux/amd64
 Experimental: false

root@sc-rdops-vm18-dhcp-57-89:~# docker plugin install --grant-all-permissions --alias vfile lipingxue/vfile:vfile-version-check VFILE_TIMEOUT_IN_SECOND=300
vfile-version-check: Pulling from lipingxue/vfile
2dc10eb4c96b: Download complete 
Digest: sha256:3806a320dcdc2501693fd07c84d805bbe67be0e99f776efbf5ccb787028135a7
Status: Downloaded newer image for lipingxue/vfile:vfile-version-check
Installed plugin lipingxue/vfile:vfile-version-check
root@sc-rdops-vm18-dhcp-57-89:~# 
root@sc-rdops-vm18-dhcp-57-89:~# docker plugin ls
ID                  NAME                DESCRIPTION                           ENABLED
a7a626d7e96a        vfile:latest        VMWare vFile Docker Volume plugin     true
cdfdd62016cd        vsphere:latest      VMWare vSphere Docker Volume plugin   true
root@sc-rdops-vm18-dhcp-57-89:~# 

```